### PR TITLE
Gui timeout

### DIFF
--- a/Platform/OpenCanopy/OcBootstrap.c
+++ b/Platform/OpenCanopy/OcBootstrap.c
@@ -82,7 +82,7 @@ OcShowMenuByOc (
     }
   }
 
-  GuiDrawLoop (&mDrawContext);
+  GuiDrawLoop (&mDrawContext, Context);
   ASSERT (mGuiContext.BootEntry != NULL || mGuiContext.Refresh);
 
   //

--- a/Platform/OpenCanopy/OcBootstrap.c
+++ b/Platform/OpenCanopy/OcBootstrap.c
@@ -82,7 +82,7 @@ OcShowMenuByOc (
     }
   }
 
-  GuiDrawLoop (&mDrawContext, Context);
+  GuiDrawLoop (&mDrawContext, Context->TimeoutSeconds);
   ASSERT (mGuiContext.BootEntry != NULL || mGuiContext.Refresh);
 
   //

--- a/Platform/OpenCanopy/OpenCanopy.c
+++ b/Platform/OpenCanopy/OpenCanopy.c
@@ -1153,7 +1153,7 @@ GuiDrawLoop (
   // Main drawing loop, time and derieve sub-frequencies as required.
   //
 
-  //STATIC BOOLEAN logOnce = 0;
+  //Capture timer at start of boot to use for timeout logic
   if(StartTimer == 0){
     //only read start time on init
     StartTimer = AsmReadTsc ();
@@ -1259,7 +1259,6 @@ GuiDrawLoop (
     //
     GuiFlushScreen (DrawContext);
 
-
     //
     // Exit early if reach timer timeout and timer isn't disabled due to key event
     //
@@ -1269,6 +1268,9 @@ GuiDrawLoop (
       mGuiContext.BootEntry = mBootPicker.SelectedEntry->Context;
       break;
     }
+
+    //UINT64 EndTsc = AsmReadTsc ();	
+    //DEBUG ((DEBUG_ERROR, "Loop delta TSC: %lld, target: %lld\n", EndTsc - StartTsc, mDeltaTscTarget));
 
   } while (!DrawContext->ExitLoop (DrawContext->GuiContext));
 }

--- a/Platform/OpenCanopy/OpenCanopy.h
+++ b/Platform/OpenCanopy/OpenCanopy.h
@@ -245,7 +245,8 @@ GuiViewCurrentCursor (
 
 VOID
 GuiDrawLoop (
-  IN OUT GUI_DRAWING_CONTEXT  *DrawContext
+  IN OUT GUI_DRAWING_CONTEXT  *DrawContext,
+  IN     VOID                 *Context
   );
 
 EFI_STATUS

--- a/Platform/OpenCanopy/OpenCanopy.h
+++ b/Platform/OpenCanopy/OpenCanopy.h
@@ -246,7 +246,7 @@ GuiViewCurrentCursor (
 VOID
 GuiDrawLoop (
   IN OUT GUI_DRAWING_CONTEXT  *DrawContext,
-  IN     VOID                 *Context
+  IN     UINT32               TimeoutSeconds
   );
 
 EFI_STATUS

--- a/Platform/OpenCanopy/Views/BootPicker.c
+++ b/Platform/OpenCanopy/Views/BootPicker.c
@@ -22,25 +22,8 @@
 #include "../OpenCanopy.h"
 #include "../BmfLib.h"
 #include "../GuiApp.h"
+#include "BootPicker.h"
 
-typedef struct {
-  GUI_OBJ_CHILD         Hdr;
-  CONST GUI_IMAGE       *ClickImage;
-  CONST GUI_IMAGE       *CurrentImage;
-} GUI_OBJ_CLICKABLE;
-
-typedef struct {
-  GUI_OBJ_CHILD   Hdr;
-  GUI_IMAGE       EntryIcon;
-  GUI_IMAGE       Label;
-  VOID            *Context;
-  BOOLEAN         CustomIcon;
-} GUI_VOLUME_ENTRY;
-
-typedef struct {
-  GUI_OBJ_CHILD    Hdr;
-  GUI_VOLUME_ENTRY *SelectedEntry;
-} GUI_VOLUME_PICKER;
 
 extern GUI_OBJ           mBootPickerView;
 extern GUI_VOLUME_PICKER mBootPicker;

--- a/Platform/OpenCanopy/Views/BootPicker.h
+++ b/Platform/OpenCanopy/Views/BootPicker.h
@@ -1,0 +1,31 @@
+/** @file
+  This file is part of OpenCanopy, OpenCore GUI.
+
+  Copyright (c) 2018-2019, Download-Fritz. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-3-Clause
+**/
+
+#ifndef BOOT_PICKER_H
+#define BOOT_PICKER_H
+
+typedef struct {
+  GUI_OBJ_CHILD         Hdr;
+  CONST GUI_IMAGE       *ClickImage;
+  CONST GUI_IMAGE       *CurrentImage;
+} GUI_OBJ_CLICKABLE;
+
+typedef struct {
+  GUI_OBJ_CHILD   Hdr;
+  GUI_IMAGE       EntryIcon;
+  GUI_IMAGE       Label;
+  VOID            *Context;
+  BOOLEAN         CustomIcon;
+} GUI_VOLUME_ENTRY;
+
+typedef struct {
+  GUI_OBJ_CHILD    Hdr;
+  GUI_VOLUME_ENTRY *SelectedEntry;
+} GUI_VOLUME_PICKER;
+
+
+#endif // BOOT_PICKER_H

--- a/Platform/OpenCanopy/Views/BootPicker.h
+++ b/Platform/OpenCanopy/Views/BootPicker.h
@@ -27,5 +27,4 @@ typedef struct {
   GUI_VOLUME_ENTRY *SelectedEntry;
 } GUI_VOLUME_PICKER;
 
-
 #endif // BOOT_PICKER_H


### PR DESCRIPTION
This change allows the OpenCanopy GUI to auto select the default boot entry after config.plist->MISC->Boot->Timeout expires. 

FYI - I had to move structs declare from BootPicker.c into BootPicker.h so that we can reference those struct from OpenCanopy.c

