### PR TITLE
[SUGGESTION] RequireSignature if clause improvement in OpenCoreMisc.c

### DIFF
--- a/Platform/OpenCore/OpenCoreMisc.c
+++ b/Platform/OpenCore/OpenCoreMisc.c
@@ -227,7 +227,7 @@ OcMiscEarlyInit (
     return EFI_SECURITY_VIOLATION; ///< Should be unreachable.
   }
 
-  if (VaultKey == NULL && Config->Misc.Security.RequireSignature) {
+  if (Config->Misc.Security.RequireVault && VaultKey == NULL && Config->Misc.Security.RequireSignature) {
     DEBUG ((DEBUG_ERROR, "OC: Configuration requires signed vault but no public key provided!\n"));
     CpuDeadLoop ();
     return EFI_SECURITY_VIOLATION; ///< Should be unreachable.

--- a/Platform/OpenCore/OpenCoreMisc.c
+++ b/Platform/OpenCore/OpenCoreMisc.c
@@ -227,7 +227,9 @@ OcMiscEarlyInit (
     return EFI_SECURITY_VIOLATION; ///< Should be unreachable.
   }
 
-  if (Config->Misc.Security.RequireVault && VaultKey == NULL && Config->Misc.Security.RequireSignature) {
+  if (!Config->Misc.Security.RequireVault && Config->Misc.Security.RequireSignature) {
+    DEBUG((DEBUG_INFO, "OC: Configuration value RequireSignature is true while RequireVault is false. Consider changing RequireSignature to false, to have a clean config.plist."));
+  } else if (Config->Misc.Security.RequireVault && VaultKey == NULL && Config->Misc.Security.RequireSignature) {
     DEBUG ((DEBUG_ERROR, "OC: Configuration requires signed vault but no public key provided!\n"));
     CpuDeadLoop ();
     return EFI_SECURITY_VIOLATION; ///< Should be unreachable.


### PR DESCRIPTION
Jumping into this if clause, makes only sense if the Misc.Security.RequireVault is set to true, as RequireSignature is only used in combination with RequireVault.

A cancel of the boot process just because RequireSignature is true, does not make sense in my opinion.
a simple debug_info about the inconsistent usage is way more user friendly and does not block users  from booting who do not use RequireVault.