### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ OpenCore bootloader front end.
 - [InsanelyMac](https://www.insanelymac.com/forum/topic/338527-opencore-development/) in English
 - [macOS86.it](https://www.macos86.it/viewtopic.php?p=32103) in Italian
 - [PCbeta.com](http://bbs.pcbeta.com/viewthread-1815623-1-1.html) in Chinese
+- [Sixflow.kr](https://sixflow.kr/opencore_bootloader/62711) in Korean
 
 ## Credits
 


### PR DESCRIPTION
Anyone can read the topic in the OpenCore Korean forum.

In Korea, scammers are getting from $300 to $600. users who can't install Hackintosh byself.
but scammer's can't speak English as well so most korean communities kept a higher membership levles.

however, I totally agree that you should use a public forum so that anyone can easily install a opencore boot loader.
so, do why i add a link to the there? it's possiblt to use public manual with Korean language.