### PR TITLE
ScanPolicy=11469571

### DIFF
--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -584,7 +584,7 @@
 			<key>RequireVault</key>
 			<true/>
 			<key>ScanPolicy</key>
-			<integer>983299</integer>
+			<integer>11469571</integer>
 		</dict>
 		<key>Tools</key>
 		<array>


### PR DESCRIPTION
the preset 983299 does not scan USB stick (usually GUID type with HFS+ filesystem) and HFS+, which may confuse beginners, in that case, the OpenCore boot menu does not show macOS Install.app at all. What do you guys think.