### PR TITLE
Added a check to fix 'Cannot override' bug #814

### DIFF
--- a/Docs/AcpiSamples/SSDT-PLUG.dsl
+++ b/Docs/AcpiSamples/SSDT-PLUG.dsl
@@ -32,73 +32,89 @@ DefinitionBlock ("", "SSDT", 2, "ACDT", "CpuPlug", 0x00003000)
     }
 
     If (CondRefOf (\_SB.CPU0)) {
-        Scope (\_SB.CPU0) {
-            Method (_DSM, 4, NotSerialized)  
-            {
-                Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+        If ((ObjectType (\_SB.CPU0) == 0x0C)) {
+            Scope (\_SB.CPU0) {
+                Method (_DSM, 4, NotSerialized)  
+                {
+                    Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+                }
             }
         }
     }
-
+    
     If (CondRefOf (\_PR.CPU0)) {
-        Scope (\_PR.CPU0) {
-            Method (_DSM, 4, NotSerialized)  
-            {
-                Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+        If ((ObjectType (\_PR.CPU0) == 0x0C)) {
+            Scope (\_PR.CPU0) {
+                Method (_DSM, 4, NotSerialized)  
+                {
+                    Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+                }
             }
         }
     }
 
     If (CondRefOf (\_SB.PR00)) {
-        Scope (\_SB.PR00) {
-            Method (_DSM, 4, NotSerialized)  
-            {
-                Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+        If ((ObjectType (\_SB.PR00) == 0x0C)) {
+            Scope (\_SB.PR00) {
+                Method (_DSM, 4, NotSerialized)  
+                {
+                    Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+                }
             }
         }
     }
     
     If (CondRefOf (\_PR.C000)) {
-        Scope (\_PR.C000) {
-            Method (_DSM, 4, NotSerialized)  
-            {
-                Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+        If ((ObjectType (\_PR.C000) == 0x0C)) {
+            Scope (\_PR.C000) {
+                Method (_DSM, 4, NotSerialized)  
+                {
+                    Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+                }
             }
         }
     }
     
-    If (CondRefOf (\_PR.P000)) {
-        Scope (\_PR.P000) {
-            Method (_DSM, 4, NotSerialized)  
-            {
-                Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+   If (CondRefOf (\_PR.P000)) {
+        If ((ObjectType (\_PR.P000) == 0x0C)) {
+            Scope (\_PR.P000) {
+                Method (_DSM, 4, NotSerialized)  
+                {
+                    Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+                }
+            }
+        }
+    }
+    
+   If (CondRefOf (\_PR.PR00)) {
+        If ((ObjectType (\_PR.PR00) == 0x0C)) {
+            Scope (\_PR.PR00) {
+                Method (_DSM, 4, NotSerialized)  
+                {
+                    Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+                }
             }
         }
     }
 
-    If (CondRefOf (\_PR.PR00)) {
-        Scope (\_PR.PR00) {
-            Method (_DSM, 4, NotSerialized)  
-            {
-                Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+   If (CondRefOf (\_SB.SCK0.CP00)) {
+        If ((ObjectType (\_SB.SCK0.CP00) == 0x0C)) {
+            Scope (\_SB.SCK0.CP00) {
+                Method (_DSM, 4, NotSerialized)  
+                {
+                    Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+                }
             }
         }
     }
 
-    If (CondRefOf (\_SB.SCK0.CP00)) {
-        Scope (\_SB.SCK0.CP00) {
-            Method (_DSM, 4, NotSerialized)  
-            {
-                Return (PMPM (Arg0, Arg1, Arg2, Arg3))
-            }
-        }
-    }
-
-    If (CondRefOf (\_SB.SCK0.PR00)) {
-        Scope (\_SB.SCK0.PR00) {
-            Method (_DSM, 4, NotSerialized)  
-            {
-                Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+   If (CondRefOf (\_SB.SCK0.PR00)) {
+        If ((ObjectType (\_SB.SCK0.PR00) == 0x0C)) {
+            Scope (\_SB.SCK0.PR00) {
+                Method (_DSM, 4, NotSerialized)  
+                {
+                    Return (PMPM (Arg0, Arg1, Arg2, Arg3))
+                }
             }
         }
     }


### PR DESCRIPTION
This one should fix issue #814 once and for all. The issue was caused by the SSDT that was adding _DSM Method to a Package (forbidden by ACPI Specification) defined on the DSDT (\_SB.PR00). The new if-condition checks if the object is a Processor. By doing this way, if it finds a Package it doesn't add the _DSM Method.