### PR TITLE
Combine RTC0 into one RTC_ device

### DIFF
--- a/Docs/AcpiSamples/SSDT-RTC0-RANGE.dsl
+++ b/Docs/AcpiSamples/SSDT-RTC0-RANGE.dsl
@@ -38,7 +38,15 @@ DefinitionBlock ("", "SSDT", 2, "ACDT", "RtcRange", 0x00000000)
         }
         */
         
-        Device (RTC0)
+        Scope (RTC_)
+        {
+            Name (_STA, Zero)  // _STA: Status
+        }
+        /*
+        Reset device to merge RTC0 to  RTC_
+        */
+
+        Device (RTC_)
         {
            /*
             * Change the below _CSR range to match your hardware.


### PR DESCRIPTION
Using RTC0_Range on X299, RTC_ and RTC0 separated settings are integrated into one.