### PR TITLE
Fix bits EFI_ACPI_6_2_SLP_BUTTON and EFI_ACPI_6_2_PWR_BUTTON in FADT

### DIFF
--- a/Library/OcAcpiLib/OcAcpiLib.c
+++ b/Library/OcAcpiLib/OcAcpiLib.c
@@ -1134,22 +1134,32 @@ AcpiFadtEnableReset (
         Context->Tables[Index] = (EFI_ACPI_COMMON_HEADER *) Fadt;
       }
     }
-  } else if ((Context->Fadt->Flags & EFI_ACPI_6_2_RESET_REG_SUP) == 0) {
+  } else if ((Context->Fadt->Flags & EFI_ACPI_6_2_RESET_REG_SUP) == 0 || (Context->Fadt->Flags & EFI_ACPI_6_2_SLP_BUTTON) == 0 || (Context->Fadt->Flags & EFI_ACPI_6_2_PWR_BUTTON)) {
     Fadt = Context->Fadt;
   } else {
     return EFI_SUCCESS;
   }
 
-  Fadt->Flags |= EFI_ACPI_6_2_RESET_REG_SUP;
+  if ((Context->Fadt->Flags & EFI_ACPI_6_2_SLP_BUTTON) == 0) {
+    Fadt->Flags |= EFI_ACPI_6_2_SLP_BUTTON;
+  }
 
-  //
-  // Resetting through port 0xCF9 is universal on Intel and AMD.
-  //
-  Fadt->ResetReg.AddressSpaceId    = EFI_ACPI_6_2_SYSTEM_IO;
-  Fadt->ResetReg.RegisterBitWidth  = 8;
-  Fadt->ResetReg.RegisterBitOffset = 0;
-  Fadt->ResetReg.AccessSize        = EFI_ACPI_6_2_BYTE;
-  Fadt->ResetReg.Address           = 0xCF9;
+  if (Context->Fadt->Flags & EFI_ACPI_6_2_PWR_BUTTON) {
+    Fadt->Flags &= ~EFI_ACPI_6_2_PWR_BUTTON;
+  }
+
+  if ((Context->Fadt->Flags & EFI_ACPI_6_2_RESET_REG_SUP) == 0) {
+      Fadt->Flags |= EFI_ACPI_6_2_RESET_REG_SUP;
+      //
+      // Resetting through port 0xCF9 is universal on Intel and AMD.
+      //
+      Fadt->ResetReg.AddressSpaceId    = EFI_ACPI_6_2_SYSTEM_IO;
+      Fadt->ResetReg.RegisterBitWidth  = 8;
+      Fadt->ResetReg.RegisterBitOffset = 0;
+      Fadt->ResetReg.AccessSize        = EFI_ACPI_6_2_BYTE;
+      if (Fadt->ResetReg.Address == 0)
+          Fadt->ResetReg.Address = 0xCF9;
+  }
 
   Fadt->Header.Checksum = 0;
   Fadt->Header.Checksum = CalculateCheckSum8 ((UINT8 *) Fadt, Fadt->Header.Length);

--- a/Library/OcAcpiLib/OcAcpiLib.c
+++ b/Library/OcAcpiLib/OcAcpiLib.c
@@ -1134,31 +1134,30 @@ AcpiFadtEnableReset (
         Context->Tables[Index] = (EFI_ACPI_COMMON_HEADER *) Fadt;
       }
     }
-  } else if ((Context->Fadt->Flags & EFI_ACPI_6_2_RESET_REG_SUP) == 0 || (Context->Fadt->Flags & EFI_ACPI_6_2_SLP_BUTTON) == 0 || (Context->Fadt->Flags & EFI_ACPI_6_2_PWR_BUTTON)) {
+  } else if ((Context->Fadt->Flags & EFI_ACPI_6_2_RESET_REG_SUP) == 0
+    || (Context->Fadt->Flags & EFI_ACPI_6_2_SLP_BUTTON) == 0
+    || (Context->Fadt->Flags & EFI_ACPI_6_2_PWR_BUTTON) != 0) {
     Fadt = Context->Fadt;
   } else {
     return EFI_SUCCESS;
   }
 
