### PR TITLE
AcpiSamples: Fix SSDT-SBUS-MCHC.dsl compilation

### DIFF
--- a/Docs/AcpiSamples/SSDT-SBUS-MCHC.dsl
+++ b/Docs/AcpiSamples/SSDT-SBUS-MCHC.dsl
@@ -4,7 +4,7 @@
 DefinitionBlock ("", "SSDT", 2, "ACDT", "MCHCSBUS", 0x00000000)
 {
     External (_SB_.PCI0, DeviceObj)
-    External (_SB_.PCI0.SBUS.BUS0, DeviceObj)
+    External (_SB_.PCI0.SBUS, DeviceObj)
 
     Scope (_SB.PCI0)
     {


### PR DESCRIPTION
Fix compilation with older versions of iASL.

REF: https://www.reddit.com/r/hackintosh/comments/gw4ij7/ssdtsbusmchcdsl_compiles_with_an_error/