### PR TITLE
Utilities: Add status check for OcConfigurationInit in ocvalidate, return -1 if it fails

### DIFF
--- a/Utilities/ocvalidate/ocvalidate.c
+++ b/Utilities/ocvalidate/ocvalidate.c
@@ -54,7 +54,13 @@ int main(int argc, char** argv) {
   long long a = current_timestamp();
 
   OC_GLOBAL_CONFIG   Config;
-  OcConfigurationInit (&Config, b, f);
+  EFI_STATUS         Status;
+  Status = OcConfigurationInit (&Config, b, f);
+
+  if (Status != EFI_SUCCESS) {
+    printf("Unsupported file\n");
+    return -1;
+  }
 
   DEBUG ((DEBUG_ERROR, "Done checking %a in %llu ms\n", argc > 1 ? argv[1] : "./config.plist", current_timestamp() - a));
 

--- a/Utilities/ocvalidate/ocvalidate.c
+++ b/Utilities/ocvalidate/ocvalidate.c
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
   Status = OcConfigurationInit (&Config, b, f);
 
   if (Status != EFI_SUCCESS) {
-    printf("Unsupported file\n");
+    printf("Invalid config\n");
     return -1;
   }
 


### PR DESCRIPTION
Current ocvalidate will pass the config even if the config file doesn't pass OcConfigurationInit successfully. Add a status check for better utility of ocvalidate.