### PR TITLE
Load icons for custom boot entries

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -2438,19 +2438,36 @@ entry choice will update till next manual reconfiguration.
   \tightlist
   \item \texttt{0x0001} --- \texttt{OC\_ATTR\_USE\_VOLUME\_ICON}, provides custom icons
     for boot entries:
+    
+    For \texttt{Tools} OpenCore will try to load a custom icon and fallback to the default icon:
     \begin{itemize}
-      \tightlist
+    \tightlist
+      \item \texttt{ResetNVRAM} --- \texttt{Resources\textbackslash Image\textbackslash ResetNVRAM.icns}
+        --- \texttt{ResetNVRAM.icns} from icons directory.
+      \item \texttt{Tools\textbackslash <TOOL\_RELATIVE\_PATH>.icns}
+        --- icon near the tool file with appended \texttt{.icns} extension.
+    \end{itemize} \medskip
+    
+    For custom boot \texttt{Entries} OpenCore will try to load a custom icon and fallback
+    to the volume icon or the default icon:
+    \begin{itemize}
+    \tightlist
+      \item \texttt{<ENTRY\_PATH>.icns} --- icon near the entry file with appended \texttt{.icns} extension.
+    \end{itemize} \medskip
+    
+    For all other entries OpenCore will try to load a volume icon and fallback to the default icon:
+    \begin{itemize}
+    \tightlist
       \item \texttt{.VolumeIcon.icns} file at \texttt{Preboot} root for APFS.
       \item \texttt{.VolumeIcon.icns} file at volume root for other filesystems.
-      \item \texttt{<ENTRY\_PATH>.icns} file near bootloader for \texttt{Entries}.
-      \item \texttt{<TOOL\_NAME>.icns} file near tool for \texttt{Tools}.
-    \end{itemize}
+    \end{itemize} \medskip
+    
     Volume icons can be set in Finder. Note, that enabling this may result in
     external and internal icons to be indistinguishable.
   \item \texttt{0x0002} --- \texttt{OC\_ATTR\_USE\_DISK\_LABEL\_FILE}, provides custom
     rendered titles for boot entries:
     \begin{itemize}
-      \tightlist
+    \tightlist
       \item \texttt{.disk\_label} (\texttt{.disk\_label\_2x}) file near bootloader for all filesystems.
       \item \texttt{<TOOL\_NAME>.lbl} (\texttt{<TOOL\_NAME>.l2x}) file near tool for \texttt{Tools}.
     \end{itemize}

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -2442,7 +2442,8 @@ entry choice will update till next manual reconfiguration.
       \tightlist
       \item \texttt{.VolumeIcon.icns} file at \texttt{Preboot} root for APFS.
       \item \texttt{.VolumeIcon.icns} file at volume root for other filesystems.
-      \item \texttt{<TOOL\_NAME>.icns} file for \texttt{Tools}.
+      \item \texttt{<ENTRY\_PATH>.icns} file near bootloader for \texttt{Entries}.
+      \item \texttt{<TOOL\_NAME>.icns} file near tool for \texttt{Tools}.
     \end{itemize}
     Volume icons can be set in Finder. Note, that enabling this may result in
     external and internal icons to be indistinguishable.
@@ -2451,7 +2452,7 @@ entry choice will update till next manual reconfiguration.
     \begin{itemize}
       \tightlist
       \item \texttt{.disk\_label} (\texttt{.disk\_label\_2x}) file near bootloader for all filesystems.
-      \item \texttt{<TOOL\_NAME.lbl} (\texttt{<TOOL\_NAME.l2x}) file near tool for \texttt{Tools}.
+      \item \texttt{<TOOL\_NAME>.lbl} (\texttt{<TOOL\_NAME>.l2x}) file near tool for \texttt{Tools}.
     \end{itemize}
     Prerendered labels can be generated via \texttt{disklabel} utility or \texttt{bless} command.
     When disabled or missing text labels (\texttt{.contentDetails} or \texttt{.disk\_label.contentDetails})

--- a/Library/OcBootManagementLib/BootEntryInfo.c
+++ b/Library/OcBootManagementLib/BootEntryInfo.c
@@ -460,7 +460,9 @@ OcGetBootEntryIcon (
   }
 
   if (BootEntry->Type == OC_BOOT_EXTERNAL_OS && BootEntry->PathName != NULL) {
-    // Try to load the icon from the same path with appended .icns extension
+    //
+    // Try to load the icon from the same path with appended .icns extension.
+    //
     Status = InternalGetAppleImage (
       FileSystem,
       BootEntry->PathName,
@@ -471,7 +473,9 @@ OcGetBootEntryIcon (
     
     DEBUG ((DEBUG_INFO, "OCB: OcGetBootEntryIcon - %s (custom entry) - %r\n", BootEntry->Name, Status));
     
-    // Return early if custom icon was loaded successfully
+    //
+    // Return early if custom icon was loaded successfully.
+    //
     if(!EFI_ERROR (Status)) {
       FreePool (BootDirectoryName);
       return Status;

--- a/Library/OcBootManagementLib/BootEntryInfo.c
+++ b/Library/OcBootManagementLib/BootEntryInfo.c
@@ -432,7 +432,7 @@ OcGetBootEntryIcon (
       NULL
       );
 
-    DEBUG ((DEBUG_INFO, "Get custom icon %s - %r\n", BootEntry->Name, Status));
+    DEBUG ((DEBUG_INFO, "OCB: OcGetBootEntryIcon - %s (tool) - %r\n", BootEntry->Name, Status));
     return Status;
   }
 
@@ -459,6 +459,25 @@ OcGetBootEntryIcon (
     return Status;
   }
 
+  if (BootEntry->Type == OC_BOOT_EXTERNAL_OS && BootEntry->PathName != NULL) {
+    // Try to load the icon from the same path with appended .icns extension
+    Status = InternalGetAppleImage (
+      FileSystem,
+      BootEntry->PathName,
+      L".icns",
+      ImageData,
+      DataLength
+      );
+    
+    DEBUG ((DEBUG_INFO, "OCB: OcGetBootEntryIcon - %s (custom entry) - %r\n", BootEntry->Name, Status));
+    
+    // Return early if custom icon was loaded successfully
+    if(!EFI_ERROR (Status)) {
+      FreePool (BootDirectoryName);
+      return Status;
+    }
+  }
+
   Status = InternalGetAppleImage (
     FileSystem,
     L"",
@@ -467,7 +486,7 @@ OcGetBootEntryIcon (
     DataLength
     );
 
-  DEBUG ((DEBUG_INFO, "OCB: Get normal icon %s - %r\n", BootEntry->Name, Status));
+  DEBUG ((DEBUG_INFO, "OCB: OcGetBootEntryIcon - %s (volume icon) - %r\n", BootEntry->Name, Status));
 
   FreePool (BootDirectoryName);
 


### PR DESCRIPTION
This PR adds support for icons for custom entries (acidanthera/bugtracker#1042).

It should try to load an icon for custom entry from the same directory and fallback to trying to load `.VolumeIcon.icns`.

For entry with `Path` = `.../\EFI\path\to\bootloader.efi` it should try to load `.../\EFI\path\to\bootloader.efi.icns`.

I'm not familiar with either UEFI programming nor with OpenCore code, so let me know if I somehow managed to do something wrong in a few lines of code.