### PR TITLE
Attempt to Fix acidanthera/bugtracker/issues/902

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,23 @@ env:
 matrix:
   include:
   - os: osx
+    name: "Check Shell Scripts"
+    osx_image: xcode10.2
+    compiler: clang
+
+    script:
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install shellcheck
+      - "./macbuild.tool --skip-tests --skip-build --skip-package"
+      - shellcheck /home/travis/build/acidanthera/OpenCorePkg/**/*.{sh,tool}
+
+  - os: osx
     name: "Build macOS XCODE5"
     osx_image: xcode10.2
     compiler: clang
 
     script:
-    - HOMEBREW_NO_AUTO_UPDATE=1 brew install openssl shellcheck
+    - HOMEBREW_NO_AUTO_UPDATE=1 brew install openssl
     - "./macbuild.tool"
-    - shellcheck ./**/*.{sh,tool}
 
     deploy:
       provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ matrix:
     compiler: clang
 
     script:
-    - HOMEBREW_NO_AUTO_UPDATE=1 brew install openssl
+    - HOMEBREW_NO_AUTO_UPDATE=1 brew install openssl shellcheck
     - "./macbuild.tool"
+    - shellcheck ./**/*.{sh,tool}
 
     deploy:
       provider: releases
@@ -77,7 +78,7 @@ matrix:
     name: "Analyze Coverity"
     osx_image: xcode11.3
     compiler: clang
-    
+
     before_install:
       - HOMEBREW_NO_AUTO_UPDATE=1 brew install openssl
       - curl -Ls https://entrust.com/root-certificates/entrust_l1k.cer -o ~/entrust_l1k.crt || exit 1

--- a/Docs/Kexts.md
+++ b/Docs/Kexts.md
@@ -58,6 +58,7 @@ Kexts
 - [FakeSMC.kext and sensors](https://github.com/CloverHackyColor/FakeSMC3_with_plugins)
 - [HWPEnabler.kext](https://github.com/headkaze/HWPEnable)
 - [OpcodeEmulator.kext](https://www.insanelymac.com/forum/topic/329704-opcode-emulator-opemu-plug-in-project/)
+- [telemetrap.kext](https://forums.macrumors.com/posts/28447707)
 - [TSCAdjustReset.kext](https://github.com/interferenc/TSCAdjustReset)
 - [VirtualSMC.kext and sensors](https://github.com/acidanthera/VirtualSMC)
 - [VoodooTSCSync.kext](https://github.com/RehabMan/VoodooTSCSync)


### PR DESCRIPTION
An attempt to fix acidanthera/bugtracker/#902 by running ShellCheck after Macbuild when all the various repos have been pulled in. It then checks each *.sh and *.tool file.

Alternative (better?) would be to update travis.yml for each repo. Perhaps even better is to check them here but also check in the specific repos

**Note:** There will be failures on current setup:
![ShellCheck_1](https://user-images.githubusercontent.com/1128876/81468018-6ec27f00-91e5-11ea-90ca-c74d73e2a770.jpg)

![ShellCheck_2](https://user-images.githubusercontent.com/1128876/81468021-72560600-91e5-11ea-9b5b-487568d31ec3.jpg)

![ShellCheck_3](https://user-images.githubusercontent.com/1128876/81468023-74b86000-91e5-11ea-8cca-a6295ddf079a.jpg)

Some are just warning that will need to be specifically disabled. 
Basically needs commitment to embrace ShellCheck