### PR TITLE
Docs: Fix typo

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -1730,7 +1730,7 @@ behaviour that does not go to any other sections
   screen output. Some firmwares do not provide it, yet select operating systems
   require its presence, which is what \texttt{ConsoleControl} UEFI protocol is for.
 
-  When console control is available, OpenCore can be made console control aware, and
+  When console control is available, OpenCore can be made console control aware,
   and set different modes for the operating system booter (\texttt{ConsoleBehaviourOs}),
   which normally runs in graphics mode, and its own user interface
   (\texttt{ConsoleBehaviourUi}), which normally runs in text mode. Possible


### PR DESCRIPTION
"and" was typed twice, fixed typo.