### PR TITLE
OcInputLib: Do not reset input protocols

### DIFF
--- a/Library/OcInputLib/Keycode/AIKShim.c
+++ b/Library/OcInputLib/Keycode/AIKShim.c
@@ -21,27 +21,6 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 
 EFI_STATUS
 EFIAPI
-AIKShimAmiKeycodeReset (
-  IN AMI_EFIKEYCODE_PROTOCOL  *This,
-  IN BOOLEAN                  ExtendedVerification
-  )
-{
-  if (This == NULL || gAikSelf.OurJobIsDone) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  if (This == gAikSelf.Source.AmiKeycode && !gAikSelf.InPollKeyboardEvent) {
-    //
-    // Do not touch any protocol but ours.
-    //
-    AIKDataReset (&gAikSelf.Data);
-  }
-
-  return gAikSelf.Source.AmiReset (This, ExtendedVerification);
-}
-
-EFI_STATUS
-EFIAPI
 AIKShimAmiKeycodeReadEfikey (
   IN  AMI_EFIKEYCODE_PROTOCOL  *This,
   OUT AMI_EFI_KEY_DATA         *KeyData
@@ -62,27 +41,6 @@ AIKShimAmiKeycodeReadEfikey (
   }
 
   return gAikSelf.Source.AmiReadEfikey (This, KeyData);
-}
-
-EFI_STATUS
-EFIAPI
-AIKShimTextInputReset (
-  IN EFI_SIMPLE_TEXT_INPUT_PROTOCOL   *This,
-  IN BOOLEAN                          ExtendedVerification
-  )
-{
-  if (This == NULL || gAikSelf.OurJobIsDone) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  if (This == gAikSelf.Source.TextInput && !gAikSelf.InPollKeyboardEvent) {
-    //
-    // Do not touch any protocol but ours.
-    //
-    AIKDataReset (&gAikSelf.Data);
-  }
-
-  return gAikSelf.Source.TextReset (This, ExtendedVerification);
 }
 
 EFI_STATUS
@@ -123,27 +81,6 @@ AIKShimTextInputReadKeyStroke (
   }
 
   return gAikSelf.Source.TextReadKeyStroke (This, Key);
-}
-
-EFI_STATUS
-EFIAPI
-AIKShimTextInputResetEx (
-  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
-  IN BOOLEAN                            ExtendedVerification
-  )
-{
-  if (This == NULL || gAikSelf.OurJobIsDone) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  if (This == gAikSelf.Source.TextInputEx && !gAikSelf.InPollKeyboardEvent) {
-    //
-    // Do not touch any protocol but ours.
-    //
-    AIKDataReset (&gAikSelf.Data);
-  }
-
-  return gAikSelf.Source.TextResetEx (This, ExtendedVerification);
 }
 
 EFI_STATUS

--- a/Library/OcInputLib/Keycode/AIKShim.h
+++ b/Library/OcInputLib/Keycode/AIKShim.h
@@ -21,13 +21,6 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 
 EFI_STATUS
 EFIAPI
