### PR TITLE
 Reset timeout on cursor interaction, spelling fix

### DIFF
--- a/Platform/OpenCanopy/OpenCanopy.c
+++ b/Platform/OpenCanopy/OpenCanopy.c
@@ -1201,7 +1201,7 @@ GuiDrawLoop (
         }
       }
       //
-      // If detected key press then disable menu timeout
+      // If detected pointer event then disable menu timeout
       //
       TimeOutSeconds = 0;
     }

--- a/Platform/OpenCanopy/OpenCanopy.c
+++ b/Platform/OpenCanopy/OpenCanopy.c
@@ -956,7 +956,7 @@ GuiRedrawAndFlushScreen (
 
 EFI_STATUS
 GuiLibConstruct (
-  IN OC_PICKER_CONTEXT  *PickerContet,
+  IN OC_PICKER_CONTEXT  *PickerContext,
   IN UINT32             CursorDefaultX,
   IN UINT32             CursorDefaultY
   )
@@ -976,7 +976,7 @@ GuiLibConstruct (
   CursorDefaultY = MIN (CursorDefaultY, OutputInfo->VerticalResolution   - 1);
 
   mPointerContext = GuiPointerConstruct (
-    PickerContet,
+    PickerContext,
     CursorDefaultX,
     CursorDefaultY,
     OutputInfo->HorizontalResolution,
@@ -986,7 +986,7 @@ GuiLibConstruct (
     DEBUG ((DEBUG_WARN, "OCUI: Failed to initialise pointer\n"));
   }
 
-  mKeyContext = GuiKeyConstruct (PickerContet);
+  mKeyContext = GuiKeyConstruct (PickerContext);
   if (mKeyContext == NULL) {
     DEBUG ((DEBUG_WARN, "OCUI: Failed to initialise key input\n"));
   }
@@ -1200,6 +1200,10 @@ GuiDrawLoop (
           HoldObject = NULL;
         }
       }
+      //
+      // If detected key press then disable menu timeout
+      //
+      TimeOutSeconds = 0;
     }
 
     if (mKeyContext != NULL) {


### PR DESCRIPTION
My keyboard is connected to a Bluetooth reciever and therefore doesn't work.
Sadly, my Logitech G603 + 2.4Ghz reciever is a tad laggy and this results in me 50% of the time not being able to select what I'd like to boot up. 

So I added the feature of also disabling the timeout on pointer events. 

Does this make sense? Please review this carefully. Was a looong time ago I wrote any C code.. :)

Also fixed a spelling error.