-  if ((Context->Fadt->Flags & EFI_ACPI_6_2_SLP_BUTTON) == 0) {
-    Fadt->Flags |= EFI_ACPI_6_2_SLP_BUTTON;
-  }
+  //
+  // Enable sleep button, but disable power button.
+  //
+  Fadt->Flags |= EFI_ACPI_6_2_SLP_BUTTON | EFI_ACPI_6_2_RESET_REG_SUP;
+  Fadt->Flags &= ~EFI_ACPI_6_2_PWR_BUTTON;
 
-  if (Context->Fadt->Flags & EFI_ACPI_6_2_PWR_BUTTON) {
-    Fadt->Flags &= ~EFI_ACPI_6_2_PWR_BUTTON;
-  }
-
-  if ((Context->Fadt->Flags & EFI_ACPI_6_2_RESET_REG_SUP) == 0) {
-      Fadt->Flags |= EFI_ACPI_6_2_RESET_REG_SUP;
-      //
-      // Resetting through port 0xCF9 is universal on Intel and AMD.
-      //
-      Fadt->ResetReg.AddressSpaceId    = EFI_ACPI_6_2_SYSTEM_IO;
-      Fadt->ResetReg.RegisterBitWidth  = 8;
-      Fadt->ResetReg.RegisterBitOffset = 0;
-      Fadt->ResetReg.AccessSize        = EFI_ACPI_6_2_BYTE;
-      if (Fadt->ResetReg.Address == 0)
-          Fadt->ResetReg.Address = 0xCF9;
+  if (Fadt->ResetReg.Address == 0) {
+    Fadt->Flags |= EFI_ACPI_6_2_RESET_REG_SUP;
+    //
+    // Resetting through port 0xCF9 is universal on Intel and AMD.
+    //
+    Fadt->ResetReg.AddressSpaceId    = EFI_ACPI_6_2_SYSTEM_IO;
+    Fadt->ResetReg.RegisterBitWidth  = 8;
+    Fadt->ResetReg.RegisterBitOffset = 0;
+    Fadt->ResetReg.AccessSize        = EFI_ACPI_6_2_BYTE;
+    Fadt->ResetReg.Address = 0xCF9;
   }
 
   Fadt->Header.Checksum = 0;

--- a/Library/OcAcpiLib/OcAcpiLib.c
+++ b/Library/OcAcpiLib/OcAcpiLib.c
@@ -1143,21 +1143,22 @@ AcpiFadtEnableReset (
   }
 
   //
-  // Enable sleep button, but disable power button.
+  // Enable sleep button, but disable power button actions.
+  // This resolves power button action in macOS on some models.
   //
   Fadt->Flags |= EFI_ACPI_6_2_SLP_BUTTON | EFI_ACPI_6_2_RESET_REG_SUP;
   Fadt->Flags &= ~EFI_ACPI_6_2_PWR_BUTTON;
 
   if (Fadt->ResetReg.Address == 0) {
-    Fadt->Flags |= EFI_ACPI_6_2_RESET_REG_SUP;
     //
     // Resetting through port 0xCF9 is universal on Intel and AMD.
+    // But may not be the case on some laptops, which use 0xB2.
     //
     Fadt->ResetReg.AddressSpaceId    = EFI_ACPI_6_2_SYSTEM_IO;
     Fadt->ResetReg.RegisterBitWidth  = 8;
     Fadt->ResetReg.RegisterBitOffset = 0;
     Fadt->ResetReg.AccessSize        = EFI_ACPI_6_2_BYTE;
-    Fadt->ResetReg.Address = 0xCF9;
+    Fadt->ResetReg.Address           = 0xCF9;
   }
 
   Fadt->Header.Checksum = 0;


### PR DESCRIPTION
Fix bits EFI_ACPI_6_2_SLP_BUTTON and EFI_ACPI_6_2_PWR_BUTTON in FADT to make power button work. These fixes are combined with reset fix (FadtEnableReset).