-AIKShimAmiKeycodeReset (
-  IN AMI_EFIKEYCODE_PROTOCOL  *This,
-  IN BOOLEAN                  ExtendedVerification
-  );
-
-EFI_STATUS
-EFIAPI
 AIKShimAmiKeycodeReadEfikey (
   IN  AMI_EFIKEYCODE_PROTOCOL  *This,
   OUT AMI_EFI_KEY_DATA         *KeyData
@@ -35,23 +28,9 @@ AIKShimAmiKeycodeReadEfikey (
 
 EFI_STATUS
 EFIAPI
-AIKShimTextInputReset (
-  IN EFI_SIMPLE_TEXT_INPUT_PROTOCOL   *This,
-  IN BOOLEAN                          ExtendedVerification
-  );
-
-EFI_STATUS
-EFIAPI
 AIKShimTextInputReadKeyStroke (
   IN  EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *This,
   OUT EFI_INPUT_KEY                   *Key
-  );
-
-EFI_STATUS
-EFIAPI
-AIKShimTextInputResetEx (
-  IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
-  IN BOOLEAN                            ExtendedVerification
   );
 
 EFI_STATUS

--- a/Library/OcInputLib/Keycode/AIKSource.c
+++ b/Library/OcInputLib/Keycode/AIKSource.c
@@ -168,15 +168,9 @@ AIKSourceInstall (
 
   DEBUG ((DEBUG_INFO, "OCII: gST->ConIn %p vs found %p\n", gST->ConIn, Source->TextInput));
 
-  //
-  // We additionally reset the protocols as our buffers are empty, and we do not want old data.
-  //
   if (Source->AmiKeycode) {
-    Source->AmiKeycode->Reset (Source->AmiKeycode, FALSE);
-    Source->AmiReset                      = Source->AmiKeycode->Reset;
     Source->AmiReadEfikey                 = Source->AmiKeycode->ReadEfikey;
     Source->AmiWait                       = Source->AmiKeycode->WaitForKeyEx;
-    Source->AmiKeycode->Reset             = AIKShimAmiKeycodeReset;
     Source->AmiKeycode->ReadEfikey        = AIKShimAmiKeycodeReadEfikey;
     Status = gBS->CreateEvent (
       EVT_NOTIFY_WAIT, TPL_NOTIFY, AIKShimWaitForKeyHandler,
@@ -190,11 +184,8 @@ AIKSourceInstall (
   }
 
   if (Source->TextInput) {
-    Source->TextInput->Reset (Source->TextInput, FALSE);
-    Source->TextReset                     = Source->TextInput->Reset;
     Source->TextReadKeyStroke             = Source->TextInput->ReadKeyStroke;
     Source->TextWait                      = Source->TextInput->WaitForKey;
-    Source->TextInput->Reset              = AIKShimTextInputReset;
     Source->TextInput->ReadKeyStroke      = AIKShimTextInputReadKeyStroke;
     Status = gBS->CreateEvent (
       EVT_NOTIFY_WAIT, TPL_NOTIFY, AIKShimWaitForKeyHandler,
@@ -208,11 +199,8 @@ AIKSourceInstall (
   }
 
   if (Source->TextInputEx) {
-    Source->TextInputEx->Reset (Source->TextInputEx, FALSE);
-    Source->TextResetEx                   = Source->TextInputEx->Reset;
     Source->TextWaitEx                    = Source->TextInputEx->WaitForKeyEx;
     Source->TextReadKeyStrokeEx           = Source->TextInputEx->ReadKeyStrokeEx;
-    Source->TextInputEx->Reset            = AIKShimTextInputResetEx;
     Source->TextInputEx->ReadKeyStrokeEx  = AIKShimTextInputReadKeyStrokeEx;
     Status = gBS->CreateEvent (
       EVT_NOTIFY_WAIT, TPL_NOTIFY, AIKShimWaitForKeyHandler,
@@ -234,40 +222,34 @@ AIKSourceUninstall (
   )
 {
   if (Source->AmiKeycode) {
-    Source->AmiKeycode->Reset             = Source->AmiReset;
     Source->AmiKeycode->ReadEfikey        = Source->AmiReadEfikey;
     if (Source->AmiWait != NULL && Source->AmiWait != Source->AmiKeycode->WaitForKeyEx) {
       gBS->CloseEvent (Source->AmiKeycode->WaitForKeyEx);
       Source->AmiKeycode->WaitForKeyEx = Source->AmiWait;
     }
-    Source->AmiReset       = NULL;
     Source->AmiReadEfikey  = NULL;
     Source->AmiWait        = NULL;
     Source->AmiKeycode     = NULL;
   }
 
   if (Source->TextInput) {
-    Source->TextInput->Reset              = Source->TextReset;
     Source->TextInput->ReadKeyStroke      = Source->TextReadKeyStroke;
     if (Source->TextWait != NULL && Source->TextWait != Source->TextInput->WaitForKey) {
       gBS->CloseEvent (Source->TextInput->WaitForKey);
       Source->TextInput->WaitForKey = Source->TextWait;
     }
     Source->TextInput         = NULL;
-    Source->TextReset         = NULL;
     Source->TextWait          = NULL;
     Source->TextReadKeyStroke = NULL;
   }
 
   if (Source->TextInputEx) {
-    Source->TextInputEx->Reset            = Source->TextResetEx;
     Source->TextInputEx->ReadKeyStrokeEx  = Source->TextReadKeyStrokeEx;
     if (Source->TextWaitEx != NULL && Source->TextWaitEx != Source->TextInputEx->WaitForKeyEx) {
       gBS->CloseEvent (Source->TextInputEx->WaitForKeyEx);
       Source->TextInputEx->WaitForKeyEx = Source->TextWaitEx;
     }
     Source->TextInputEx         = NULL;
-    Source->TextResetEx         = NULL;
     Source->TextWaitEx          = NULL;
     Source->TextReadKeyStrokeEx = NULL;
   }

--- a/Library/OcInputLib/Keycode/AIKSource.h
+++ b/Library/OcInputLib/Keycode/AIKSource.h
@@ -29,8 +29,8 @@ typedef struct {
 
   //
   // Solved input protocol instances from ConSplitHandler
-  // We override their ReadKey and Reset handlers and implement
-  // them ourselves via polled data from one of these protocols.
+  // We override their ReadKey handlers and implement them
+  // ourselves via polled data from one of these protocols.
   // Polled proto is prioritised as present: AMI, EX, Legacy.
   //
   AMI_EFIKEYCODE_PROTOCOL            *AmiKeycode;
@@ -40,13 +40,10 @@ typedef struct {
   //
   // Original implementations of the protocols.
   //
-  AMI_RESET_EX                       AmiReset;
   AMI_READ_EFI_KEY                   AmiReadEfikey;
   EFI_EVENT                          AmiWait;
-  EFI_INPUT_RESET                    TextReset;
   EFI_EVENT                          TextWait;
   EFI_INPUT_READ_KEY                 TextReadKeyStroke;
-  EFI_INPUT_RESET_EX                 TextResetEx;
   EFI_INPUT_READ_KEY_EX              TextReadKeyStrokeEx;
   EFI_EVENT                          TextWaitEx;
 } AIK_SOURCE;


### PR DESCRIPTION
On some firmware the reseting input protocols upon OpenCore initialization will discard all currently pressed keys on keyboard. This leads to issue where user unable to trigger showing boot picker by just holding OPT key. https://github.com/acidanthera/bugtracker/issues/564 

Alternatively, we can make this behaviour configurable with option `ResetInputProtocols=true/false`, but this seems unnecessary and just removing 'reset' should work everywhere.