### PR TITLE
correct EC scope in SSDT-EC-USBX.dsl

### DIFF
--- a/Docs/AcpiSamples/SSDT-EC-USBX.dsl
+++ b/Docs/AcpiSamples/SSDT-EC-USBX.dsl
@@ -78,7 +78,7 @@ DefinitionBlock ("", "SSDT", 2, "ACDT", "SsdtEC", 0x00001000)
             }
         }
 
-        Scope (\_SB.PCI0.LPCB)
+        Scope (PCI0.LPCB)
         {
             Device (EC)
             {


### PR DESCRIPTION
can not nest \_SB under \_SB, possible better ways to organize scopes