### PR TITLE
Build: Fix ShellCheck warning in macbuild

### DIFF
--- a/macbuild.tool
+++ b/macbuild.tool
@@ -69,7 +69,7 @@ package() {
   popd || exit 1
 }
 
-cd $(dirname "$0") || exit 1
+cd "$(dirname "$0")" || exit 1
 ARCHS=(X64 IA32)
 SELFPKG=OpenCorePkg
 DEPNAMES=('EfiPkg' 'MacInfoPkg' 'DuetPkg')


### PR DESCRIPTION
Fix for final outstanding warning. Passes ShellCheck.
Tested and builds without error locally ... Should pass TravisCI