### PR TITLE
32-bit prelinking support

### DIFF
--- a/Include/Acidanthera/Library/OcAppleKernelLib.h
+++ b/Include/Acidanthera/Library/OcAppleKernelLib.h
@@ -174,31 +174,31 @@ typedef struct {
   //
   // Pointer to PRELINK_INFO_SEGMENT.
   //
-  MACH_SEGMENT_COMMAND_64  *PrelinkedInfoSegment;
+  MACH_SEGMENT_COMMAND_ANY *PrelinkedInfoSegment;
   //
   // Pointer to PRELINK_INFO_SECTION.
   //
-  MACH_SECTION_64          *PrelinkedInfoSection;
+  MACH_SECTION_ANY         *PrelinkedInfoSection;
   //
   // Pointer to PRELINK_TEXT_SEGMENT.
   //
-  MACH_SEGMENT_COMMAND_64  *PrelinkedTextSegment;
+  MACH_SEGMENT_COMMAND_ANY *PrelinkedTextSegment;
   //
   // Pointer to PRELINK_TEXT_SECTION.
   //
-  MACH_SECTION_64          *PrelinkedTextSection;
+  MACH_SECTION_ANY         *PrelinkedTextSection;
   //
   // Pointer to PRELINK_STATE_SEGMENT (for 10.6.8).
   //
-  MACH_SEGMENT_COMMAND_64  *PrelinkedStateSegment;
+  MACH_SEGMENT_COMMAND_ANY *PrelinkedStateSegment;
   //
   // Pointer to PRELINK_STATE_SECTION_KERNEL (for 10.6.8).
   //
-  MACH_SECTION_64          *PrelinkedStateSectionKernel;
+  MACH_SECTION_ANY         *PrelinkedStateSectionKernel;
   //
   // Pointer to PRELINK_STATE_SECTION_KEXTS (for 10.6.8).
   //
-  MACH_SECTION_64          *PrelinkedStateSectionKexts;
+  MACH_SECTION_ANY         *PrelinkedStateSectionKexts;
   //
   // Contents of PRELINK_STATE_SECTION_KERNEL section (for 10.6.8).
   //
@@ -222,7 +222,7 @@ typedef struct {
   //
   // Pointer to KC_LINKEDIT_SEGMENT (for KC mode).
   //
-  MACH_SEGMENT_COMMAND_64  *LinkEditSegment;
+  MACH_SEGMENT_COMMAND_ANY *LinkEditSegment;
   //
   // Pointer to KC_REGION0_SEGMENT (for KC mode).
   //
@@ -301,6 +301,10 @@ typedef struct {
   // Kernel virtual base.
   //
   UINT64                   VirtualBase;
+  //
+  // Prelinked is 32-bit.
+  //
+  BOOLEAN                  Is32Bit;
 } PRELINKED_CONTEXT;
 
 //

--- a/Include/Acidanthera/Library/OcAppleKernelLib.h
+++ b/Include/Acidanthera/Library/OcAppleKernelLib.h
@@ -716,6 +716,7 @@ OcMatchDarwinVersion (
   @param[in,out] Prelinked           Unpacked prelinked buffer (Mach-O image).
   @param[in]     PrelinkedSize       Unpacked prelinked buffer size.
   @param[in]     PrelinkedAllocSize  Unpacked prelinked buffer allocated size.
+  @param[in]     Is32Bit             TRUE if prelinked is 32-bit.
 
   @return  EFI_SUCCESS on success.
 **/
@@ -724,7 +725,8 @@ PrelinkedContextInit (
   IN OUT  PRELINKED_CONTEXT  *Context,
   IN OUT  UINT8              *Prelinked,
   IN      UINT32             PrelinkedSize,
-  IN      UINT32             PrelinkedAllocSize
+  IN      UINT32             PrelinkedAllocSize,
+  IN      BOOLEAN            Is32Bit
   );
 
 /**

--- a/Include/Acidanthera/Library/OcMachoLib.h
+++ b/Include/Acidanthera/Library/OcMachoLib.h
@@ -287,6 +287,23 @@ MachoGetSectionByName64 (
   );
 
 /**
+  Retrieves a section within a segment by the name of SegmentName.
+
+  @param[in,out] Context      Context of the Mach-O.
+  @param[in]     SegmentName  The name of the segment to search in.
+  @param[in]     SectionName  The name of the section to search for.
+
+  @retval NULL  NULL is returned on failure.
+
+**/
+MACH_SECTION_ANY *
+MachoGetSegmentSectionByName (
+  IN OUT OC_MACHO_CONTEXT  *Context,
+  IN     CONST CHAR8       *SegmentName,
+  IN     CONST CHAR8       *SectionName
+  );
+
+/**
   Retrieves a 32-bit section within a segment by the name of SegmentName.
 
   @param[in,out] Context      Context of the Mach-O.
@@ -899,6 +916,23 @@ MachoGetSymbolByExternRelocationOffset64 (
   IN OUT OC_MACHO_CONTEXT   *Context,
   IN     UINT64             Address,
   OUT    MACH_NLIST_64      **Symbol
+  );
+
+/**
+  Relocate Symbol to be against LinkAddress.
+
+  @param[in,out] Context      Context of the Mach-O.
+  @param[in]     LinkAddress  The address to be linked against.
+  @param[in,out] Symbol       The symbol to be relocated.
+
+  @returns  Whether the operation has been completed successfully.
+
+**/
+BOOLEAN
+MachoRelocateSymbol (
+  IN OUT OC_MACHO_CONTEXT   *Context,
+  IN     UINT64             LinkAddress,
+  IN OUT MACH_NLIST_ANY     *Symbol
   );
 
 /**

--- a/Include/Acidanthera/Library/OcMachoLib.h
+++ b/Include/Acidanthera/Library/OcMachoLib.h
@@ -1560,6 +1560,7 @@ MachoGetFilePointerByAddress (
   @param[out] Destination      Output buffer.
   @param[in]  DestinationSize  Output buffer maximum size.
   @param[in]  Strip            Output with stripped prelink commands.
+  @param[in]  FileOffset       Pointer to the file offset of the first segment.
 
   @returns  New image size or 0 on failure.
 
@@ -1569,7 +1570,8 @@ MachoExpandImage (
   IN  OC_MACHO_CONTEXT   *Context,
   OUT UINT8              *Destination,
   IN  UINT32             DestinationSize,
-  IN  BOOLEAN            Strip
+  IN  BOOLEAN            Strip,
+  OUT UINT64             *FileOffset OPTIONAL
   );
 
 /**

--- a/Include/Acidanthera/Library/OcMachoLib.h
+++ b/Include/Acidanthera/Library/OcMachoLib.h
@@ -1575,6 +1575,19 @@ MachoExpandImage (
   );
 
 /**
+  Calculates size required for expanded Mach-O image using MachoExpandImage().
+
+  @param[in]  Context          Context of the Mach-O.
+
+  @returns  New image size or 0 on failure.
+
+**/
+UINT32
+MachoGetExpandedImageSize (
+  IN  OC_MACHO_CONTEXT   *Context
+  );
+
+/**
   Find Mach-O entry point from LC_UNIXTHREAD loader command.
   This command does not verify Mach-O and assumes it is valid.
 

--- a/Include/Acidanthera/Library/OcMachoLib.h
+++ b/Include/Acidanthera/Library/OcMachoLib.h
@@ -437,6 +437,21 @@ MachoGetNextSection64 (
   );
 
 /**
+  Retrieves a section by its index.
+
+  @param[in,out] Context  Context of the Mach-O.
+  @param[in]     Index    Index of the section to retrieve.
+
+  @retval NULL  NULL is returned on failure.
+
+**/
+MACH_SECTION_ANY *
+MachoGetSectionByIndex (
+  IN OUT OC_MACHO_CONTEXT  *Context,
+  IN     UINT32            Index
+  );
+
+/**
   Retrieves a 32-bit section by its index.
 
   @param[in,out] Context  Context of the Mach-O.
@@ -1333,6 +1348,18 @@ MachoGetVtableSymbolsFromSmcp64 (
   IN     CONST CHAR8          *SmcpName,
   OUT    CONST MACH_NLIST_64  **Vtable,
   OUT    CONST MACH_NLIST_64  **MetaVtable
+  );
+
+/**
+  Returns whether the Relocation's type indicates a Pair for the Intel 32
+  platform.
+  
+  @param[in] Type  The Relocation's type to verify.
+
+**/
+BOOLEAN
+MachoRelocationIsPairIntel32 (
+  IN UINT8  Type
   );
 
 /**

--- a/Include/Apple/IndustryStandard/AppleKmodInfo.h
+++ b/Include/Apple/IndustryStandard/AppleKmodInfo.h
@@ -63,4 +63,9 @@ typedef struct KMOD_INFO_64_V1 {
 
 #pragma pack()
 
+typedef union {
+  KMOD_INFO_32_V1 Kmod32;
+  KMOD_INFO_64_V1 Kmod64;
+} KMOD_INFO_ANY;
+
 #endif // APPLE_KMOD_INFO_H

--- a/Include/Apple/IndustryStandard/AppleKxldState.h
+++ b/Include/Apple/IndustryStandard/AppleKxldState.h
@@ -99,6 +99,11 @@ STATIC_ASSERT (sizeof (KXLD_SYM_ENTRY_64) == 16, "Invalid KXLD_SYM_ENTRY_64 size
 
 #pragma pack(pop)
 
+typedef union {
+  KXLD_SYM_ENTRY_32 Kxld32;
+  KXLD_SYM_ENTRY_64 Kxld64;
+} KXLD_SYM_ENTRY_ANY;
+
 /**
   Symbol marked with this flag is obsolete (deprecated).
 **/

--- a/Library/OcAppleKernelLib/KextPatcher.c
+++ b/Library/OcAppleKernelLib/KextPatcher.c
@@ -238,6 +238,7 @@ PatcherGetSymbolAddress (
       //
       if (Index == 0 && Context->KxldState != NULL) {
         SymbolAddress = InternalKxldSolveSymbol (
+          Context->Is32Bit,
           Context->KxldState,
           Context->KxldStateSize,
           Name

--- a/Library/OcAppleKernelLib/KxldState.c
+++ b/Library/OcAppleKernelLib/KxldState.c
@@ -192,7 +192,8 @@ InternalKxldStateBuildLinkedSymbolTable (
   PRELINKED_KEXT_SYMBOL    *WalkerBottom;
   PRELINKED_KEXT_SYMBOL    *WalkerTop;
   CONST CHAR8              *Name;
-  CONST KXLD_SYM_ENTRY_64  *KxldSymbols;
+  CONST KXLD_SYM_ENTRY_ANY *KxldSymbols;
+  UINT64                   KxldAddress;
   UINT32                   Index;
   UINT32                   NumSymbols;
   UINT32                   NumCxxSymbols;
@@ -208,7 +209,7 @@ InternalKxldStateBuildLinkedSymbolTable (
   KxldSymbols = InternalGetKxldSymbols (
     Kext->Context.KxldState,
     Kext->Context.KxldStateSize,
-    MachCpuTypeX8664,
+    Context->Is32Bit ? MachCpuTypeI386 : MachCpuTypeX8664,
     &NumSymbols
     );
 
@@ -228,7 +229,8 @@ InternalKxldStateBuildLinkedSymbolTable (
 
   DEBUG ((
     DEBUG_VERBOSE,
-    "OCAK: Processing %a KXLD state with %u symbols\n",
+    "OCAK: Processing %a-bit %a KXLD state with %u symbols\n",
+    Context->Is32Bit ? "32" : "64",
     Kext->Identifier,
     NumSymbols
     ));
@@ -237,7 +239,7 @@ InternalKxldStateBuildLinkedSymbolTable (
     Name = InternalGetKxldString (
       Kext->Context.KxldState,
       Kext->Context.KxldStateSize,
-      KxldSymbols->NameOffset
+      Context->Is32Bit ? KxldSymbols->Kxld32.NameOffset : KxldSymbols->Kxld64.NameOffset
       );
     if (Name == NULL) {
       return EFI_INVALID_PARAMETER;
@@ -245,29 +247,32 @@ InternalKxldStateBuildLinkedSymbolTable (
 
     Result = MachoSymbolNameIsCxx (Name);
 
+    KxldAddress = Context->Is32Bit ? KxldSymbols->Kxld32.Address : KxldSymbols->Kxld64.Address;
+
     DEBUG ((
       DEBUG_VERBOSE,
-      "OCAK: Adding symbol %a with %Lx value (flags %u)\n",
+      "OCAK: Adding %a-bit symbol %a with %Lx value (flags %u)\n",
+      Context->Is32Bit ? "32" : "64",
       Name,
-      KxldSymbols->Address,
-      KxldSymbols->Flags
+      KxldAddress,
+      Context->Is32Bit ? KxldSymbols->Kxld32.Flags : KxldSymbols->Kxld64.Flags
       ));
 
     if (!Result) {
-      WalkerBottom->Value  = KxldSymbols->Address;
+      WalkerBottom->Value  = KxldAddress;
       WalkerBottom->Name   = Name;
-      WalkerBottom->Length = (UINT32)AsciiStrLen (WalkerBottom->Name);
+      WalkerBottom->Length = (UINT32) AsciiStrLen (WalkerBottom->Name);
       ++WalkerBottom;
     } else {
-      WalkerTop->Value  = KxldSymbols->Address;
+      WalkerTop->Value  = KxldAddress;
       WalkerTop->Name   = Name;
-      WalkerTop->Length = (UINT32)AsciiStrLen (WalkerTop->Name);
+      WalkerTop->Length = (UINT32) AsciiStrLen (WalkerTop->Name);
       --WalkerTop;
 
       ++NumCxxSymbols;
     }
 
-    ++KxldSymbols;
+    KxldSymbols = KXLD_ANY_NEXT (Context->Is32Bit, KxldSymbols);
   }
 
   Kext->NumberOfSymbols    = NumSymbols;
@@ -285,7 +290,7 @@ InternalKxldStateBuildLinkedVtables (
 {
   PRELINKED_VTABLE                 *LinkedVtables;
   PRELINKED_VTABLE                 *CurrentVtable;
-  CONST KXLD_SYM_ENTRY_64          *KxldSymbols;
+  CONST KXLD_SYM_ENTRY_ANY         *KxldSymbols;
   CONST KXLD_VTABLE_HEADER         *KxldVtables;
   UINT32                           Index;
   UINT32                           Index2;
@@ -303,7 +308,7 @@ InternalKxldStateBuildLinkedVtables (
   KxldVtables = InternalGetKxldVtables (
     Kext->Context.KxldState,
     Kext->Context.KxldStateSize,
-    MachCpuTypeX8664,
+    Context->Is32Bit ? MachCpuTypeI386 : MachCpuTypeX8664,
     &NumVtables
     );
 
@@ -346,7 +351,7 @@ InternalKxldStateBuildLinkedVtables (
       return EFI_INVALID_PARAMETER;
     }
 
-    KxldSymbols = (KXLD_SYM_ENTRY_64 *) ((UINT8 *) Kext->Context.KxldState + KxldVtables[Index].EntryOffset);
+    KxldSymbols = (KXLD_SYM_ENTRY_ANY *) ((UINT8 *) Kext->Context.KxldState + KxldVtables[Index].EntryOffset);
     CurrentVtable->NumEntries = KxldVtables[Index].NumEntries;
 
     DEBUG ((
@@ -360,18 +365,18 @@ InternalKxldStateBuildLinkedVtables (
       ));
 
     for (Index2 = 0; Index2 < CurrentVtable->NumEntries; ++Index2) {
-      CurrentVtable->Entries[Index2].Address = KxldSymbols->Address;
+      CurrentVtable->Entries[Index2].Address = Context->Is32Bit ? KxldSymbols->Kxld32.Address : KxldSymbols->Kxld64.Address;
       CurrentVtable->Entries[Index2].Name    = InternalGetKxldString (
         Kext->Context.KxldState,
         Kext->Context.KxldStateSize,
-        KxldSymbols->NameOffset
+        Context->Is32Bit ? KxldSymbols->Kxld32.NameOffset : KxldSymbols->Kxld64.NameOffset
         );
       if (CurrentVtable->Entries[Index2].Name == NULL) {
         FreePool (LinkedVtables);
         return EFI_INVALID_PARAMETER;
       }
 
-      ++KxldSymbols;
+      KxldSymbols = KXLD_ANY_NEXT (Context->Is32Bit, KxldSymbols);
     }
 
     CurrentVtable = GET_NEXT_PRELINKED_VTABLE (CurrentVtable);
@@ -542,7 +547,8 @@ InternalKxldStateRebuild (
     }
     DEBUG ((
       DEBUG_INFO,
-      "OCAK: Rebasing KXLD state from %Lx to %Lx - %r\n",
+      "OCAK: Rebasing %a-bit KXLD state from %Lx to %Lx - %r\n",
+      Context->Is32Bit ? "32" : "64",
       Context->PrelinkedStateKextsAddress,
       Context->Is32Bit ?
         Context->PrelinkedStateSectionKexts->Section32.Address : Context->PrelinkedStateSectionKexts->Section64.Address,
@@ -557,13 +563,15 @@ InternalKxldStateRebuild (
 
 UINT64
 InternalKxldSolveSymbol (
+  IN BOOLEAN       Is32Bit,
   IN CONST VOID    *KxldState,
   IN UINT32        KxldStateSize,
   IN CONST CHAR8   *Name
   )
 {
   CONST CHAR8              *LocalName;
-  CONST KXLD_SYM_ENTRY_64  *KxldSymbols;
+  CONST KXLD_SYM_ENTRY_ANY *KxldSymbols;
+  UINT64                   KxldAddress;
   UINT32                   Index;
   UINT32                   NumSymbols;
 
@@ -574,7 +582,7 @@ InternalKxldSolveSymbol (
   KxldSymbols = InternalGetKxldSymbols (
     KxldState,
     KxldStateSize,
-    MachCpuTypeX8664,
+    Is32Bit ? MachCpuTypeI386 : MachCpuTypeX8664,
     &NumSymbols
     );
 
@@ -584,7 +592,8 @@ InternalKxldSolveSymbol (
 
   DEBUG ((
     DEBUG_VERBOSE,
-    "OCAK: Processing KXLD state for %a with %u symbols\n",
+    "OCAK: Processing %a-bit KXLD state for %a with %u symbols\n",
+    Is32Bit ? "32" : "64",
     Name,
     NumSymbols
     ));
@@ -593,25 +602,28 @@ InternalKxldSolveSymbol (
     LocalName = InternalGetKxldString (
       KxldState,
       KxldStateSize,
-      KxldSymbols->NameOffset
+      Is32Bit ? KxldSymbols->Kxld32.NameOffset : KxldSymbols->Kxld64.NameOffset
       );
     if (LocalName == NULL) {
       return 0;
     }
 
+    KxldAddress = Is32Bit ? KxldSymbols->Kxld32.Address : KxldSymbols->Kxld64.Address;
+
     DEBUG ((
       DEBUG_VERBOSE,
-      "OCAK: Checking symbol %a with %Lx value (flags %u)\n",
+      "OCAK: Checking %a-bit symbol %a with %Lx value (flags %u)\n",
+      Is32Bit ? "32" : "64",
       LocalName,
-      KxldSymbols->Address,
-      KxldSymbols->Flags
+      KxldAddress,
+      Is32Bit ? KxldSymbols->Kxld32.Flags : KxldSymbols->Kxld64.Flags
       ));
 
     if (AsciiStrCmp (LocalName, Name) == 0) {
-      return KxldSymbols->Address;
+      return KxldAddress;
     }
 
-    ++KxldSymbols;
+    KxldSymbols = KXLD_ANY_NEXT (Is32Bit, KxldSymbols);
   }
 
   return 0;

--- a/Library/OcAppleKernelLib/Link.c
+++ b/Library/OcAppleKernelLib/Link.c
@@ -1897,25 +1897,25 @@ InternalPrelinkKext (
       LinkEditSegment->Segment64.FileSize = LinkEditSize;
       LinkEditSegment->Segment64.Size     = LinkEditSize;
     }
-  }
 
-  if (DySymtab != NULL) {
-    DySymtab->LocalRelocationsOffset = (UINT32)(LinkEditFileOffset + RelocationsOffset);
-    DySymtab->NumOfLocalRelocations  = NumRelocations;
+    if (DySymtab != NULL) {
+      DySymtab->LocalRelocationsOffset = (UINT32)(LinkEditFileOffset + RelocationsOffset);
+      DySymtab->NumOfLocalRelocations  = NumRelocations;
 
-    //
-    // Clear dynamic linker information.
-    //
-    DySymtab->LocalSymbolsIndex         = 0;
-    DySymtab->NumLocalSymbols           = 0;
-    DySymtab->NumExternalSymbols        = 0;
-    DySymtab->ExternalSymbolsIndex      = 0;
-    DySymtab->NumExternalRelocations    = 0;
-    DySymtab->ExternalRelocationsOffset = 0;
-    DySymtab->UndefinedSymbolsIndex     = 0;
-    DySymtab->NumUndefinedSymbols       = 0;
-    DySymtab->IndirectSymbolsOffset     = 0;
-    DySymtab->NumIndirectSymbols        = 0;
+      //
+      // Clear dynamic linker information.
+      //
+      DySymtab->LocalSymbolsIndex         = 0;
+      DySymtab->NumLocalSymbols           = 0;
+      DySymtab->NumExternalSymbols        = 0;
+      DySymtab->ExternalSymbolsIndex      = 0;
+      DySymtab->NumExternalRelocations    = 0;
+      DySymtab->ExternalRelocationsOffset = 0;
+      DySymtab->UndefinedSymbolsIndex     = 0;
+      DySymtab->NumUndefinedSymbols       = 0;
+      DySymtab->IndirectSymbolsOffset     = 0;
+      DySymtab->NumIndirectSymbols        = 0;
+    }
   }
 
   //
@@ -2011,6 +2011,10 @@ InternalPrelinkKext (
     // Adapt the Mach-O header to signal being prelinked.
     //
     MachHeader->Header32.Flags = MACH_HEADER_FLAG_NO_UNDEFINED_REFERENCES;
+
+    if (LinkEditSegment != NULL) { //FIXME : Symbols are not in a segment in MH_OBJECT.
+      MachSize = SegmentOffset + SegmentSize;
+    }
   } else {
     //
     // Populate kmod information.
@@ -2030,14 +2034,15 @@ InternalPrelinkKext (
     // Adapt the Mach-O header to signal being prelinked.
     //
     MachHeader->Header64.Flags = MACH_HEADER_FLAG_NO_UNDEFINED_REFERENCES;
+
+    MachSize = SegmentOffset + SegmentSize;
   }
 
   //
   // Reinitialize the Mach-O context to account for the changed __LINKEDIT
   // segment and file size.
   //
-  //FIXME : Symbols are not in a segment in MH_OBJECT.
-  if (!MachoInitializeContext (MachoContext, MachHeader, MachSize /*(SegmentOffset + SegmentSize)*/, MachoContext->ContainerOffset, Context->Is32Bit)) { 
+  if (!MachoInitializeContext (MachoContext, MachHeader, MachSize, MachoContext->ContainerOffset, Context->Is32Bit)) { 
     //
     // This should never failed under normal and abnormal conditions.
     //

--- a/Library/OcAppleKernelLib/Link.c
+++ b/Library/OcAppleKernelLib/Link.c
@@ -729,14 +729,16 @@ InternalIsDirectPureVirtualCall (
   IN UINT64                  Offset
   )
 {
+  UINT32                       Remainder;
   UINT64                       Index;
   CONST PRELINKED_VTABLE_ENTRY *Entry;
 
-  if ((Offset % (Is32Bit ? sizeof (UINT32) : sizeof (UINT64))) != 0 || (Offset < VTABLE_ENTRY_SIZE_X (Is32Bit))) {
+  DivU64x32Remainder (Offset, Is32Bit ? sizeof (UINT32) : sizeof (UINT64), &Remainder);
+  if (Remainder != 0 || Offset < VTABLE_ENTRY_SIZE_X (Is32Bit)) {
     return FALSE;
   }
 
-  Index = ((Offset - VTABLE_ENTRY_SIZE_X (Is32Bit)) / (Is32Bit ? sizeof (UINT32) : sizeof (UINT64)));
+  Index = DivU64x32 (Offset - VTABLE_ENTRY_SIZE_X (Is32Bit), Is32Bit ? sizeof (UINT32) : sizeof (UINT64));
   if (Index >= Vtable->NumEntries) {
     return FALSE;
   }

--- a/Library/OcAppleKernelLib/Link.c
+++ b/Library/OcAppleKernelLib/Link.c
@@ -1,6 +1,5 @@
 /** @file
   Library handling KEXT prelinking.
-  Currently limited to Intel 64 architectures.
   
 Copyright (c) 2018, Download-Fritz.  All rights reserved.<BR>
 This program and the accompanying materials are licensed and made available
@@ -24,6 +23,8 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include <Library/OcAppleKernelLib.h>
 #include <Library/OcGuardLib.h>
 #include <Library/OcMachoLib.h>
+
+#include <Library/OcFileLib.h>
 
 #include "PrelinkedInternal.h"
 
@@ -280,7 +281,7 @@ InternalOcGetSymbolValue (
 /**
   Patches Symbol with Value and marks it as solved.
 
-  @param[in]  Is32Bit 32-bit.
+  @param[in]  Is32Bit Symbol is 32-bit.
   @param[in]  Value   The value to solve Symbol with.
   @param[out] Symbol  The symbol to solve.
 
@@ -438,32 +439,77 @@ InternalSolveSymbol (
     Value = *WeakTestValue;
 
     if (Value == 0) {
-      for (Index = 0; Index < NumUndefinedSymbols; ++Index) {
-        WeakTestSymbol = &UndefinedSymbols[Index];
-        Result = AsciiStrCmp (
-                   MachoGetSymbolName (
-                     &Kext->Context.MachContext,
-                     WeakTestSymbol
-                     ),
-                   KXLD_WEAK_TEST_SYMBOL
-                   );
-        if (Result == 0) {
-          if (((Context->Is32Bit ?
-            WeakTestSymbol->Symbol32.Descriptor : WeakTestSymbol->Symbol64.Descriptor) & MACH_N_TYPE_TYPE) == MACH_N_TYPE_UNDF) {
-            Success = InternalSolveSymbolNonWeak (
-                        Context,
-                        Kext,
-                        Name,
-                        Symbol
-                        );
-            if (!Success) {
-              return FALSE;
+      //
+      // Fallback to the primary symbol table if we do not have a separate undefined symbol table, but only on 32-bit.
+      //
+      if (NumUndefinedSymbols > 0) {
+        for (Index = 0; Index < NumUndefinedSymbols; ++Index) {
+          if (Context->Is32Bit) {
+            WeakTestSymbol = (MACH_NLIST_ANY *)&(&UndefinedSymbols->Symbol32)[Index];
+          } else {
+            WeakTestSymbol = (MACH_NLIST_ANY *)&(&UndefinedSymbols->Symbol64)[Index];
+          }
+          Result = AsciiStrCmp (
+                    MachoGetSymbolName (
+                      &Kext->Context.MachContext,
+                      WeakTestSymbol
+                      ),
+                    KXLD_WEAK_TEST_SYMBOL
+                    );
+          if (Result == 0) {
+            if (((Context->Is32Bit ?
+              WeakTestSymbol->Symbol32.Descriptor : WeakTestSymbol->Symbol64.Descriptor) & MACH_N_TYPE_TYPE) == MACH_N_TYPE_UNDF) {
+              Success = InternalSolveSymbolNonWeak (
+                          Context,
+                          Kext,
+                          Name,
+                          Symbol
+                          );
+              if (!Success) {
+                return FALSE;
+              }
             }
+
+            Value = Context->Is32Bit ? WeakTestSymbol->Symbol32.Value : WeakTestSymbol->Symbol64.Value;
+            *WeakTestValue = Value;
+            break;
+          }
+        }
+      } else if (Context->Is32Bit) {
+        Index = 0;
+        while (TRUE) {
+          WeakTestSymbol = MachoGetSymbolByIndex (&Kext->Context.MachContext, Index);
+          if (WeakTestSymbol == NULL) {
+            break;
           }
 
-          Value = Context->Is32Bit ? WeakTestSymbol->Symbol32.Value : WeakTestSymbol->Symbol64.Value;
-          *WeakTestValue = Value;
-          break;
+          Result = AsciiStrCmp (
+                    MachoGetSymbolName (
+                      &Kext->Context.MachContext,
+                      WeakTestSymbol
+                      ),
+                    KXLD_WEAK_TEST_SYMBOL
+                    );
+          if (Result == 0) {
+            if (((Context->Is32Bit ?
+              WeakTestSymbol->Symbol32.Descriptor : WeakTestSymbol->Symbol64.Descriptor) & MACH_N_TYPE_TYPE) == MACH_N_TYPE_UNDF) {
+              Success = InternalSolveSymbolNonWeak (
+                          Context,
+                          Kext,
+                          Name,
+                          Symbol
+                          );
+              if (!Success) {
+                return FALSE;
+              }
+            }
+
+            Value = Context->Is32Bit ? WeakTestSymbol->Symbol32.Value : WeakTestSymbol->Symbol64.Value;
+            *WeakTestValue = Value;
+            break;
+          }
+
+          ++Index;
         }
       }
     }
@@ -538,7 +584,7 @@ InternalCalculateDisplacementIntel64 (
 **/
 STATIC
 BOOLEAN
-InternalCalculateTargetsIntel64 (
+InternalCalculateTargets (
   IN     PRELINKED_CONTEXT           *Context,
   IN OUT PRELINKED_KEXT              *Kext,
   IN     UINT64                      LoadAddress,
@@ -554,9 +600,9 @@ InternalCalculateTargetsIntel64 (
   OC_MACHO_CONTEXT      *MachoContext;
 
   UINT64                TargetAddress;
-  MACH_NLIST_64         *Symbol;
+  MACH_NLIST_ANY        *Symbol;
   CONST CHAR8           *Name;
-  MACH_SECTION_64       *Section;
+  MACH_SECTION_ANY      *Section;
   UINT64                PairAddress;
   UINT64                PairDummy;
 
@@ -579,7 +625,7 @@ InternalCalculateTargetsIntel64 (
   // section's boundary.
   //
   if (Relocation->Extern != 0) {
-    Symbol = MachoGetSymbolByIndex64 (
+    Symbol = MachoGetSymbolByIndex (
                 MachoContext,
                 Relocation->SymbolNumber
                 );
@@ -587,7 +633,7 @@ InternalCalculateTargetsIntel64 (
       return FALSE;
     }
 
-    Name = MachoGetSymbolName64 (MachoContext, Symbol);
+    Name = MachoGetSymbolName (MachoContext, Symbol);
     //
     // If this symbol is a padslot that has already been replaced, then the
     // only way a relocation entry can still reference it is if there is a
@@ -604,14 +650,14 @@ InternalCalculateTargetsIntel64 (
       *Vtable = InternalGetOcVtableByName (Context, Kext, Name);
     }
 
-    TargetAddress = Symbol->Value;
+    TargetAddress = Context->Is32Bit ? Symbol->Symbol32.Value : Symbol->Symbol64.Value;
   } else {
     if ((Relocation->SymbolNumber == NO_SECT)
      || (Relocation->SymbolNumber > MAX_SECT)) {
       return FALSE;
     }
 
-    Section = MachoGetSectionByIndex64 (
+    Section = MachoGetSectionByIndex (
                 MachoContext,
                 (Relocation->SymbolNumber - 1)
                 );
@@ -619,14 +665,25 @@ InternalCalculateTargetsIntel64 (
       return FALSE;
     }
 
-    TargetAddress = ALIGN_VALUE (
-                      (Section->Address + LoadAddress),
-                      LShiftU64 (1, Section->Alignment)
-                      );
-    TargetAddress -= Section->Address;
+    if (Context->Is32Bit) {
+      TargetAddress = ALIGN_VALUE (
+                        (Section->Section32.Address + LoadAddress),
+                        LShiftU64 (1, Section->Section32.Alignment)
+                        );
+      TargetAddress -= Section->Section32.Address;
+    } else {
+      TargetAddress = ALIGN_VALUE (
+                        (Section->Section64.Address + LoadAddress),
+                        LShiftU64 (1, Section->Section64.Alignment)
+                        );
+      TargetAddress -= Section->Section64.Address;
+    }
   }
 
-  if (MachoRelocationIsPairIntel64 ((UINT8)Relocation->Type)) {
+  if (Context->Is32Bit ?
+    MachoRelocationIsPairIntel32 ((UINT8) Relocation->Type) :
+    MachoRelocationIsPairIntel64 ((UINT8) Relocation->Type)
+    ) {
     if (NextRelocation == NULL) {
       return FALSE;
     }
@@ -635,7 +692,7 @@ InternalCalculateTargetsIntel64 (
     // of a pair itself.  Pass dummy data for the related arguments.  This call
     // shall never reach this very branch.
     //
-    Success = InternalCalculateTargetsIntel64 (
+    Success = InternalCalculateTargets (
                 Context,
                 Kext,
                 LoadAddress,
@@ -666,7 +723,8 @@ InternalCalculateTargetsIntel64 (
 **/
 STATIC
 BOOLEAN
-InternalIsDirectPureVirtualCall64 (
+InternalIsDirectPureVirtualCall (
+  IN BOOLEAN                 Is32Bit,
   IN CONST PRELINKED_VTABLE  *Vtable,
   IN UINT64                  Offset
   )
@@ -674,11 +732,11 @@ InternalIsDirectPureVirtualCall64 (
   UINT64                       Index;
   CONST PRELINKED_VTABLE_ENTRY *Entry;
 
-  if ((Offset % sizeof (UINT64)) != 0 || (Offset < VTABLE_ENTRY_SIZE_64)) {
+  if ((Offset % (Is32Bit ? sizeof (UINT32) : sizeof (UINT64))) != 0 || (Offset < VTABLE_ENTRY_SIZE_X (Is32Bit))) {
     return FALSE;
   }
 
-  Index = ((Offset - VTABLE_ENTRY_SIZE_64) / sizeof (UINT64));
+  Index = ((Offset - VTABLE_ENTRY_SIZE_X (Is32Bit)) / (Is32Bit ? sizeof (UINT32) : sizeof (UINT64)));
   if (Index >= Vtable->NumEntries) {
     return FALSE;
   }
@@ -693,7 +751,8 @@ InternalIsDirectPureVirtualCall64 (
 
 /**
   Relocates Relocation against the specified Symtab's Symbol Table and
-  LoadAddress.  This logically matches KXLD's x86_64_process_reloc.
+  LoadAddress. This logically matches KXLD's generic_process_reloc (for 32-bit)
+  and x86_64_process_reloc (for 64-bit).
 
   @param[in,out] Context         Prelinking context.
   @param[in]     Kext            KEXT prelinking context.
@@ -714,7 +773,7 @@ InternalIsDirectPureVirtualCall64 (
 **/
 STATIC
 UINTN
-InternalRelocateRelocationIntel64 (
+InternalRelocateRelocation (
   IN PRELINKED_CONTEXT           *Context,
   IN PRELINKED_KEXT              *Kext,
   IN UINT64                      LoadAddress,
@@ -723,25 +782,27 @@ InternalRelocateRelocationIntel64 (
   IN CONST MACH_RELOCATION_INFO  *NextRelocation  OPTIONAL
   )
 {
-  UINTN           ReturnValue;
+  UINTN                     ReturnValue;
 
-  UINT8           Type;
-  INT32           Instruction32;
-  UINT64          Instruction64;
-  UINT64          Target;
-  BOOLEAN         IsPair;
-  UINT64          PairTarget;
-  CONST PRELINKED_VTABLE *Vtable;
-  UINT64          LinkPc;
-  UINT64          Adjustment;
-  UINT32          Length;
-  UINT32          Address;
-  UINT8           *InstructionPtr;
-  UINT32          MaxSize;
-  BOOLEAN         PcRelative;
-  BOOLEAN         IsNormalLocal;
-  BOOLEAN         Result;
-  BOOLEAN         InvalidPcRel;
+  UINT8                     Type;
+  INT32                     Instruction32;
+  UINT64                    Instruction64;
+  UINT64                    Target;
+  BOOLEAN                   IsPair;
+  UINT64                    PairTarget;
+  CONST PRELINKED_VTABLE    *Vtable;
+  UINT64                    LinkPc;
+  UINT64                    Adjustment;
+  UINT32                    Length;
+  UINT32                    Address;
+  UINT8                     *InstructionPtr;
+  UINT32                    MaxSize;
+  BOOLEAN                   PcRelative;
+  BOOLEAN                   IsNormalLocal;
+  BOOLEAN                   Result;
+  BOOLEAN                   InvalidPcRel;
+
+  MACH_SCATTERED_RELOCATION_INFO  *ScatteredRelocation;
 
   ASSERT (Relocation != NULL);
 
@@ -751,8 +812,26 @@ InternalRelocateRelocationIntel64 (
 
   Address    = Relocation->Address;
   Length     = Relocation->Size;
-  Type       = (UINT8)Relocation->Type;
+  Type       = (UINT8) Relocation->Type;
   PcRelative = (Relocation->PcRelative != 0);
+
+  InvalidPcRel        = FALSE;
+  ScatteredRelocation = NULL;
+
+  //
+  // Scattered relocations apply only to 32-bit.
+  //
+  if (Context->Is32Bit) {
+    if (((MACH_SCATTERED_RELOCATION_INFO *) Relocation)->Scattered) {
+      ScatteredRelocation = (MACH_SCATTERED_RELOCATION_INFO *) Relocation;
+
+      Address    = ScatteredRelocation->Address;
+      Length     = ScatteredRelocation->Size;
+      Type       = (UINT8) ScatteredRelocation->Type;
+      PcRelative = (ScatteredRelocation->PcRelative != 0);
+      Target     = LoadAddress;
+    }
+  }
 
   if (Length < 2) {
     return MAX_UINTN;
@@ -774,18 +853,20 @@ InternalRelocateRelocationIntel64 (
   LinkPc = (Address + LoadAddress);
 
   Vtable = NULL;
-  Result = InternalCalculateTargetsIntel64 (
-             Context,
-             Kext,
-             LoadAddress,
-             Relocation,
-             NextRelocation,
-             &Target,
-             &PairTarget,
-             &Vtable
-             );
-  if (!Result) {
-    return MAX_UINTN;
+  if (ScatteredRelocation == NULL) {
+    Result = InternalCalculateTargets (
+              Context,
+              Kext,
+              LoadAddress,
+              Relocation,
+              NextRelocation,
+              &Target,
+              &PairTarget,
+              &Vtable
+              );
+    if (!Result) {
+      return MAX_UINTN;
+    }
   }
 
   // Length == 2
@@ -793,117 +874,133 @@ InternalRelocateRelocationIntel64 (
     CopyMem (&Instruction32, InstructionPtr, sizeof (Instruction32));
 
     if ((Vtable != NULL)
-     && InternalIsDirectPureVirtualCall64 (Vtable, Instruction32)) {
+     && InternalIsDirectPureVirtualCall (Context->Is32Bit, Vtable, Instruction32)) {
       return MAX_UINTN;
     }
-    //
-    // There are a number of different small adjustments for pc-relative
-    // relocation entries.  The general case is to subtract the size of the
-    // relocation (represented by the length parameter), and it applies to
-    // the GOT types and external SIGNED types.  The non-external signed types
-    // have a different adjustment corresponding to the specific type.
-    //
-    switch (Type) {
-      case MachX8664RelocSigned:
-        if (IsNormalLocal) {
-          Adjustment = 0;    
+
+    if (Context->Is32Bit) {
+      if (PcRelative) {
+        Target = Target + Address - (LinkPc + RelocationBase);
+      }
+
+      ASSERT (Type == MachGenericRelocVanilla); // FIXME
+
+      switch (Type) {
+        case MachGenericRelocVanilla:
+          Instruction32 += (UINT32) Target;
+          break;
+      }
+
+    } else {
+      //
+      // There are a number of different small adjustments for pc-relative
+      // relocation entries.  The general case is to subtract the size of the
+      // relocation (represented by the length parameter), and it applies to
+      // the GOT types and external SIGNED types.  The non-external signed types
+      // have a different adjustment corresponding to the specific type.
+      //
+      switch (Type) {
+        case MachX8664RelocSigned:
+          if (IsNormalLocal) {
+            Adjustment = 0;    
+            break;
+          }
+          // Fall through
+        case MachX8664RelocSigned1:
+          if (IsNormalLocal) {
+            Adjustment = 1;
+            break;
+          }
+          // Fall through
+        case MachX8664RelocSigned2:
+          if (IsNormalLocal) {
+            Adjustment = 2;
+            break;
+          }
+          // Fall through
+        case MachX8664RelocSigned4:
+          if (IsNormalLocal) {
+            Adjustment = 4;
+            break;
+          }
+          // Fall through
+        case MachX8664RelocBranch:
+        case MachX8664RelocGot:
+        case MachX8664RelocGotLoad:
+        {
+          Adjustment = LShiftU64 (1, Length);
           break;
         }
-        // Fall through
-      case MachX8664RelocSigned1:
-        if (IsNormalLocal) {
-          Adjustment = 1;
+
+        default:
+        {
           break;
         }
-        // Fall through
-      case MachX8664RelocSigned2:
-        if (IsNormalLocal) {
-          Adjustment = 2;
+      }
+      //
+      // Perform the actual relocation.  All of the 32-bit relocations are 
+      // pc-relative except for SUBTRACTOR, so a good chunk of the logic is
+      // stuck in calculate_displacement_x86_64.  The signed relocations are
+      // a special case, because when they are non-external, the instruction
+      // already contains the pre-relocation displacement, so we only need to
+      // find the difference between how far the PC was relocated, and how
+      // far the target is relocated.  Since the target variable already
+      // contains the difference between the target's base and link
+      // addresses, we add the difference between the PC's base and link
+      // addresses to the adjustment variable.  This will yield the
+      // appropriate displacement in calculate_displacement.
+      //
+      switch (Type) {
+        case MachX8664RelocBranch:
+        {
+          InvalidPcRel = !PcRelative;
+          Adjustment += LinkPc;
           break;
         }
-        // Fall through
-      case MachX8664RelocSigned4:
-        if (IsNormalLocal) {
-          Adjustment = 4;
+
+        case MachX8664RelocSigned:
+        case MachX8664RelocSigned1:
+        case MachX8664RelocSigned2:
+        case MachX8664RelocSigned4:
+        {
+          InvalidPcRel = !PcRelative;
+          Adjustment += (IsNormalLocal ? LoadAddress : LinkPc);
           break;
         }
-        // Fall through
-      case MachX8664RelocBranch:
-      case MachX8664RelocGot:
-      case MachX8664RelocGotLoad:
-      {
-        Adjustment = LShiftU64 (1, Length);
-        break;
+
+        case MachX8664RelocGot:
+        case MachX8664RelocGotLoad:
+        {
+          InvalidPcRel = !PcRelative;
+          Adjustment += LinkPc;
+          Target      = PairTarget;
+          IsPair      = TRUE;
+          break;
+        }
+
+        case MachX8664RelocSubtractor:
+        {
+          InvalidPcRel = PcRelative;
+          Instruction32 = (INT32)(Target - PairTarget);
+          IsPair        = TRUE;
+          break;
+        }
+
+        default:
+        {
+          return MAX_UINTN;
+        }
       }
 
-      default:
-      {
-        break;
-      }
-    }
-    //
-    // Perform the actual relocation.  All of the 32-bit relocations are 
-    // pc-relative except for SUBTRACTOR, so a good chunk of the logic is
-    // stuck in calculate_displacement_x86_64.  The signed relocations are
-    // a special case, because when they are non-external, the instruction
-    // already contains the pre-relocation displacement, so we only need to
-    // find the difference between how far the PC was relocated, and how
-    // far the target is relocated.  Since the target variable already
-    // contains the difference between the target's base and link
-    // addresses, we add the difference between the PC's base and link
-    // addresses to the adjustment variable.  This will yield the
-    // appropriate displacement in calculate_displacement.
-    //
-    switch (Type) {
-      case MachX8664RelocBranch:
-      {
-        InvalidPcRel = !PcRelative;
-        Adjustment += LinkPc;
-        break;
-      }
-
-      case MachX8664RelocSigned:
-      case MachX8664RelocSigned1:
-      case MachX8664RelocSigned2:
-      case MachX8664RelocSigned4:
-      {
-        InvalidPcRel = !PcRelative;
-        Adjustment += (IsNormalLocal ? LoadAddress : LinkPc);
-        break;
-      }
-
-      case MachX8664RelocGot:
-      case MachX8664RelocGotLoad:
-      {
-        InvalidPcRel = !PcRelative;
-        Adjustment += LinkPc;
-        Target      = PairTarget;
-        IsPair      = TRUE;
-        break;
-      }
-
-      case MachX8664RelocSubtractor:
-      {
-        InvalidPcRel = PcRelative;
-        Instruction32 = (INT32)(Target - PairTarget);
-        IsPair        = TRUE;
-        break;
-      }
-
-      default:
-      {
-        return MAX_UINTN;
-      }
-    }
-
-    if (PcRelative) {
-      Result = InternalCalculateDisplacementIntel64 (
-                 Target,
-                 Adjustment,
-                 &Instruction32
-                 );
-      if (!Result) {
-        return MAX_UINTN;
+      if (PcRelative) {
+        Result = InternalCalculateDisplacementIntel64 (
+                  Target,
+                  Adjustment,
+                  &Instruction32
+                  );
+        if (!Result) {
+          return MAX_UINTN;
+        }
       }
     }
 
@@ -912,7 +1009,7 @@ InternalRelocateRelocationIntel64 (
     CopyMem (&Instruction64, InstructionPtr, sizeof (Instruction64));
 
     if ((Vtable != NULL)
-     && InternalIsDirectPureVirtualCall64 (Vtable, Instruction64)) {
+     && InternalIsDirectPureVirtualCall (Context->Is32Bit, Vtable, Instruction64)) {
       return MAX_UINTN;
     }
 
@@ -945,7 +1042,11 @@ InternalRelocateRelocationIntel64 (
     DEBUG ((DEBUG_WARN, "OCAK: Relocation has invalid PC relative flag\n"));
   }
 
-  ReturnValue = (MachoPreserveRelocationIntel64 (Type) ? 1 : 0);
+  if (Context->Is32Bit) {
+    ReturnValue = 0;
+  } else {
+    ReturnValue = (MachoPreserveRelocationIntel64 (Type) ? 1 : 0);
+  }
 
   if (IsPair) {
     ReturnValue |= BIT31;
@@ -974,7 +1075,7 @@ InternalRelocateRelocationIntel64 (
 **/
 STATIC
 BOOLEAN
-InternalRelocateAndCopyRelocations64 (
+InternalRelocateAndCopyRelocations (
   IN  PRELINKED_CONTEXT           *Context,
   IN  PRELINKED_KEXT              *Kext,
   IN  UINT64                      LoadAddress,
@@ -987,13 +1088,64 @@ InternalRelocateAndCopyRelocations64 (
   UINT32                     PreservedRelocations;
 
   UINT32                     Index;
+  UINT32                     SectionIndex;
   CONST MACH_RELOCATION_INFO *NextRelocation;
   UINTN                      Result;
   MACH_RELOCATION_INFO       *Relocation;
+  MACH_SECTION               *Section32;
 
   ASSERT (Kext != NULL);
   ASSERT (NumRelocations != NULL);
   ASSERT (SourceRelocations != NULL || *NumRelocations == 0);
+
+  //
+  // Fallback to section-based relocations if needed for 32-bit.
+  //
+  if (Context->Is32Bit && *NumRelocations == 0) {
+    SectionIndex = 0;
+    while (TRUE) {
+      Section32 = MachoGetSectionByIndex32 (&Kext->Context.MachContext, SectionIndex);
+      if (Section32 == NULL) {
+        break;
+      }
+
+      if (Section32->NumRelocations > 0) {
+        Relocation = (MACH_RELOCATION_INFO *) ((UINTN) MachoGetMachHeader32 (&Kext->Context.MachContext) + Section32->RelocationsOffset);
+        for (Index = 0; Index < Section32->NumRelocations; ++Index) {
+          NextRelocation = &Relocation[Index + 1];
+          //
+          // The last Relocation does not have a successor.
+          //
+          if (Index == (Section32->NumRelocations - 1)) {
+            NextRelocation = NULL;
+          }
+
+          //
+          // Relocate the relocation.
+          //
+          Result = InternalRelocateRelocation (
+                    Context,
+                    Kext,
+                    LoadAddress,
+                    RelocationBase + Section32->Address,
+                    &Relocation[Index],
+                    NextRelocation
+                    );
+          if (Result == MAX_UINTN) {
+            return FALSE;
+          }
+        }
+
+        Section32->NumRelocations     = 0;
+        Section32->RelocationsOffset  = 0;
+      }
+
+      ++SectionIndex;
+    }
+
+    return TRUE;
+  }
+
   ASSERT (TargetRelocations != NULL);
 
   PreservedRelocations = 0;
@@ -1022,7 +1174,7 @@ InternalRelocateAndCopyRelocations64 (
     //
     // Relocate the relocation.
     //
-    Result = InternalRelocateRelocationIntel64 (
+    Result = InternalRelocateRelocation (
                Context,
                Kext,
                LoadAddress,
@@ -1059,7 +1211,7 @@ InternalRelocateAndCopyRelocations64 (
     }
     //
     // Skip the next Relocation as instructed by
-    // InternalRelocateRelocationIntel64().
+    // InternalRelocateRelocation().
     //
     if ((Result & BIT31) != 0) {
       ++Index;
@@ -1077,6 +1229,50 @@ InternalRelocateAndCopyRelocations64 (
 
 STATIC
 BOOLEAN
+InternalRelocateSymbol (
+  IN     OC_MACHO_CONTEXT  *MachoContext,
+  IN     UINT64            LoadAddress,
+  IN OUT MACH_NLIST_ANY    *Symbol,
+  IN OUT UINT32            *KmodInfoOffset
+  )
+{
+  BOOLEAN         Result;
+  CONST CHAR8     *SymbolName;
+  UINT32          KmodOffset;
+  UINT32          MaxSize;
+
+  KmodOffset = *KmodInfoOffset;
+
+  if ((KmodOffset == 0) && (((MachoContext->Is32Bit ? Symbol->Symbol32.Type : Symbol->Symbol64.Type) & MACH_N_TYPE_STAB) == 0)) {
+    SymbolName = MachoGetSymbolName (MachoContext, Symbol);
+    ASSERT (SymbolName != NULL);
+
+    if (AsciiStrCmp (SymbolName, "_kmod_info") == 0) {
+      Result = MachoSymbolGetFileOffset (
+                MachoContext,
+                Symbol,
+                &KmodOffset,
+                &MaxSize
+                );
+      if (!Result
+      || (MaxSize < (MachoContext->Is32Bit ? sizeof (KMOD_INFO_32_V1) : sizeof (KMOD_INFO_64_V1))
+      || (KmodOffset % 4) != 0)) { //FIXME ?
+        return FALSE;
+      }
+
+      *KmodInfoOffset = KmodOffset;
+    }
+  }
+
+  return MachoRelocateSymbol (
+          MachoContext,
+          LoadAddress,
+          Symbol
+          );
+}
+
+STATIC
+BOOLEAN
 InternalRelocateSymbols (
   IN     OC_MACHO_CONTEXT  *MachoContext,
   IN     UINT64            LoadAddress,
@@ -1085,48 +1281,59 @@ InternalRelocateSymbols (
   OUT    UINT32            *KmodInfoOffset
   )
 {
+  BOOLEAN         Result;
   UINT32          Index;
   MACH_NLIST_ANY  *Symbol;
-  CONST CHAR8     *SymbolName;
-  BOOLEAN         Result;
-  UINT32          KmodOffset;
-  UINT32          MaxSize;
+  UINT8           SymbolType;
 
   ASSERT (MachoContext != NULL);
   ASSERT (Symbols != NULL || NumSymbols == 0);
   ASSERT (KmodInfoOffset != NULL);
 
-  KmodOffset = *KmodInfoOffset;
+  //
+  // Fallback to standard symbol lookup if needed for 32-bit.
+  //
+  if (MachoContext->Is32Bit && NumSymbols == 0) {
+    Index = 0;
+    while (TRUE) {
+      Symbol = MachoGetSymbolByIndex (MachoContext, Index);
+      if (Symbol == NULL) {
+        break;
+      }
 
-  for (Index = 0; Index < NumSymbols; ++Index) {
-    Symbol = &Symbols[Index];
+      SymbolType = Symbol->Symbol32.Type & MACH_N_TYPE_TYPE;
+      if (SymbolType == MACH_N_TYPE_SECT || SymbolType == MACH_N_TYPE_EXT) {
+        Result = InternalRelocateSymbol (
+                  MachoContext,
+                  LoadAddress,
+                  Symbol,
+                  KmodInfoOffset
+                  );
 
-    if ((KmodOffset == 0) && (((MachoContext->Is32Bit ? Symbol->Symbol32.Type : Symbol->Symbol64.Type) & MACH_N_TYPE_STAB) == 0)) {
-      SymbolName = MachoGetSymbolName (MachoContext, Symbol);
-      ASSERT (SymbolName != NULL);
-
-      if (AsciiStrCmp (SymbolName, "_kmod_info") == 0) {
-        Result = MachoSymbolGetFileOffset (
-                   MachoContext,
-                   Symbol,
-                   &KmodOffset,
-                   &MaxSize
-                   );
-        if (!Result
-         || (MaxSize < (MachoContext->Is32Bit ? sizeof (KMOD_INFO_32_V1) : sizeof (KMOD_INFO_64_V1))
-         || (KmodOffset % 4) != 0)) { //FIXME ?
+        if (!Result) {
           return FALSE;
         }
-
-        *KmodInfoOffset = KmodOffset;
       }
+
+      ++Index;
     }
 
-    Result = MachoRelocateSymbol (
-               MachoContext,
-               LoadAddress,
-               Symbol
-               );
+    return TRUE;
+  }
+
+  for (Index = 0; Index < NumSymbols; ++Index) {
+    if (MachoContext->Is32Bit) {
+      Symbol = (MACH_NLIST_ANY *)&(&Symbols->Symbol32)[Index];
+    } else {
+      Symbol = (MACH_NLIST_ANY *)&(&Symbols->Symbol64)[Index];
+    }
+    Result = InternalRelocateSymbol (
+              MachoContext,
+              LoadAddress,
+              Symbol,
+              KmodInfoOffset
+              );
+
     if (!Result) {
       return FALSE;
     }
@@ -1251,6 +1458,7 @@ InternalProcessSymbolPointers (
   @param[in,out] Context      Prelinking context.
   @param[in]     Kext         KEXT prelinking context.
   @param[in]     LoadAddress  The address this KEXT shall be linked against.
+  @param[in]     FileOffset   The file offset of the first segment.
 
   @retval  Returned is whether the prelinking process has been successful.
            The state of the KEXT is undefined in case this routine fails.
@@ -1260,7 +1468,8 @@ EFI_STATUS
 InternalPrelinkKext (
   IN OUT PRELINKED_CONTEXT  *Context,
   IN     PRELINKED_KEXT     *Kext,
-  IN     UINT64             LoadAddress
+  IN     UINT64             LoadAddress,
+  IN     UINT64             FileOffset
   )
 {
   OC_MACHO_CONTEXT           *MachoContext;
@@ -1269,6 +1478,7 @@ InternalPrelinkKext (
   UINT64                     LinkEditFileSize;
 
   MACH_HEADER_ANY            *MachHeader;
+  UINT32                     MachSize;
 
   MACH_SEGMENT_COMMAND_ANY   *Segment;
   MACH_SECTION_ANY           *Section;
@@ -1293,6 +1503,7 @@ InternalPrelinkKext (
   UINT32                     NumExternalSymbols;
   CONST MACH_NLIST_ANY       *UndefinedSymtab;
   UINT32                     NumUndefinedSymbols;
+  UINT32                     NumUndefinedSymbolsActual;
   UINT64                     WeakTestValue;
 
   UINT32                     NumRelocations;
@@ -1312,6 +1523,7 @@ InternalPrelinkKext (
 
   UINT32                     SegmentOffset;
   UINT32                     SegmentSize;
+  UINT64                     LoadAddressOffset;
 
   UINT64                     SegmentVmSizes;
   UINT32                     KmodInfoOffset;
@@ -1321,20 +1533,36 @@ InternalPrelinkKext (
   ASSERT (Kext != NULL);
   ASSERT (LoadAddress != 0);
 
+  //
+  // ASSUMPTIONS:
+  // If kext is 64-bit, it has a __LINKEDIT segment and DYSYMTAB.
+  // If kext is 32-bit, it can optionally have a __LINKEDIT segment and DYSYMTAB.
+  //
+
   MachoContext    = &Kext->Context.MachContext;
   LinkEditSegment = Kext->LinkEditSegment;
 
   MachHeader = MachoGetMachHeader (MachoContext);
+  MachSize   = MachoGetFileSize (MachoContext);
+
   //
   // Only perform actions when the kext is flag'd to be dynamically linked.
   //
-  if (((Context->Is32Bit ? MachHeader->Header32.Flags : MachHeader->Header64.Flags) & MACH_HEADER_FLAG_DYNAMIC_LINKER_LINK) == 0) {
+  if (!Context->Is32Bit && (MachHeader->Header64.Flags & MACH_HEADER_FLAG_DYNAMIC_LINKER_LINK) == 0) {
     return EFI_SUCCESS;
   }
 
-  if (LinkEditSegment == NULL || Kext->Context.VirtualKmod == 0) {
+  if ((!Context->Is32Bit && LinkEditSegment == NULL) || Kext->Context.VirtualKmod == 0) {
     return EFI_UNSUPPORTED;
   }
+
+  if (OcOverflowAddU64 (LoadAddress, FileOffset, &LoadAddressOffset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+  if (Context->Is32Bit) {
+    ASSERT (LoadAddressOffset < MAX_UINT32);
+  }
+
   //
   // Retrieve the symbol tables required for most following operations.
   //
@@ -1357,7 +1585,10 @@ InternalPrelinkKext (
   ASSERT (Symtab != NULL);
 
   DySymtab = MachoContext->DySymtab;
-  ASSERT (DySymtab != NULL);
+  if (!Context->Is32Bit) {
+    ASSERT (DySymtab != NULL);
+  }
+
   //
   // Prepare constructing a new __LINKEDIT section to...
   //   1. strip undefined symbols for they are not allowed in prelinked
@@ -1374,33 +1605,39 @@ InternalPrelinkKext (
   // Example prelinked layout
   //   Symbol Table - relocations (external -> local) - String Table
   //
-  SymbolTableSize = (NumSymbols * sizeof (MACH_NLIST_64));
+  SymbolTableSize = (NumSymbols * (Context->Is32Bit ? sizeof (MACH_NLIST) : sizeof (MACH_NLIST_64)));
   StringTableSize = Symtab->StringsSize;
+
   //
   // For the allocation, assume all relocations will be preserved to simplify
   // the code, the memory is only temporarily allocated anyway.
   //
-  NumRelocations  = DySymtab->NumOfLocalRelocations;
-  NumRelocations += DySymtab->NumExternalRelocations;
+  if (DySymtab != NULL) {
+    NumRelocations  = DySymtab->NumOfLocalRelocations;
+    NumRelocations += DySymtab->NumExternalRelocations;
+  } else {
+    NumRelocations  = 0;
+  }
   RelocationsSize = (NumRelocations * sizeof (MACH_RELOCATION_INFO));
 
-  LinkEdit     = Context->LinkBuffer;
-  LinkEditSize = (SymbolTableSize + RelocationsSize + StringTableSize);
+  LinkEdit        = Context->LinkBuffer;
+  LinkEditSize    = (SymbolTableSize + RelocationsSize + StringTableSize);
 
-  if (LinkEditSize > (Context->Is32Bit ?
-    LinkEditSegment->Segment32.FileSize : LinkEditSegment->Segment64.FileSize)) {
+  if (LinkEditSegment != NULL
+    && LinkEditSize > (Context->Is32Bit ? LinkEditSegment->Segment32.FileSize : LinkEditSegment->Segment64.FileSize)) {
     return EFI_UNSUPPORTED;
   }
 
-  SymbolTableSize -= (NumUndefinedSymbols * sizeof (MACH_NLIST_64));
+  SymbolTableSize  -= (NumUndefinedSymbols * (Context->Is32Bit ? sizeof (MACH_NLIST) : sizeof (MACH_NLIST_64)));
 
   SymbolTableOffset = 0;
   RelocationsOffset = (SymbolTableOffset + SymbolTableSize);
+
   //
   // Solve indirect symbols.
   //
   WeakTestValue      = 0;
-  NumIndirectSymbols = MachoGetIndirectSymbolTable (
+  NumIndirectSymbols = MachoGetIndirectSymbolTable ( // FIXME
                          MachoContext,
                          &IndirectSymtab
                          );
@@ -1424,11 +1661,24 @@ InternalPrelinkKext (
       return EFI_LOAD_ERROR;
     }
   }
+
   //
-  // Solve undefined symbols.
+  // Solve undefined symbols. If on 32-bit, we may not have a DYSYMTAB so fallback to checking all symbols.
   //
-  for (Index = 0; Index < NumUndefinedSymbols; ++Index) {
-    Symbol = (MACH_NLIST_ANY *) &UndefinedSymtab[Index];
+  NumUndefinedSymbolsActual = NumUndefinedSymbols;
+  if (NumUndefinedSymbols == 0 && Context->Is32Bit) {
+    NumUndefinedSymbolsActual = NumSymbols;
+  }
+  for (Index = 0; Index < NumUndefinedSymbolsActual; ++Index) {
+    if (Context->Is32Bit) {
+      Symbol = (MACH_NLIST_ANY *) (NumUndefinedSymbols == 0 ? &(&SymbolTable->Symbol32)[Index] : &(&UndefinedSymtab->Symbol32)[Index]);
+      if ((Symbol->Symbol32.Type & MACH_N_TYPE_TYPE) != MACH_N_TYPE_UNDF) {
+        continue;
+      }
+    } else {
+      Symbol = (MACH_NLIST_ANY *) &(&UndefinedSymtab->Symbol64)[Index];
+    }
+
     //
     // Undefined symbols are solved via their name.
     //
@@ -1468,44 +1718,48 @@ InternalPrelinkKext (
     DEBUG ((DEBUG_INFO, "OCAK: Vtable patching failed for kext %a\n", Kext->Identifier));
     return EFI_LOAD_ERROR;
   }
+
   //
   // Relocate local and external symbols.
+  // We only need to call InternalRelocateSymbols once if there is no DYSYMTAB.
   //
   KmodInfoOffset = 0;
-
-  Result = InternalRelocateSymbols (
-             MachoContext,
-             LoadAddress,
-             NumLocalSymbols,
-             (MACH_NLIST_ANY *)LocalSymtab,
-             &KmodInfoOffset
-             );
-  if (!Result) {
-    return EFI_LOAD_ERROR;
+  if (DySymtab != NULL) {
+      Result = InternalRelocateSymbols (
+              MachoContext,
+              LoadAddressOffset,
+              NumLocalSymbols,
+              (MACH_NLIST_ANY *) LocalSymtab,
+              &KmodInfoOffset
+              );
+    if (!Result) {
+      return EFI_LOAD_ERROR;
+    }
   }
 
   Result = InternalRelocateSymbols (
              MachoContext,
-             LoadAddress,
+             LoadAddressOffset,
              NumExternalSymbols,
-             (MACH_NLIST_ANY *)ExternalSymtab,
+             (MACH_NLIST_ANY *) ExternalSymtab,
              &KmodInfoOffset
              );
   if (!Result || (KmodInfoOffset == 0)) {
     return EFI_LOAD_ERROR;
   }
 
-  KmodInfo = (KMOD_INFO_ANY *)((UINTN)MachHeader + (UINTN)KmodInfoOffset);
+  KmodInfo     = (KMOD_INFO_ANY *)((UINTN) MachHeader + (UINTN)KmodInfoOffset);
 
   FirstSegment = MachoGetNextSegment (MachoContext, NULL);
   if (FirstSegment == NULL) {
     return EFI_UNSUPPORTED;
   }
-  
-  Result = InternalProcessSymbolPointers (MachoContext, DySymtab, LoadAddress);
+
+  Result = InternalProcessSymbolPointers (MachoContext, DySymtab, LoadAddressOffset);
   if (!Result) {
     return EFI_LOAD_ERROR;
   }
+
   //
   // Copy the relocations to be reserved and adapt the symbol number they
   // reference in case it has been relocated above.
@@ -1513,15 +1767,16 @@ InternalPrelinkKext (
   TargetRelocation = (MACH_RELOCATION_INFO *)(
                        (UINTN)LinkEdit + RelocationsOffset
                        );
+
   //
   // Relocate and copy local and external relocations.
   //
   Relocations    = MachoContext->LocalRelocations;
-  NumRelocations = DySymtab->NumOfLocalRelocations;
-  Result = InternalRelocateAndCopyRelocations64 (
+  NumRelocations = DySymtab != NULL ? DySymtab->NumOfLocalRelocations : 0;
+  Result = InternalRelocateAndCopyRelocations (
              Context,
              Kext,
-             LoadAddress,
+             LoadAddressOffset,
              Context->Is32Bit ? FirstSegment->Segment32.VirtualAddress : FirstSegment->Segment64.VirtualAddress,
              Relocations,
              &NumRelocations,
@@ -1531,117 +1786,143 @@ InternalPrelinkKext (
     return EFI_LOAD_ERROR;
   }
 
-  Relocations     = MachoContext->ExternRelocations;
-  NumRelocations2 = DySymtab->NumExternalRelocations;
-  Result = InternalRelocateAndCopyRelocations64 (
-             Context,
-             Kext,
-             LoadAddress,
-             Context->Is32Bit ? FirstSegment->Segment32.VirtualAddress : FirstSegment->Segment64.VirtualAddress,
-             Relocations,
-             &NumRelocations2,
-             &TargetRelocation[NumRelocations]
-             );
-  if (!Result) {
-    return EFI_LOAD_ERROR;
-  }
-  NumRelocations += NumRelocations2;
-  RelocationsSize = (NumRelocations * sizeof (MACH_RELOCATION_INFO));
   //
-  // Copy the entire symbol table excluding the area for undefined symbols.
+  // If there is no DYSYMTAB, the call to InternalRelocateAndCopyRelocations
+  // above takes care of all relocations.
   //
-  SymtabSize = SymbolTableSize;
-  if (NumUndefinedSymbols > 0) {
-    SymtabSize = (UINT32)((UndefinedSymtab - SymbolTable) * (Context->Is32Bit ? sizeof (MACH_NLIST) : sizeof (MACH_NLIST_64)));
+  if (DySymtab != NULL) {
+    Relocations     = MachoContext->ExternRelocations;
+    NumRelocations2 = DySymtab->NumExternalRelocations;
+    Result = InternalRelocateAndCopyRelocations (
+              Context,
+              Kext,
+              LoadAddressOffset,
+              Context->Is32Bit ?
+                FirstSegment->Segment32.VirtualAddress : FirstSegment->Segment64.VirtualAddress,
+              Relocations,
+              &NumRelocations2,
+              &TargetRelocation[NumRelocations]
+              );
+    if (!Result) {
+      return EFI_LOAD_ERROR;
+    }
+    NumRelocations += NumRelocations2;
+    RelocationsSize = (NumRelocations * sizeof (MACH_RELOCATION_INFO));
   }
 
-  CopyMem (
-    (VOID *)((UINTN)LinkEdit + SymbolTableOffset),
-    SymbolTable,
-    SymtabSize
-    );
+  if (LinkEditSegment != NULL) {
+    //
+    // Copy the entire symbol table excluding the area for undefined symbols.
+    //
+    SymtabSize = SymbolTableSize;
+    if (NumUndefinedSymbols > 0) {
+      SymtabSize = (UINT32)((UndefinedSymtab - SymbolTable) * (Context->Is32Bit ? sizeof (MACH_NLIST) : sizeof (MACH_NLIST_64)));
+    }
 
-  if (NumUndefinedSymbols > 0) {
-    SymtabSize2  = (UINT32)(&SymbolTable[NumSymbols] - &UndefinedSymtab[NumUndefinedSymbols]);
-    SymtabSize2 *= Context->Is32Bit ? sizeof (MACH_NLIST) : sizeof (MACH_NLIST_64);
     CopyMem (
-      (VOID *)((UINTN)LinkEdit + SymbolTableOffset + SymtabSize),
-      (VOID *)&UndefinedSymtab[NumUndefinedSymbols],
-      SymtabSize2
+      (VOID *)((UINTN)LinkEdit + SymbolTableOffset),
+      SymbolTable,
+      SymtabSize
       );
 
-    NumSymbols -= NumUndefinedSymbols;
+    if (NumUndefinedSymbols > 0) {
+      if (Context->Is32Bit) {
+        SymtabSize2  = (UINT32)(&(&SymbolTable->Symbol32)[NumSymbols] - &(&UndefinedSymtab->Symbol32)[NumUndefinedSymbols]);
+        SymtabSize2 *= sizeof (MACH_NLIST);
+
+        CopyMem (
+          (VOID *)((UINTN)LinkEdit + SymbolTableOffset + SymtabSize),
+          (VOID *)&(&UndefinedSymtab->Symbol32)[NumUndefinedSymbols],
+          SymtabSize2
+          );
+      } else {
+        SymtabSize2  = (UINT32)(&(&SymbolTable->Symbol64)[NumSymbols] - &(&UndefinedSymtab->Symbol64)[NumUndefinedSymbols]);
+        SymtabSize2 *= sizeof (MACH_NLIST_64);
+
+        CopyMem (
+          (VOID *)((UINTN)LinkEdit + SymbolTableOffset + SymtabSize),
+          (VOID *)&(&UndefinedSymtab->Symbol64)[NumUndefinedSymbols],
+          SymtabSize2
+          );
+      }
+
+      NumSymbols -= NumUndefinedSymbols;
+    }
+
+    //
+    // Copy the String Table.  Don't strip it for the saved bytes are unlikely
+    // worth the time required.
+    //
+    StringTableOffset = (RelocationsOffset + RelocationsSize);
+    CopyMem (
+      (VOID *)((UINTN)LinkEdit + StringTableOffset),
+      StringTable,
+      StringTableSize
+      );
+    //
+    // Set up the tables with the new offsets and Symbol Table length.
+    //
+    if (Context->Is32Bit) {
+      LinkEditFileOffset = LinkEditSegment->Segment32.FileOffset;
+      LinkEditFileSize   = LinkEditSegment->Segment32.FileSize;
+    } else {
+      LinkEditFileOffset = LinkEditSegment->Segment64.FileOffset;
+      LinkEditFileSize   = LinkEditSegment->Segment64.FileSize;
+    }
+    
+    Symtab->SymbolsOffset = (UINT32)(LinkEditFileOffset + SymbolTableOffset);
+    Symtab->NumSymbols    = NumSymbols;
+    Symtab->StringsOffset = (UINT32)(LinkEditFileOffset + StringTableOffset);
+
+    //
+    // Copy the new __LINKEDIT segment into the binary and fix its Load Command.
+    //
+    LinkEditSize = (SymbolTableSize + RelocationsSize + StringTableSize);
+
+    CopyMem (
+      (VOID *)((UINTN)MachHeader + (UINTN)LinkEditFileOffset),
+      LinkEdit,
+      LinkEditSize
+      );
+    ZeroMem (
+      (VOID *)((UINTN)MachHeader + (UINTN)LinkEditFileOffset + LinkEditSize),
+      (UINTN)(LinkEditFileSize - LinkEditSize)
+      );
+
+    LinkEditSize = MACHO_ALIGN (LinkEditSize);
+    if (Context->Is32Bit) {
+      LinkEditSegment->Segment32.FileSize = LinkEditSize;
+      LinkEditSegment->Segment32.Size     = LinkEditSize;
+    } else {
+      LinkEditSegment->Segment64.FileSize = LinkEditSize;
+      LinkEditSegment->Segment64.Size     = LinkEditSize;
+    }
   }
-  //
-  // Copy the String Table.  Don't strip it for the saved bytes are unlikely
-  // worth the time required.
-  //
-  StringTableOffset = (RelocationsOffset + RelocationsSize);
-  CopyMem (
-    (VOID *)((UINTN)LinkEdit + StringTableOffset),
-    StringTable,
-    StringTableSize
-    );
-  //
-  // Set up the tables with the new offsets and Symbol Table length.
-  //
-  if (Context->Is32Bit) {
-    LinkEditFileOffset = LinkEditSegment->Segment32.FileOffset;
-    LinkEditFileSize   = LinkEditSegment->Segment32.FileSize;
-  } else {
-    LinkEditFileOffset = LinkEditSegment->Segment64.FileOffset;
-    LinkEditFileSize   = LinkEditSegment->Segment64.FileSize;
-  }
-  
-  Symtab->SymbolsOffset = (UINT32)(LinkEditFileOffset + SymbolTableOffset);
-  Symtab->NumSymbols    = NumSymbols;
-  Symtab->StringsOffset = (UINT32)(LinkEditFileOffset + StringTableOffset);
 
-  DySymtab->LocalRelocationsOffset = (UINT32)(LinkEditFileOffset + RelocationsOffset);
-  DySymtab->NumOfLocalRelocations  = NumRelocations;
-  //
-  // Clear dynamic linker information.
-  //
-  DySymtab->LocalSymbolsIndex         = 0;
-  DySymtab->NumLocalSymbols           = 0;
-  DySymtab->NumExternalSymbols        = 0;
-  DySymtab->ExternalSymbolsIndex      = 0;
-  DySymtab->NumExternalRelocations    = 0;
-  DySymtab->ExternalRelocationsOffset = 0;
-  DySymtab->UndefinedSymbolsIndex     = 0;
-  DySymtab->NumUndefinedSymbols       = 0;
-  DySymtab->IndirectSymbolsOffset     = 0;
-  DySymtab->NumIndirectSymbols        = 0;
-  //
-  // Copy the new __LINKEDIT segment into the binary and fix its Load Command.
-  //
-  LinkEditSize = (SymbolTableSize + RelocationsSize + StringTableSize);
+  if (DySymtab != NULL) {
+    DySymtab->LocalRelocationsOffset = (UINT32)(LinkEditFileOffset + RelocationsOffset);
+    DySymtab->NumOfLocalRelocations  = NumRelocations;
 
-  CopyMem (
-    (VOID *)((UINTN)MachHeader + (UINTN)LinkEditFileOffset),
-    LinkEdit,
-    LinkEditSize
-    );
-  ZeroMem (
-    (VOID *)((UINTN)MachHeader + (UINTN)LinkEditFileOffset + LinkEditSize),
-    (UINTN)(LinkEditFileSize - LinkEditSize)
-    );
-
-  LinkEditSize = MACHO_ALIGN (LinkEditSize);
-  if (Context->Is32Bit) {
-    LinkEditSegment->Segment32.FileSize = LinkEditSize;
-    LinkEditSegment->Segment32.Size     = LinkEditSize;
-  } else {
-    LinkEditSegment->Segment64.FileSize = LinkEditSize;
-    LinkEditSegment->Segment64.Size     = LinkEditSize;
+    //
+    // Clear dynamic linker information.
+    //
+    DySymtab->LocalSymbolsIndex         = 0;
+    DySymtab->NumLocalSymbols           = 0;
+    DySymtab->NumExternalSymbols        = 0;
+    DySymtab->ExternalSymbolsIndex      = 0;
+    DySymtab->NumExternalRelocations    = 0;
+    DySymtab->ExternalRelocationsOffset = 0;
+    DySymtab->UndefinedSymbolsIndex     = 0;
+    DySymtab->NumUndefinedSymbols       = 0;
+    DySymtab->IndirectSymbolsOffset     = 0;
+    DySymtab->NumIndirectSymbols        = 0;
   }
 
   //
   // Adapt the link addresses of all Segments and their Sections.
   //
-  SegmentOffset = 0;
-  SegmentSize   = 0;
-
+  SegmentOffset  = 0;
+  SegmentSize    = 0;
   SegmentVmSizes = 0;
 
   Segment = NULL;
@@ -1650,25 +1931,30 @@ InternalPrelinkKext (
     while ((Section = MachoGetNextSection (MachoContext, Segment, Section)) != NULL) {
       if (Context->Is32Bit) {
         Section->Section32.Address = ALIGN_VALUE (
-                                      (Section->Section32.Address + LoadAddress),
-                                      (UINT64)(1U << Section->Section32.Alignment)
+                                      (Section->Section32.Address + LoadAddressOffset),
+                                      (UINT32)(1U << Section->Section32.Alignment)
                                       );
       } else {
         Section->Section64.Address = ALIGN_VALUE (
-                                      (Section->Section64.Address + LoadAddress),
+                                      (Section->Section64.Address + LoadAddressOffset),
                                       (UINT64)(1U << Section->Section64.Alignment)
                                       );
       }
     }
 
     if (Context->Is32Bit) {
-      Segment->Segment32.VirtualAddress += (UINT32) LoadAddress;
+      Segment->Segment32.VirtualAddress += (UINT32) LoadAddressOffset;
 
       //
       // Logically equivalent to kxld_seg_set_vm_protections.
       // Assertion: Not i386 (strict protection).
       //
-      if (AsciiStrnCmp (Segment->Segment32.SegmentName, "__TEXT", ARRAY_SIZE (Segment->Segment32.SegmentName)) == 0) {
+      // MH_OBJECT has only one unnamed segment, so all protections need to be enabled.
+      //
+      if (AsciiStrnCmp (Segment->Segment32.SegmentName, "", ARRAY_SIZE (Segment->Segment32.SegmentName)) == 0) {
+        Segment->Segment32.InitialProtection = TEXT_SEG_PROT | DATA_SEG_PROT;
+        Segment->Segment32.MaximumProtection = TEXT_SEG_PROT | DATA_SEG_PROT;
+      } else if (AsciiStrnCmp (Segment->Segment32.SegmentName, "__TEXT", ARRAY_SIZE (Segment->Segment32.SegmentName)) == 0) {
         Segment->Segment32.InitialProtection = TEXT_SEG_PROT;
         Segment->Segment32.MaximumProtection = TEXT_SEG_PROT;
       } else {
@@ -1683,7 +1969,7 @@ InternalPrelinkKext (
 
       SegmentVmSizes += Segment->Segment32.Size;
     } else {
-      Segment->Segment64.VirtualAddress += LoadAddress;
+      Segment->Segment64.VirtualAddress += LoadAddressOffset;
 
       //
       // Logically equivalent to kxld_seg_set_vm_protections.
@@ -1750,7 +2036,8 @@ InternalPrelinkKext (
   // Reinitialize the Mach-O context to account for the changed __LINKEDIT
   // segment and file size.
   //
-  if (!MachoInitializeContext64 (MachoContext, MachHeader, (SegmentOffset + SegmentSize), MachoContext->ContainerOffset)) {
+  //FIXME : Symbols are not in a segment in MH_OBJECT.
+  if (!MachoInitializeContext (MachoContext, MachHeader, MachSize /*(SegmentOffset + SegmentSize)*/, MachoContext->ContainerOffset, Context->Is32Bit)) { 
     //
     // This should never failed under normal and abnormal conditions.
     //

--- a/Library/OcAppleKernelLib/Link.c
+++ b/Library/OcAppleKernelLib/Link.c
@@ -1935,7 +1935,7 @@ InternalPrelinkKext (
     while ((Section = MachoGetNextSection (MachoContext, Segment, Section)) != NULL) {
       if (Context->Is32Bit) {
         Section->Section32.Address = ALIGN_VALUE (
-                                      (Section->Section32.Address + LoadAddressOffset),
+                                      (Section->Section32.Address + (UINT32) LoadAddressOffset),
                                       (UINT32)(1U << Section->Section32.Alignment)
                                       );
       } else {

--- a/Library/OcAppleKernelLib/Link.c
+++ b/Library/OcAppleKernelLib/Link.c
@@ -885,12 +885,14 @@ InternalRelocateRelocation (
         Target = Target + Address - (LinkPc + RelocationBase);
       }
 
-      ASSERT (Type == MachGenericRelocVanilla); // FIXME
-
       switch (Type) {
         case MachGenericRelocVanilla:
           Instruction32 += (UINT32) Target;
           break;
+
+        default:
+          DEBUG ((DEBUG_ERROR, "OCAK: Non-vanilla 32-bit relocations are unsupported\n")); //FIXME: Implement paired relocs.
+          return MAX_UINTN;
       }
 
     } else {

--- a/Library/OcAppleKernelLib/Link.c
+++ b/Library/OcAppleKernelLib/Link.c
@@ -2061,8 +2061,8 @@ InternalPrelinkKext (
     // XNU makes it read only, and this prevents __TEXT from gaining executable permission.
     // See OSKext::setVMAttributes.
     //
-    KmodInfo->Kmod32.HdrSize = IsObject32 ? FileOffset : 0;
-    KmodInfo->Kmod32.Size    = IsObject32 ? MachSize : KmodInfo->Kmod32.HdrSize + SegmentVmSizes;
+    KmodInfo->Kmod32.HdrSize = IsObject32 ? (UINT32) FileOffset : 0;
+    KmodInfo->Kmod32.Size    = IsObject32 ? MachSize : KmodInfo->Kmod32.HdrSize + (UINT32) SegmentVmSizes;
     //
     // Adapt the Mach-O header to signal being prelinked.
     //

--- a/Library/OcAppleKernelLib/PrelinkedContext.c
+++ b/Library/OcAppleKernelLib/PrelinkedContext.c
@@ -794,11 +794,11 @@ PrelinkedInjectComplete (
 #endif
 
   if (Context->Is32Bit) {
-    Context->PrelinkedInfoSegment->Segment32.VirtualAddress = Context->PrelinkedLastAddress;
+    Context->PrelinkedInfoSegment->Segment32.VirtualAddress = (UINT32) Context->PrelinkedLastAddress;
     Context->PrelinkedInfoSegment->Segment32.Size           = MACHO_ALIGN (ExportedInfoSize);
     Context->PrelinkedInfoSegment->Segment32.FileOffset     = Context->PrelinkedSize;
     Context->PrelinkedInfoSegment->Segment32.FileSize       = MACHO_ALIGN (ExportedInfoSize);
-    Context->PrelinkedInfoSection->Section32.Address        = Context->PrelinkedLastAddress;
+    Context->PrelinkedInfoSection->Section32.Address        = (UINT32) Context->PrelinkedLastAddress;
     Context->PrelinkedInfoSection->Section32.Size           = MACHO_ALIGN (ExportedInfoSize);
     Context->PrelinkedInfoSection->Section32.Offset         = Context->PrelinkedSize;
   } else {

--- a/Library/OcAppleKernelLib/PrelinkedContext.c
+++ b/Library/OcAppleKernelLib/PrelinkedContext.c
@@ -98,23 +98,23 @@ PrelinkedFindLastLoadAddress (
 STATIC
 EFI_STATUS
 PrelinkedGetSegmentsFromMacho (
-  IN   OC_MACHO_CONTEXT         *MachoContext,
-  OUT  MACH_SEGMENT_COMMAND_64  **PrelinkedInfoSegment,
-  OUT  MACH_SECTION_64          **PrelinkedInfoSection
+  IN   OC_MACHO_CONTEXT           *MachoContext,
+  OUT  MACH_SEGMENT_COMMAND_ANY   **PrelinkedInfoSegment,
+  OUT  MACH_SECTION_ANY           **PrelinkedInfoSection
   )
 {
-  *PrelinkedInfoSegment = MachoGetSegmentByName64 (
+  *PrelinkedInfoSegment = MachoGetSegmentByName (
     MachoContext,
     PRELINK_INFO_SEGMENT
     );
   if (*PrelinkedInfoSegment == NULL) {
     return EFI_NOT_FOUND;
   }
-  if ((*PrelinkedInfoSegment)->FileOffset > MAX_UINT32) {
+  if ((MachoContext->Is32Bit ? (*PrelinkedInfoSegment)->Segment32.FileOffset : (*PrelinkedInfoSegment)->Segment64.FileOffset) > MAX_UINT32) {
     return EFI_UNSUPPORTED;
   }
 
-  *PrelinkedInfoSection = MachoGetSectionByName64 (
+  *PrelinkedInfoSection = MachoGetSectionByName (
     MachoContext,
     *PrelinkedInfoSegment,
     PRELINK_INFO_SECTION
@@ -122,7 +122,7 @@ PrelinkedGetSegmentsFromMacho (
   if (*PrelinkedInfoSection == NULL) {
     return EFI_NOT_FOUND;
   }
-  if ((*PrelinkedInfoSection)->Size > MAX_UINT32) {
+  if ((MachoContext->Is32Bit ? (*PrelinkedInfoSection)->Section32.Size : (*PrelinkedInfoSection)->Section64.Size) > MAX_UINT32) {
     return EFI_UNSUPPORTED;
   }
 
@@ -138,15 +138,16 @@ InternalConnectExternalSymtab (
      OUT BOOLEAN           *KernelCollection  OPTIONAL
   )
 {
-  MACH_HEADER_64           *Header;
+  MACH_HEADER_ANY          *Header;
   MACH_SEGMENT_COMMAND_64  *Segment;
   BOOLEAN                  IsKernelCollection;
 
   //
   // Detect kernel type.
   //
-  Header             = MachoGetMachHeader64 (Context);
-  IsKernelCollection = Header->FileType == MachHeaderFileTypeFileSet;
+  Header             = MachoGetMachHeader (Context);
+  IsKernelCollection = (Context->Is32Bit ?
+    Header->Header32.FileType : Header->Header64.FileType) == MachHeaderFileTypeFileSet;
 
   if (KernelCollection != NULL) {
     *KernelCollection = IsKernelCollection;
@@ -241,9 +242,10 @@ PrelinkedContextInit (
   //
   // Initialise primary context.
   //
-  if (!MachoInitializeContext64 (&Context->PrelinkedMachContext, Prelinked, PrelinkedSize, 0)) {
+  if (!MachoInitializeContext32 (&Context->PrelinkedMachContext, Prelinked, PrelinkedSize, 0)) {
     return EFI_INVALID_PARAMETER;
   }
+  Context->Is32Bit = TRUE;
 
   Status = InternalConnectExternalSymtab (
     &Context->PrelinkedMachContext,
@@ -268,7 +270,7 @@ PrelinkedContextInit (
 
   Context->VirtualBase = PrelinkedKext->Context.VirtualBase;
 
-  Context->PrelinkedLastAddress = MACHO_ALIGN (MachoGetLastAddress64 (&Context->PrelinkedMachContext));
+  Context->PrelinkedLastAddress = MACHO_ALIGN (MachoGetLastAddress (&Context->PrelinkedMachContext));
   if (Context->PrelinkedLastAddress == 0) {
     return EFI_INVALID_PARAMETER;
   }
@@ -285,7 +287,7 @@ PrelinkedContextInit (
     return Status;
   }
 
-  Context->PrelinkedTextSegment = MachoGetSegmentByName64 (
+  Context->PrelinkedTextSegment = MachoGetSegmentByName (
     &Context->PrelinkedMachContext,
     PRELINK_TEXT_SEGMENT
     );
@@ -293,7 +295,7 @@ PrelinkedContextInit (
     return EFI_NOT_FOUND;
   }
 
-  Context->PrelinkedTextSection = MachoGetSectionByName64 (
+  Context->PrelinkedTextSection = MachoGetSectionByName (
     &Context->PrelinkedMachContext,
     Context->PrelinkedTextSegment,
     PRELINK_TEXT_SECTION
@@ -308,8 +310,8 @@ PrelinkedContextInit (
     //
     Status = PrelinkedGetSegmentsFromMacho (
       &Context->InnerMachContext,
-      &Context->InnerInfoSegment,
-      &Context->InnerInfoSection
+      (MACH_SEGMENT_COMMAND_ANY **) &Context->InnerInfoSegment,
+      (MACH_SECTION_ANY **) &Context->InnerInfoSection
       );
     if (EFI_ERROR (Status)) {
       return Status;
@@ -323,7 +325,7 @@ PrelinkedContextInit (
       return EFI_NOT_FOUND;
     }
 
-    Context->LinkEditSegment = MachoGetSegmentByName64 (
+    Context->LinkEditSegment = MachoGetSegmentByName (
       &Context->PrelinkedMachContext,
       KC_LINKEDIT_SEGMENT
       );
@@ -332,16 +334,22 @@ PrelinkedContextInit (
     }
   }
 
-  Context->PrelinkedInfo = AllocateCopyPool (
-    (UINTN)Context->PrelinkedInfoSection->Size,
-    &Context->Prelinked[Context->PrelinkedInfoSection->Offset]
-    );
+  Context->PrelinkedInfo = Context->Is32Bit ?
+    AllocateCopyPool (Context->PrelinkedInfoSection->Section32.Size,
+      &Context->Prelinked[Context->PrelinkedInfoSection->Section32.Offset]) :
+    AllocateCopyPool ((UINTN) Context->PrelinkedInfoSection->Section64.Size,
+      &Context->Prelinked[Context->PrelinkedInfoSection->Section64.Offset]);  
   if (Context->PrelinkedInfo == NULL) {
     PrelinkedContextFree (Context);
     return EFI_OUT_OF_RESOURCES;
   }
 
-  Context->PrelinkedInfoDocument = XmlDocumentParse (Context->PrelinkedInfo, (UINT32)Context->PrelinkedInfoSection->Size, TRUE);
+  Context->PrelinkedInfoDocument = XmlDocumentParse (
+    Context->PrelinkedInfo,
+    (UINT32) (Context->Is32Bit ?
+      Context->PrelinkedInfoSection->Section32.Size : Context->PrelinkedInfoSection->Section64.Size),
+    TRUE
+    );
   if (Context->PrelinkedInfoDocument == NULL) {
     PrelinkedContextFree (Context);
     return EFI_INVALID_PARAMETER;
@@ -367,14 +375,14 @@ PrelinkedContextInit (
     //
     // In KC mode last load address is the __LINKEDIT address.
     //
-    SegmentEndOffset = Context->LinkEditSegment->FileOffset + Context->LinkEditSegment->FileSize;
+    SegmentEndOffset = Context->LinkEditSegment->Segment64.FileOffset + Context->LinkEditSegment->Segment64.FileSize;
 
     if (MACHO_ALIGN (SegmentEndOffset) != Context->PrelinkedSize) {
       PrelinkedContextFree (Context);
       return EFI_INVALID_PARAMETER;
     }
     
-    Context->PrelinkedLastLoadAddress = Context->LinkEditSegment->VirtualAddress + Context->LinkEditSegment->Size;
+    Context->PrelinkedLastLoadAddress = Context->LinkEditSegment->Segment64.VirtualAddress + Context->LinkEditSegment->Segment64.Size;
   }
 
   //
@@ -524,15 +532,15 @@ PrelinkedInjectPrepare (
     ASSERT (Context->PrelinkedLastAddress == Context->PrelinkedLastLoadAddress);
 
     Context->KextsFixupChains = (VOID *) (Context->Prelinked +
-      Context->LinkEditSegment->FileOffset + Context->LinkEditSegment->FileSize);
+      Context->LinkEditSegment->Segment64.FileOffset + Context->LinkEditSegment->Segment64.FileSize);
 
     AlignedExpansion = MACHO_ALIGN (LinkedExpansion);
 
-    Context->PrelinkedSize              += AlignedExpansion;
-    Context->PrelinkedLastAddress       += AlignedExpansion;
-    Context->PrelinkedLastLoadAddress   += AlignedExpansion;
-    Context->LinkEditSegment->Size      += AlignedExpansion;
-    Context->LinkEditSegment->FileSize  += AlignedExpansion;
+    Context->PrelinkedSize                        += AlignedExpansion;
+    Context->PrelinkedLastAddress                 += AlignedExpansion;
+    Context->PrelinkedLastLoadAddress             += AlignedExpansion;
+    Context->LinkEditSegment->Segment64.Size      += AlignedExpansion;
+    Context->LinkEditSegment->Segment64.FileSize  += AlignedExpansion;
   } else {
     //
     // For older variant of the prelinkedkernel plist info is normally
@@ -573,16 +581,22 @@ PrelinkedInjectPrepare (
     // ffffff8000ec5000 - ffffff8000ec5000 (at 0000000000d63000 - 0000000000dd7000) - __CTF
     // ffffff8000ec5000 - ffffff80010358a8 (at 0000000000dd7000 - 0000000000f478a8) - __LINKEDIT
     //
-    SegmentEndOffset = Context->PrelinkedInfoSegment->FileOffset + Context->PrelinkedInfoSegment->FileSize;
+    SegmentEndOffset = Context->Is32Bit ?
+      Context->PrelinkedInfoSegment->Segment32.FileOffset + Context->PrelinkedInfoSegment->Segment32.FileSize :
+      Context->PrelinkedInfoSegment->Segment64.FileOffset + Context->PrelinkedInfoSegment->Segment64.FileSize;
 
     if (MACHO_ALIGN (SegmentEndOffset) == Context->PrelinkedSize) {
       DEBUG ((
         DEBUG_INFO,
         "OCAK: Reducing prelink size from %X to %X via plist\n",
         Context->PrelinkedSize,
-        (UINT32) MACHO_ALIGN (Context->PrelinkedInfoSegment->FileOffset)
+        (UINT32) MACHO_ALIGN (Context->Is32Bit ?
+          Context->PrelinkedInfoSegment->Segment32.FileOffset : Context->PrelinkedInfoSegment->Segment32.FileOffset
+          )
         ));
-      Context->PrelinkedSize = (UINT32) MACHO_ALIGN (Context->PrelinkedInfoSegment->FileOffset);
+      Context->PrelinkedSize = (UINT32) MACHO_ALIGN (Context->Is32Bit ?
+        Context->PrelinkedInfoSegment->Segment32.FileOffset : Context->PrelinkedInfoSegment->Segment32.FileOffset
+        );
     } else {
        DEBUG ((
         DEBUG_INFO,
@@ -593,31 +607,50 @@ PrelinkedInjectPrepare (
     }
 
     if (Context->PrelinkedStateSegment != NULL) {
-      SegmentEndOffset = Context->PrelinkedStateSegment->FileOffset + Context->PrelinkedStateSegment->FileSize;
+      SegmentEndOffset = Context->Is32Bit ?
+        Context->PrelinkedStateSegment->Segment32.FileOffset + Context->PrelinkedStateSegment->Segment32.FileSize :
+        Context->PrelinkedStateSegment->Segment64.FileOffset + Context->PrelinkedStateSegment->Segment64.FileSize;
 
       if (MACHO_ALIGN (SegmentEndOffset) == Context->PrelinkedSize) {
         DEBUG ((
           DEBUG_INFO,
           "OCAK: Reducing prelink size from %X to %X via state\n",
           Context->PrelinkedSize,
-          (UINT32) MACHO_ALIGN (Context->PrelinkedStateSegment->FileOffset)
+          (UINT32) MACHO_ALIGN (Context->Is32Bit ?
+            Context->PrelinkedStateSegment->Segment32.FileOffset : Context->PrelinkedStateSegment->Segment64.FileOffset
+            )
           ));
-        Context->PrelinkedSize = (UINT32) MACHO_ALIGN (Context->PrelinkedStateSegment->FileOffset);
+        Context->PrelinkedSize = (UINT32) MACHO_ALIGN (Context->Is32Bit ?
+          Context->PrelinkedStateSegment->Segment32.FileOffset : Context->PrelinkedStateSegment->Segment64.FileOffset
+          );
 
         //
         // Need to NULL this, as they are used in address calculations
-        // in e.g. MachoGetLastAddress64.
+        // in e.g. MachoGetLastAddress.
         //
-        Context->PrelinkedStateSegment->VirtualAddress = 0;
-        Context->PrelinkedStateSegment->Size           = 0;
-        Context->PrelinkedStateSegment->FileOffset     = 0;
-        Context->PrelinkedStateSegment->FileSize       = 0;
-        Context->PrelinkedStateSectionKernel->Address  = 0;
-        Context->PrelinkedStateSectionKernel->Size     = 0;
-        Context->PrelinkedStateSectionKernel->Offset   = 0;
-        Context->PrelinkedStateSectionKexts->Address   = 0;
-        Context->PrelinkedStateSectionKexts->Size      = 0;
-        Context->PrelinkedStateSectionKexts->Offset    = 0;
+        if (Context->Is32Bit) {
+          Context->PrelinkedStateSegment->Segment32.VirtualAddress = 0;
+          Context->PrelinkedStateSegment->Segment32.Size           = 0;
+          Context->PrelinkedStateSegment->Segment32.FileOffset     = 0;
+          Context->PrelinkedStateSegment->Segment32.FileSize       = 0;
+          Context->PrelinkedStateSectionKernel->Section32.Address  = 0;
+          Context->PrelinkedStateSectionKernel->Section32.Size     = 0;
+          Context->PrelinkedStateSectionKernel->Section32.Offset   = 0;
+          Context->PrelinkedStateSectionKexts->Section32.Address   = 0;
+          Context->PrelinkedStateSectionKexts->Section32.Size      = 0;
+          Context->PrelinkedStateSectionKexts->Section32.Offset    = 0;
+        } else {
+          Context->PrelinkedStateSegment->Segment64.VirtualAddress = 0;
+          Context->PrelinkedStateSegment->Segment64.Size           = 0;
+          Context->PrelinkedStateSegment->Segment64.FileOffset     = 0;
+          Context->PrelinkedStateSegment->Segment64.FileSize       = 0;
+          Context->PrelinkedStateSectionKernel->Section64.Address  = 0;
+          Context->PrelinkedStateSectionKernel->Section64.Size     = 0;
+          Context->PrelinkedStateSectionKernel->Section64.Offset   = 0;
+          Context->PrelinkedStateSectionKexts->Section64.Address   = 0;
+          Context->PrelinkedStateSectionKexts->Section64.Size      = 0;
+          Context->PrelinkedStateSectionKexts->Section64.Offset    = 0;
+        }
       } else {
          DEBUG ((
           DEBUG_INFO,
@@ -628,15 +661,25 @@ PrelinkedInjectPrepare (
       }
     }
 
-    Context->PrelinkedInfoSegment->VirtualAddress = 0;
-    Context->PrelinkedInfoSegment->Size           = 0;
-    Context->PrelinkedInfoSegment->FileOffset     = 0;
-    Context->PrelinkedInfoSegment->FileSize       = 0;
-    Context->PrelinkedInfoSection->Address        = 0;
-    Context->PrelinkedInfoSection->Size           = 0;
-    Context->PrelinkedInfoSection->Offset         = 0;
+    if (Context->Is32Bit) {
+      Context->PrelinkedInfoSegment->Segment32.VirtualAddress = 0;
+      Context->PrelinkedInfoSegment->Segment32.Size           = 0;
+      Context->PrelinkedInfoSegment->Segment32.FileOffset     = 0;
+      Context->PrelinkedInfoSegment->Segment32.FileSize       = 0;
+      Context->PrelinkedInfoSection->Section32.Address        = 0;
+      Context->PrelinkedInfoSection->Section32.Size           = 0;
+      Context->PrelinkedInfoSection->Section32.Offset         = 0;
+    } else {
+      Context->PrelinkedInfoSegment->Segment64.VirtualAddress = 0;
+      Context->PrelinkedInfoSegment->Segment64.Size           = 0;
+      Context->PrelinkedInfoSegment->Segment64.FileOffset     = 0;
+      Context->PrelinkedInfoSegment->Segment64.FileSize       = 0;
+      Context->PrelinkedInfoSection->Section64.Address        = 0;
+      Context->PrelinkedInfoSection->Section64.Size           = 0;
+      Context->PrelinkedInfoSection->Section64.Offset         = 0;
+    }
 
-    Context->PrelinkedLastAddress = MACHO_ALIGN (MachoGetLastAddress64 (&Context->PrelinkedMachContext));
+    Context->PrelinkedLastAddress = MACHO_ALIGN (MachoGetLastAddress (&Context->PrelinkedMachContext));
     if (Context->PrelinkedLastAddress == 0) {
       return EFI_INVALID_PARAMETER;
     }
@@ -644,7 +687,9 @@ PrelinkedInjectPrepare (
     //
     // Prior to plist there usually is prelinked text. 
     //
-    SegmentEndOffset = Context->PrelinkedTextSegment->FileOffset + Context->PrelinkedTextSegment->FileSize;
+    SegmentEndOffset = Context->Is32Bit ?
+      Context->PrelinkedTextSegment->Segment32.FileOffset + Context->PrelinkedTextSegment->Segment32.FileSize :
+      Context->PrelinkedTextSegment->Segment64.FileOffset + Context->PrelinkedTextSegment->Segment64.FileSize;
 
     if (MACHO_ALIGN (SegmentEndOffset) != Context->PrelinkedSize) {
       //
@@ -700,7 +745,9 @@ PrelinkedInjectComplete (
     if (EFI_ERROR (Status)) {
       return Status;
     }
-  } else if (Context->PrelinkedStateSegment != NULL && Context->PrelinkedStateSegment->VirtualAddress == 0) {
+  } else if (Context->PrelinkedStateSegment != NULL && (Context->Is32Bit ?
+    Context->PrelinkedStateSegment->Segment32.VirtualAddress : Context->PrelinkedStateSegment->Segment64.VirtualAddress)
+    == 0) {
     Status = InternalKxldStateRebuild (Context);
     if (EFI_ERROR (Status)) {
       return Status;
@@ -746,13 +793,23 @@ PrelinkedInjectComplete (
   }
 #endif
 
-  Context->PrelinkedInfoSegment->VirtualAddress = Context->PrelinkedLastAddress;
-  Context->PrelinkedInfoSegment->Size           = MACHO_ALIGN (ExportedInfoSize);
-  Context->PrelinkedInfoSegment->FileOffset     = Context->PrelinkedSize;
-  Context->PrelinkedInfoSegment->FileSize       = MACHO_ALIGN (ExportedInfoSize);
-  Context->PrelinkedInfoSection->Address        = Context->PrelinkedLastAddress;
-  Context->PrelinkedInfoSection->Size           = MACHO_ALIGN (ExportedInfoSize);
-  Context->PrelinkedInfoSection->Offset         = Context->PrelinkedSize;
+  if (Context->Is32Bit) {
+    Context->PrelinkedInfoSegment->Segment32.VirtualAddress = Context->PrelinkedLastAddress;
+    Context->PrelinkedInfoSegment->Segment32.Size           = MACHO_ALIGN (ExportedInfoSize);
+    Context->PrelinkedInfoSegment->Segment32.FileOffset     = Context->PrelinkedSize;
+    Context->PrelinkedInfoSegment->Segment32.FileSize       = MACHO_ALIGN (ExportedInfoSize);
+    Context->PrelinkedInfoSection->Section32.Address        = Context->PrelinkedLastAddress;
+    Context->PrelinkedInfoSection->Section32.Size           = MACHO_ALIGN (ExportedInfoSize);
+    Context->PrelinkedInfoSection->Section32.Offset         = Context->PrelinkedSize;
+  } else {
+    Context->PrelinkedInfoSegment->Segment64.VirtualAddress = Context->PrelinkedLastAddress;
+    Context->PrelinkedInfoSegment->Segment64.Size           = MACHO_ALIGN (ExportedInfoSize);
+    Context->PrelinkedInfoSegment->Segment64.FileOffset     = Context->PrelinkedSize;
+    Context->PrelinkedInfoSegment->Segment64.FileSize       = MACHO_ALIGN (ExportedInfoSize);
+    Context->PrelinkedInfoSection->Section64.Address        = Context->PrelinkedLastAddress;
+    Context->PrelinkedInfoSection->Section64.Size           = MACHO_ALIGN (ExportedInfoSize);
+    Context->PrelinkedInfoSection->Section64.Offset         = Context->PrelinkedSize;
+  }
 
   if (Context->IsKernelCollection) {
     //
@@ -790,7 +847,7 @@ PrelinkedInjectComplete (
     // This happens when __REGION kexts are squashed.
     // Obtain its address again.
     //
-    Context->LinkEditSegment = MachoGetSegmentByName64 (
+    Context->LinkEditSegment = MachoGetSegmentByName (
       &Context->PrelinkedMachContext,
       KC_LINKEDIT_SEGMENT
       );
@@ -906,7 +963,7 @@ PrelinkedInjectKext (
   //
   if (Executable != NULL) {
     ASSERT (ExecutableSize > 0);
-    if (!MachoInitializeContext64 (&ExecutableContext, (UINT8 *)Executable, ExecutableSize, 0)) {
+    if (!MachoInitializeContext (&ExecutableContext, (UINT8 *)Executable, ExecutableSize, 0, Context->Is32Bit)) {
       DEBUG ((DEBUG_INFO, "OCAK: Injected kext %a/%a is not a supported executable\n", BundlePath, ExecutablePath));
       return EFI_INVALID_PARAMETER;
     }
@@ -927,6 +984,7 @@ PrelinkedInjectKext (
     if (OcOverflowAddU32 (KextOffset, AlignedExecutableSize, &NewPrelinkedSize)
       || NewPrelinkedSize > Context->PrelinkedAllocSize
       || ExecutableSize == 0) {
+        DEBUG ((DEBUG_INFO, "got here %X\n", ExecutableSize ));
       return EFI_BUFFER_TOO_SMALL;
     }
 
@@ -935,7 +993,7 @@ PrelinkedInjectKext (
       AlignedExecutableSize - ExecutableSize
       );
 
-    if (!MachoInitializeContext64 (&ExecutableContext, &Context->Prelinked[KextOffset], ExecutableSize, 0)) {
+    if (!MachoInitializeContext (&ExecutableContext, &Context->Prelinked[KextOffset], ExecutableSize, 0, Context->Is32Bit)) {
       return EFI_INVALID_PARAMETER;
     }
 
@@ -1015,6 +1073,8 @@ PrelinkedInjectKext (
     return EFI_OUT_OF_RESOURCES;
   }
 
+  DEBUG ((DEBUG_INFO, "got here\n"));
+
   if (Executable != NULL) {
     PrelinkedKext = InternalLinkPrelinkedKext (
       Context,
@@ -1023,6 +1083,7 @@ PrelinkedInjectKext (
       Context->PrelinkedLastLoadAddress,
       KmodAddress
       );
+    DEBUG ((DEBUG_INFO, "got here 3\n"));
 
     if (PrelinkedKext == NULL) {
       XmlDocumentFree (InfoPlistDocument);
@@ -1061,9 +1122,9 @@ PrelinkedInjectKext (
       //
       // For legacy prelinkedkernel we append to __PRELINK_TEXT.
       //
-      Context->PrelinkedTextSegment->Size     += AlignedExecutableSize;
-      Context->PrelinkedTextSegment->FileSize += AlignedExecutableSize;
-      Context->PrelinkedTextSection->Size     += AlignedExecutableSize;
+      Context->PrelinkedTextSegment->Segment64.Size     += AlignedExecutableSize;
+      Context->PrelinkedTextSegment->Segment64.FileSize += AlignedExecutableSize;
+      Context->PrelinkedTextSection->Section64.Size     += AlignedExecutableSize;
     }
   }
 

--- a/Library/OcAppleKernelLib/PrelinkedContext.c
+++ b/Library/OcAppleKernelLib/PrelinkedContext.c
@@ -885,13 +885,10 @@ PrelinkedReserveKextSize (
       return EFI_INVALID_PARAMETER;
     }
 
-    /*ExecutableSize = MachoGetVmSize (&Context);
+    ExecutableSize = MachoGetExpandedImageSize (&Context);
     if (ExecutableSize == 0) {
       return EFI_INVALID_PARAMETER;
-    }*/
-
-    ExecutableSize  = MACHO_ALIGN (ExecutableSize);
-    ExecutableSize += SIZE_16KB; // FIXME: Need to calculate size that MachoExpandImage requires.
+    }
   }
 
   if (OcOverflowAddU32 (*ReservedInfoSize, InfoPlistSize, &InfoPlistSize)

--- a/Library/OcAppleKernelLib/PrelinkedInternal.h
+++ b/Library/OcAppleKernelLib/PrelinkedInternal.h
@@ -259,7 +259,7 @@ InternalConnectExternalSymtab (
 
 #define KXLD_WEAK_TEST_SYMBOL  "_gOSKextUnresolved"
 
-#define KXLD_ANY_NEXT(a,b) ((VOID *) ((UINTN)(b)) + ((a) ? sizeof ((b)->Kxld32) : sizeof ((b)->Kxld64)))
+#define KXLD_ANY_NEXT(a,b) ((VOID *) (((UINTN)(b)) + ((a) ? sizeof ((b)->Kxld32) : sizeof ((b)->Kxld64))))
 
 #define OS_METACLASS_VTABLE_NAME "__ZTV11OSMetaClass"
 

--- a/Library/OcAppleKernelLib/PrelinkedInternal.h
+++ b/Library/OcAppleKernelLib/PrelinkedInternal.h
@@ -234,6 +234,7 @@ InternalUnlockContextKexts (
   @param[in]     PlistRoot       Current kext info.plist.
   @param[in]     LoadAddress     Kext load address.
   @param[in]     KmodAddress     Kext kmod address.
+  @param[in]     FileOffset      The file offset of the first segment.
 
   @return  prelinked kext to be inserted into PRELINKED_CONTEXT.
 **/
@@ -243,7 +244,8 @@ InternalLinkPrelinkedKext (
   IN OUT OC_MACHO_CONTEXT   *Executable,
   IN     XML_NODE           *PlistRoot,
   IN     UINT64             LoadAddress,
-  IN     UINT64             KmodAddress
+  IN     UINT64             KmodAddress,
+  IN     UINT64             FileOffset
   );
 
 EFI_STATUS
@@ -426,6 +428,7 @@ InternalSolveSymbolValue (
   @param[in,out] Context      Prelinking context.
   @param[in]     Kext         KEXT prelinking context.
   @param[in]     LoadAddress  The address this KEXT shall be linked against.
+  @param[in]     FileOffset   The file offset of the first segment.
 
   @retval  Returned is whether the prelinking process has been successful.
            The state of the KEXT is undefined in case this routine fails.
@@ -435,7 +438,8 @@ EFI_STATUS
 InternalPrelinkKext (
   IN OUT PRELINKED_CONTEXT  *Context,
   IN     PRELINKED_KEXT     *Kext,
-  IN     UINT64             LoadAddress
+  IN     UINT64             LoadAddress,
+  IN     UINT64             FileOffset
   );
 
 /**

--- a/Library/OcAppleKernelLib/PrelinkedInternal.h
+++ b/Library/OcAppleKernelLib/PrelinkedInternal.h
@@ -104,7 +104,7 @@ struct PRELINKED_KEXT_ {
   //
   // Linkedit segment reference.
   //
-  MACH_SEGMENT_COMMAND_64  *LinkEditSegment;
+  MACH_SEGMENT_COMMAND_ANY *LinkEditSegment;
   //
   // The String Table associated with this symbol table.
   //
@@ -112,7 +112,7 @@ struct PRELINKED_KEXT_ {
   //
   // Symbol table.
   //
-  CONST MACH_NLIST_64      *SymbolTable;
+  CONST MACH_NLIST_ANY     *SymbolTable;
   //
   // Symbol table size.
   //
@@ -263,9 +263,11 @@ InternalConnectExternalSymtab (
 
 #define SYM_MAX_NAME_LEN  256U
 
+#define VTABLE_ENTRY_SIZE_32   4U
 #define VTABLE_ENTRY_SIZE_64   8U
-#define VTABLE_HEADER_LEN_64   2U
-#define VTABLE_HEADER_SIZE_64  (VTABLE_HEADER_LEN_64 * VTABLE_ENTRY_SIZE_64)
+#define VTABLE_HEADER_LEN      2U
+#define VTABLE_HEADER_SIZE_32  (VTABLE_HEADER_LEN * VTABLE_ENTRY_SIZE_32)
+#define VTABLE_HEADER_SIZE_64  (VTABLE_HEADER_LEN * VTABLE_ENTRY_SIZE_64)
 
 #define KERNEL_ADDRESS_MASK 0xFFFFFFFF00000000ULL
 #define KERNEL_ADDRESS_KEXT 0xFFFFFF7F00000000ULL
@@ -311,14 +313,14 @@ STATIC_ASSERT (
   );
 
 typedef struct {
-  CONST MACH_NLIST_64 *Smcp;
-  CONST MACH_NLIST_64 *Vtable;
-  UINT64              *VtableData;
-  CONST MACH_NLIST_64 *MetaVtable;
-  UINT64              *MetaVtableData;
-  UINT32              NumSolveSymbols;
-  UINT32              MetaSymsIndex;
-  MACH_NLIST_64       *SolveSymbols[];
+  CONST MACH_NLIST_ANY  *Smcp;
+  CONST MACH_NLIST_ANY  *Vtable;
+  VOID                  *VtableData;
+  CONST MACH_NLIST_ANY  *MetaVtable;
+  VOID                  *MetaVtableData;
+  UINT32                NumSolveSymbols;
+  UINT32                MetaSymsIndex;
+  MACH_NLIST_ANY        *SolveSymbols[];
 } OC_VTABLE_PATCH_ENTRY;
 //
 // This ASSERT is very dirty, but it is unlikely to trigger nevertheless.
@@ -404,9 +406,10 @@ InternalOcGetSymbolValue (
   );
 
 VOID
-InternalSolveSymbolValue64 (
-  IN  UINT64         Value,
-  OUT MACH_NLIST_64  *Symbol
+InternalSolveSymbolValue (
+  IN  BOOLEAN             Is32Bit,
+  IN  UINT64              Value,
+  OUT MACH_NLIST_ANY      *Symbol
   );
 
 /**
@@ -422,7 +425,7 @@ InternalSolveSymbolValue64 (
 
 **/
 EFI_STATUS
-InternalPrelinkKext64 (
+InternalPrelinkKext (
   IN OUT PRELINKED_CONTEXT  *Context,
   IN     PRELINKED_KEXT     *Kext,
   IN     UINT64             LoadAddress

--- a/Library/OcAppleKernelLib/PrelinkedKext.c
+++ b/Library/OcAppleKernelLib/PrelinkedKext.c
@@ -389,7 +389,7 @@ InternalScanBuildLinkedSymbolTable (
           return EFI_LOAD_ERROR;
         }
 
-        CopyMem (&SymbolScratch, Symbol, sizeof (SymbolScratch));
+        CopyMem (&SymbolScratch, Symbol, Context->Is32Bit ? sizeof (SymbolScratch.Symbol32) : sizeof (SymbolScratch.Symbol64));
         ResolvedSymbol = InternalOcGetSymbolName (
                            Context,
                            Kext,

--- a/Library/OcAppleKernelLib/PrelinkedKext.c
+++ b/Library/OcAppleKernelLib/PrelinkedKext.c
@@ -357,7 +357,11 @@ InternalScanBuildLinkedSymbolTable (
   NumCxxSymbols = 0;
 
   for (Index = 0; Index < Kext->NumberOfSymbols; ++Index) {
-    Symbol     = &Kext->SymbolTable[Index];
+    if (Context->Is32Bit) {
+      Symbol = (MACH_NLIST_ANY *)&(&Kext->SymbolTable->Symbol32)[Index];
+    } else {
+      Symbol = (MACH_NLIST_ANY *)&(&Kext->SymbolTable->Symbol64)[Index];
+    }
     SymbolType = Context->Is32Bit ? Symbol->Symbol32.Type : Symbol->Symbol64.Type;
     if ((SymbolType & MACH_N_TYPE_STAB) != 0) {
       ++NumDiscardedSyms;

--- a/Library/OcAppleKernelLib/PrelinkedKext.c
+++ b/Library/OcAppleKernelLib/PrelinkedKext.c
@@ -271,8 +271,6 @@ InternalScanCurrentPrelinkedKextLinkInfo (
     return;
   }
 
-  DEBUG ((DEBUG_INFO, "here kxld\n"));
-
   if (Kext->LinkEditSegment == NULL && Kext->NumberOfSymbols == 0) {
     if (AsciiStrCmp (Kext->Identifier, PRELINK_KERNEL_IDENTIFIER) == 0) {
       Kext->LinkEditSegment = Context->LinkEditSegment;
@@ -1055,7 +1053,8 @@ InternalLinkPrelinkedKext (
   IN OUT OC_MACHO_CONTEXT   *Executable,
   IN     XML_NODE           *PlistRoot,
   IN     UINT64             LoadAddress,
-  IN     UINT64             KmodAddress
+  IN     UINT64             KmodAddress,
+  IN     UINT64             FileOffset
   )
 {
   EFI_STATUS      Status;
@@ -1110,7 +1109,7 @@ InternalLinkPrelinkedKext (
   Kext->Context.VirtualBase = LoadAddress;
   Kext->Context.VirtualKmod = KmodAddress;
 
-  Status = InternalPrelinkKext (Context, Kext, LoadAddress);
+  Status = InternalPrelinkKext (Context, Kext, LoadAddress, FileOffset);
 
   if (EFI_ERROR (Status)) {
     InternalFreePrelinkedKext (Kext);

--- a/Library/OcAppleKernelLib/PrelinkedKext.c
+++ b/Library/OcAppleKernelLib/PrelinkedKext.c
@@ -57,7 +57,7 @@ InternalCreatePrelinkedKext (
   UINT64                   SourceSize;
   UINT64                   CalculatedSourceSize;
   UINT64                   SourceEnd;
-  MACH_SEGMENT_COMMAND_64  *BaseSegment;
+  MACH_SEGMENT_COMMAND_ANY *BaseSegment;
   UINT64                   KxldState;
   UINT64                   KxldOffset;
   UINT32                   KxldStateSize;
@@ -188,15 +188,15 @@ InternalCreatePrelinkedKext (
 
   if (Prelinked != NULL && HasExe) {
     if (Prelinked->IsKernelCollection) {
-      BaseSegment = Prelinked->RegionSegment;
+      BaseSegment = (MACH_SEGMENT_COMMAND_ANY *) Prelinked->RegionSegment;
     } else {
       BaseSegment = Prelinked->PrelinkedTextSegment;
     }
 
-    SourceBase -= BaseSegment->VirtualAddress;
-    if (OcOverflowAddU64 (SourceBase, BaseSegment->FileOffset, &SourceBase) ||
-      OcOverflowAddU64 (SourceBase, SourceSize, &SourceEnd) ||
-      SourceEnd > Prelinked->PrelinkedSize) {
+    SourceBase -= Prelinked->Is32Bit ? BaseSegment->Segment32.VirtualAddress : BaseSegment->Segment64.VirtualAddress;
+    if (OcOverflowAddU64 (SourceBase, Prelinked->Is32Bit ? BaseSegment->Segment32.FileOffset : BaseSegment->Segment64.FileOffset, &SourceBase)
+      || OcOverflowAddU64 (SourceBase, SourceSize, &SourceEnd)
+      || SourceEnd > Prelinked->PrelinkedSize) {
       return NULL;
     }
 
@@ -270,11 +270,13 @@ InternalScanCurrentPrelinkedKextLinkInfo (
     return;
   }
 
+  DEBUG ((DEBUG_INFO, "here kxld\n"));
+
   if (Kext->LinkEditSegment == NULL && Kext->NumberOfSymbols == 0) {
     if (AsciiStrCmp (Kext->Identifier, PRELINK_KERNEL_IDENTIFIER) == 0) {
       Kext->LinkEditSegment = Context->LinkEditSegment;
     } else {
-      Kext->LinkEditSegment = MachoGetSegmentByName64 (
+      Kext->LinkEditSegment = MachoGetSegmentByName (
         &Kext->Context.MachContext,
         "__LINKEDIT"
         );
@@ -284,12 +286,12 @@ InternalScanCurrentPrelinkedKextLinkInfo (
       "OCAK: Requesting __LINKEDIT for %a - %p at %p\n",
       Kext->Identifier,
       Kext->LinkEditSegment,
-      (UINT8 *) MachoGetMachHeader64 (&Kext->Context.MachContext) - Context->Prelinked
+      (UINT8 *) MachoGetMachHeader (&Kext->Context.MachContext) - Context->Prelinked
       ));
   }
 
   if (Kext->SymbolTable == NULL && Kext->NumberOfSymbols == 0) {
-    Kext->NumberOfSymbols = MachoGetSymbolTable64 (
+    Kext->NumberOfSymbols = MachoGetSymbolTable (
                    &Kext->Context.MachContext,
                    &Kext->SymbolTable,
                    &Kext->StringTable,
@@ -316,7 +318,7 @@ InternalScanBuildLinkedSymbolTable (
   IN     PRELINKED_CONTEXT  *Context
   )
 {
-  CONST MACH_HEADER_64  *MachHeader;
+  CONST MACH_HEADER_ANY *MachHeader;
   BOOLEAN               ResolveSymbols;
   PRELINKED_KEXT_SYMBOL *SymbolTable;
   PRELINKED_KEXT_SYMBOL *WalkerBottom;
@@ -324,8 +326,9 @@ InternalScanBuildLinkedSymbolTable (
   UINT32                NumCxxSymbols;
   UINT32                NumDiscardedSyms;
   UINT32                Index;
-  CONST MACH_NLIST_64   *Symbol;
-  MACH_NLIST_64         SymbolScratch;
+  CONST MACH_NLIST_ANY  *Symbol;
+  UINT8                 SymbolType;
+  MACH_NLIST_ANY        SymbolScratch;
   CONST PRELINKED_KEXT_SYMBOL *ResolvedSymbol;
   CONST CHAR8           *Name;
   BOOLEAN               Result;
@@ -339,12 +342,12 @@ InternalScanBuildLinkedSymbolTable (
     return EFI_OUT_OF_RESOURCES;
   }
 
-  MachHeader = MachoGetMachHeader64 (&Kext->Context.MachContext);
+  MachHeader = MachoGetMachHeader (&Kext->Context.MachContext);
   ASSERT (MachHeader != NULL);
   //
   // KPIs declare undefined and indirect symbols even in prelinkedkernel.
   //
-  ResolveSymbols = ((MachHeader->Flags & MACH_HEADER_FLAG_NO_UNDEFINED_REFERENCES) == 0);
+  ResolveSymbols = (((Context->Is32Bit ? MachHeader->Header32.Flags : MachHeader->Header64.Flags) & MACH_HEADER_FLAG_NO_UNDEFINED_REFERENCES) == 0);
   NumDiscardedSyms = 0;
 
   WalkerBottom = &SymbolTable[0];
@@ -353,8 +356,9 @@ InternalScanBuildLinkedSymbolTable (
   NumCxxSymbols = 0;
 
   for (Index = 0; Index < Kext->NumberOfSymbols; ++Index) {
-    Symbol = &Kext->SymbolTable[Index];
-    if ((Symbol->Type & MACH_N_TYPE_STAB) != 0) {
+    Symbol     = &Kext->SymbolTable[Index];
+    SymbolType = Context->Is32Bit ? Symbol->Symbol32.Type : Symbol->Symbol64.Type;
+    if ((SymbolType & MACH_N_TYPE_STAB) != 0) {
       ++NumDiscardedSyms;
       continue;
     }
@@ -363,20 +367,20 @@ InternalScanBuildLinkedSymbolTable (
     // Undefined symbols will be resolved via the KPI's dependencies and
     // hence do not need to be included (again).
     //
-    if ((Symbol->Type & MACH_N_TYPE_TYPE) == MACH_N_TYPE_UNDF) {
+    if ((SymbolType & MACH_N_TYPE_TYPE) == MACH_N_TYPE_UNDF) {
       ++NumDiscardedSyms;
       continue;
     }
 
-    Name   = MachoGetSymbolName64 (&Kext->Context.MachContext, Symbol);
+    Name   = MachoGetSymbolName (&Kext->Context.MachContext, Symbol);
     Result = MachoSymbolNameIsCxx (Name);
 
     if (ResolveSymbols) {
       //
       // Resolve indirect symbols via the KPI's dependencies (kernel).
       //
-      if ((Symbol->Type & MACH_N_TYPE_TYPE) == MACH_N_TYPE_INDR) {
-        Name = MachoGetIndirectSymbolName64 (&Kext->Context.MachContext, Symbol);
+      if ((SymbolType & MACH_N_TYPE_TYPE) == MACH_N_TYPE_INDR) {
+        Name = MachoGetIndirectSymbolName (&Kext->Context.MachContext, Symbol);
         if (Name == NULL) {
           FreePool (SymbolTable);
           return EFI_LOAD_ERROR;
@@ -393,19 +397,25 @@ InternalScanBuildLinkedSymbolTable (
           FreePool (SymbolTable);
           return EFI_NOT_FOUND;
         }
-        SymbolScratch.Value = ResolvedSymbol->Value;
+        if (Context->Is32Bit) {
+          SymbolScratch.Symbol32.Value = (UINT32) ResolvedSymbol->Value;
+        } else {
+          SymbolScratch.Symbol64.Value = ResolvedSymbol->Value;
+        }
         Symbol = &SymbolScratch;
       }
     }
 
     if (!Result) {
-      WalkerBottom->Value  = Symbol->Value;
-      WalkerBottom->Name   = Kext->StringTable + Symbol->UnifiedName.StringIndex;
+      WalkerBottom->Value  = Context->Is32Bit ? Symbol->Symbol32.Value : Symbol->Symbol64.Value;
+      WalkerBottom->Name   = Kext->StringTable + (Context->Is32Bit ?
+        Symbol->Symbol32.UnifiedName.StringIndex : Symbol->Symbol64.UnifiedName.StringIndex);
       WalkerBottom->Length = (UINT32)AsciiStrLen (WalkerBottom->Name);
       ++WalkerBottom;
     } else {
-      WalkerTop->Value  = Symbol->Value;
-      WalkerTop->Name   = Kext->StringTable + Symbol->UnifiedName.StringIndex;
+      WalkerTop->Value  = Context->Is32Bit ? Symbol->Symbol32.Value : Symbol->Symbol64.Value;
+      WalkerTop->Name   = Kext->StringTable + (Context->Is32Bit ?
+        Symbol->Symbol32.UnifiedName.StringIndex : Symbol->Symbol64.UnifiedName.StringIndex);
       WalkerTop->Length = (UINT32)AsciiStrLen (WalkerTop->Name);
       --WalkerTop;
 
@@ -538,10 +548,11 @@ InternalGetLinkBufferSize (
   // LinkBuffer must be able to hold all symbols and for KEXTs to be prelinked
   // also the __LINKEDIT segment (however not both simultaneously/separately).
   //
-  Size = Kext->NumberOfSymbols * sizeof (MACH_NLIST_64);
+  Size = Kext->NumberOfSymbols * (Kext->Context.Is32Bit ? sizeof (MACH_NLIST) : sizeof (MACH_NLIST_64));
   
   if (Kext->LinkEditSegment != NULL) {
-    Size = MAX ((UINT32) Kext->LinkEditSegment->FileSize, Size);
+    Size = MAX ((UINT32) (Kext->Context.Is32Bit ?
+      Kext->LinkEditSegment->Segment32.FileSize : Kext->LinkEditSegment->Segment64.FileSize), Size);
   }
 
   return Size;
@@ -704,9 +715,16 @@ InternalCachedPrelinkedKernel (
   IN OUT PRELINKED_CONTEXT  *Prelinked
   )
 {
-  LIST_ENTRY               *Kext;
-  PRELINKED_KEXT           *NewKext;
-  MACH_SEGMENT_COMMAND_64  *Segment;
+  LIST_ENTRY                *Kext;
+  PRELINKED_KEXT            *NewKext;
+  MACH_SEGMENT_COMMAND_ANY  *Segment;
+
+  UINT64                    VirtualAddress;
+  UINT64                    FileOffset;
+  UINT64                    KernelSize;
+  UINT64                    KextsSize;
+  UINT64                    KernelOffset;
+  UINT64                    KextsOffset;
 
   //
   // First entry is prelinked kernel.
@@ -730,11 +748,14 @@ InternalCachedPrelinkedKernel (
     sizeof (NewKext->Context.MachContext)
     );
 
-  Segment = MachoGetSegmentByName64 (
+  Segment = MachoGetSegmentByName (
     &NewKext->Context.MachContext,
     "__TEXT"
     );
-  if (Segment == NULL || Segment->VirtualAddress < Segment->FileOffset) {
+  VirtualAddress = Prelinked->Is32Bit ? Segment->Segment32.VirtualAddress : Segment->Segment64.VirtualAddress;
+  FileOffset     = Prelinked->Is32Bit ? Segment->Segment32.FileOffset : Segment->Segment64.FileOffset;
+
+  if (Segment == NULL || VirtualAddress < FileOffset) {
     FreePool (NewKext);
     return NULL;
   }
@@ -743,7 +764,8 @@ InternalCachedPrelinkedKernel (
   NewKext->Identifier                 = PRELINK_KERNEL_IDENTIFIER;
   NewKext->BundleLibraries            = NULL;
   NewKext->CompatibleVersion          = "0";
-  NewKext->Context.VirtualBase        = Segment->VirtualAddress - Segment->FileOffset;
+  NewKext->Context.Is32Bit            = Prelinked->Is32Bit;
+  NewKext->Context.VirtualBase        = VirtualAddress - FileOffset;
   NewKext->Context.VirtualKmod        = 0;
   NewKext->Context.IsKernelCollection = Prelinked->IsKernelCollection;
 
@@ -751,42 +773,57 @@ InternalCachedPrelinkedKernel (
     //
     // Find optional __PRELINK_STATE segment, present in 10.6.8
     //
-    Prelinked->PrelinkedStateSegment = MachoGetSegmentByName64 (
+    Prelinked->PrelinkedStateSegment = MachoGetSegmentByName (
       &Prelinked->PrelinkedMachContext,
       PRELINK_STATE_SEGMENT
       );
 
     if (Prelinked->PrelinkedStateSegment != NULL) {
-      Prelinked->PrelinkedStateSectionKernel = MachoGetSectionByName64 (
+      Prelinked->PrelinkedStateSectionKernel = MachoGetSectionByName (
         &Prelinked->PrelinkedMachContext,
         Prelinked->PrelinkedStateSegment,
         PRELINK_STATE_SECTION_KERNEL
         );
-      Prelinked->PrelinkedStateSectionKexts = MachoGetSectionByName64 (
+      Prelinked->PrelinkedStateSectionKexts = MachoGetSectionByName (
         &Prelinked->PrelinkedMachContext,
         Prelinked->PrelinkedStateSegment,
         PRELINK_STATE_SECTION_KEXTS
         );
 
+      KernelSize = Prelinked->Is32Bit ?
+        Prelinked->PrelinkedStateSectionKernel->Section32.Size :
+        Prelinked->PrelinkedStateSectionKernel->Section64.Size;
+      KextsSize = Prelinked->Is32Bit ?
+        Prelinked->PrelinkedStateSectionKexts->Section32.Size :
+        Prelinked->PrelinkedStateSectionKexts->Section64.Size;
+      KernelOffset = Prelinked->Is32Bit ?
+        Prelinked->PrelinkedStateSectionKernel->Section32.Offset :
+        Prelinked->PrelinkedStateSectionKernel->Section64.Offset;
+      KextsOffset = Prelinked->Is32Bit ?
+        Prelinked->PrelinkedStateSectionKexts->Section32.Offset :
+        Prelinked->PrelinkedStateSectionKexts->Section64.Offset;
+
       if (Prelinked->PrelinkedStateSectionKernel != NULL
         && Prelinked->PrelinkedStateSectionKexts != NULL
-        && Prelinked->PrelinkedStateSectionKernel->Size > 0
-        && Prelinked->PrelinkedStateSectionKexts->Size > 0) {
-        Prelinked->PrelinkedStateKernelSize = (UINT32) Prelinked->PrelinkedStateSectionKernel->Size;
-        Prelinked->PrelinkedStateKextsSize = (UINT32) Prelinked->PrelinkedStateSectionKexts->Size;
+        && KernelSize > 0
+        && KextsSize > 0) {
+        Prelinked->PrelinkedStateKernelSize = (UINT32) KernelSize;
+        Prelinked->PrelinkedStateKextsSize = (UINT32) KextsSize;
         Prelinked->PrelinkedStateKernel = AllocateCopyPool (
           Prelinked->PrelinkedStateKernelSize,
-          &Prelinked->Prelinked[Prelinked->PrelinkedStateSectionKernel->Offset]
+          &Prelinked->Prelinked[KernelOffset]
           );
         Prelinked->PrelinkedStateKexts = AllocateCopyPool (
           Prelinked->PrelinkedStateKextsSize,
-          &Prelinked->Prelinked[Prelinked->PrelinkedStateSectionKexts->Offset]
+          &Prelinked->Prelinked[KextsOffset]
           );
       }
 
       if (Prelinked->PrelinkedStateKernel != NULL
         && Prelinked->PrelinkedStateKexts != NULL) {
-        Prelinked->PrelinkedStateKextsAddress = Prelinked->PrelinkedStateSectionKexts->Address;
+        Prelinked->PrelinkedStateKextsAddress = Prelinked->Is32Bit ?
+          Prelinked->PrelinkedStateSectionKexts->Section32.Address :
+          Prelinked->PrelinkedStateSectionKexts->Section64.Address;
         NewKext->Context.KxldState = Prelinked->PrelinkedStateKernel;
         NewKext->Context.KxldStateSize = Prelinked->PrelinkedStateKernelSize;
       } else {
@@ -1070,7 +1107,7 @@ InternalLinkPrelinkedKext (
   Kext->Context.VirtualBase = LoadAddress;
   Kext->Context.VirtualKmod = KmodAddress;
 
-  Status = InternalPrelinkKext64 (Context, Kext, LoadAddress);
+  Status = InternalPrelinkKext (Context, Kext, LoadAddress);
 
   if (EFI_ERROR (Status)) {
     InternalFreePrelinkedKext (Kext);

--- a/Library/OcAppleKernelLib/Vtables.c
+++ b/Library/OcAppleKernelLib/Vtables.c
@@ -521,7 +521,7 @@ InternalInitializeVtablePatchData (
   // Assumption: Not ARM (ARM requires an alignment to the function pointer
   //             retrieved from VtableData.
   //
-  MaxSymbols     = (*MaxSize / sizeof (*SolveSymbols)); // FIXME valid for both?
+  MaxSymbols     = (*MaxSize / (MachoContext->Is32Bit ? sizeof (MACH_NLIST) : sizeof (MACH_NLIST_64)));
   VtableMaxSize /= VTABLE_ENTRY_SIZE_X (MachoContext->Is32Bit);
 
   SymIndex = 0;
@@ -551,7 +551,7 @@ InternalInitializeVtablePatchData (
         // If the VTable entry is 0 and it is not referenced by a Relocation,
         // it is the end of the table.
         //
-        *MaxSize      -= (SymIndex * sizeof (*SolveSymbols)); // FIXME valid for both?
+        *MaxSize      -= (SymIndex * (MachoContext->Is32Bit ? sizeof (MACH_NLIST) : sizeof (MACH_NLIST_64)));
         *VtableDataPtr = VtableData;
         *NumEntries    = (EntryOffset - VTABLE_HEADER_LEN);
         *NumSymbols    = SymIndex;

--- a/Library/OcAppleKernelLib/Vtables.c
+++ b/Library/OcAppleKernelLib/Vtables.c
@@ -120,7 +120,7 @@ InternalConstructVtablePrelinked64 (
   //
   for (
     Index = 0;
-    (Value = VtableData[Index + VTABLE_HEADER_LEN_64]) != 0;
+    (Value = VtableData[Index + VTABLE_HEADER_LEN]) != 0;
     ++Index
     ) {
 
@@ -163,14 +163,14 @@ InternalGetVtableEntries64 (
   //             retrieved from VtableData.
   //
   MaxSize /= VTABLE_ENTRY_SIZE_64;
-  Index    = VTABLE_HEADER_LEN_64;
+  Index    = VTABLE_HEADER_LEN;
   do {
     if (Index >= MaxSize) {
       return FALSE;
     }
   } while (VtableData[Index++] != 0);
 
-  *NumEntries = (Index - VTABLE_HEADER_LEN_64);
+  *NumEntries = (Index - VTABLE_HEADER_LEN);
   return TRUE;
 }
 
@@ -262,7 +262,7 @@ InternalPatchVtableSymbol (
   IN OUT OC_MACHO_CONTEXT              *MachoContext,
   IN     CONST PRELINKED_VTABLE_ENTRY  *ParentEntry,
   IN     CONST CHAR8                   *VtableName,
-  OUT    MACH_NLIST_64                 *Symbol
+  OUT    MACH_NLIST_ANY                *Symbol
   )
 {
   CONST CHAR8 *Name;
@@ -285,11 +285,11 @@ InternalPatchVtableSymbol (
   //
   // 1) If the symbol is defined locally, do not patch
   //
-  if (MachoSymbolIsLocalDefined64 (MachoContext, Symbol)) {
+  if (MachoSymbolIsLocalDefined (MachoContext, Symbol)) {
     return TRUE;
   }
 
-  Name = MachoGetSymbolName64 (MachoContext, Symbol);
+  Name = MachoGetSymbolName (MachoContext, Symbol);
   //
   // 2) If the child is a pure virtual function, do not patch.
   // In general, we want to proceed with patching when the symbol is
@@ -325,7 +325,7 @@ InternalPatchVtableSymbol (
   // declared as part of the class and not inherited, which means we
   // should not patch it.
   //
-  if (!MachoSymbolIsDefined64 (Symbol)) {
+  if (!MachoSymbolIsDefined (MachoContext, Symbol)) {
     ClassName = MachoGetClassNameFromVtableName (VtableName);
 
     Success = MachoGetFunctionPrefixFromClassName (
@@ -363,7 +363,7 @@ InternalPatchVtableSymbol (
   //       changed for the symbol value is already resolved and nothing but a
   //       VTable Relocation should reference it.
   //
-  InternalSolveSymbolValue64 (ParentEntry->Address, Symbol);
+  InternalSolveSymbolValue (MachoContext->Is32Bit, ParentEntry->Address, Symbol);
   //
   // The C++ ABI requires that functions be aligned on a 2-byte boundary:
   // http://www.codesourcery.com/public/cxx-abi/abi.html#member-pointers
@@ -373,7 +373,8 @@ InternalPatchVtableSymbol (
   // context.
   //
   Name = ParentEntry->Name;
-  if (!MachoSymbolNameIsPureVirtual (Name) && ((Symbol->Value & 1U) != 0)) {
+  if (!MachoSymbolNameIsPureVirtual (Name)
+    && (((MachoContext->Is32Bit ? Symbol->Symbol32.Value : Symbol->Symbol64.Value) & 1U) != 0)) {
     DEBUG ((DEBUG_WARN, "OCAK: Prelink: Invalid VTable symbol\n"));
   }
 
@@ -382,14 +383,14 @@ InternalPatchVtableSymbol (
 
 STATIC
 BOOLEAN
-InternalInitializeVtableByEntriesAndRelocations64 (
+InternalInitializeVtableByEntriesAndRelocations (
   IN     PRELINKED_CONTEXT            *Context,
   IN     PRELINKED_KEXT               *Kext,
   IN     CONST PRELINKED_VTABLE       *SuperVtable,
-  IN     CONST MACH_NLIST_64          *VtableSymbol,
+  IN     CONST MACH_NLIST_ANY         *VtableSymbol,
   IN     CONST UINT64                 *VtableData,
   IN     UINT32                       NumSolveSymbols,
-  IN OUT MACH_NLIST_64                **SolveSymbols,
+  IN OUT MACH_NLIST_ANY               **SolveSymbols,
   OUT    PRELINKED_VTABLE             *Vtable
   )
 {
@@ -401,19 +402,19 @@ InternalInitializeVtableByEntriesAndRelocations64 (
   UINT64                     EntryValue;
   UINT32                     SolveSymbolIndex;
   BOOLEAN                    Result;
-  MACH_NLIST_64              *Symbol;
+  MACH_NLIST_ANY             *Symbol;
 
   MachoContext  = &Kext->Context.MachContext;
   VtableEntries = Vtable->Entries;
 
-  VtableName       = MachoGetSymbolName64 (MachoContext, VtableSymbol);
+  VtableName       = MachoGetSymbolName (MachoContext, VtableSymbol);
   SolveSymbolIndex = 0;
   //
   // Assumption: Not ARM (ARM requires an alignment to the function pointer
   //             retrieved from VtableData.
   //
   for (Index = 0; Index < SuperVtable->NumEntries; ++Index) {
-    EntryValue = VtableData[Index + VTABLE_HEADER_LEN_64];
+    EntryValue = VtableData[Index + VTABLE_HEADER_LEN];
     if (EntryValue != 0) {
       //
       // If we can't find a symbol, it means it is a locally-defined,
@@ -459,8 +460,8 @@ InternalInitializeVtableByEntriesAndRelocations64 (
           return FALSE;
         }
 
-        VtableEntries[Index].Name    = MachoGetSymbolName64 (MachoContext, Symbol);
-        VtableEntries[Index].Address = Symbol->Value;
+        VtableEntries[Index].Name    = MachoGetSymbolName (MachoContext, Symbol);
+        VtableEntries[Index].Address = Context->Is32Bit ? Symbol->Symbol32.Value : Symbol->Symbol64.Value;
         continue;
       }
     }
@@ -479,28 +480,26 @@ STATIC
 BOOLEAN
 InternalInitializeVtablePatchData (
   IN OUT OC_MACHO_CONTEXT     *MachoContext,
-  IN     CONST MACH_NLIST_64  *VtableSymbol,
+  IN     CONST MACH_NLIST_ANY *VtableSymbol,
   IN OUT UINT32               *MaxSize,
-  OUT    UINT64               **VtableDataPtr,
+  OUT    VOID                 **VtableDataPtr,
   OUT    UINT32               *NumEntries,
   OUT    UINT32               *NumSymbols,
-  OUT    MACH_NLIST_64        **SolveSymbols
+  OUT    MACH_NLIST_ANY       **SolveSymbols
   )
 {
-  BOOLEAN              Result;
-  UINT32               VtableOffset;
-  UINT32               VtableMaxSize;
-  CONST MACH_HEADER_64 *MachHeader;
-  UINT64               *VtableData;
-  UINT32               SymIndex;
-  UINT32               EntryOffset;
-  UINT64               FileOffset;
-  UINT32               MaxSymbols;
-  MACH_NLIST_64        *Symbol;
+  BOOLEAN               Result;
+  UINT32                VtableOffset;
+  UINT32                VtableMaxSize;
+  CONST MACH_HEADER_ANY *MachHeader;
+  VOID                  *VtableData;
+  UINT32                SymIndex;
+  UINT32                EntryOffset;
+  UINT64                FileOffset;
+  UINT32                MaxSymbols;
+  MACH_NLIST_ANY        *Symbol;
 
-  VOID                 *Tmp;
-
-  Result = MachoSymbolGetFileOffset64 (
+  Result = MachoSymbolGetFileOffset (
              MachoContext,
              VtableSymbol,
              &VtableOffset,
@@ -510,39 +509,38 @@ InternalInitializeVtablePatchData (
     return FALSE;
   }
 
-  MachHeader = MachoGetMachHeader64 (MachoContext);
+  MachHeader = MachoGetMachHeader (MachoContext);
   ASSERT (MachHeader != NULL);
 
-  Tmp = (VOID *)((UINTN)MachHeader + VtableOffset);
-  if (!OC_TYPE_ALIGNED (UINT64, Tmp)) {
+  VtableData = (VOID *)((UINTN) MachHeader + VtableOffset);
+  if (MachoContext->Is32Bit ? !OC_TYPE_ALIGNED (UINT32, VtableData) : !OC_TYPE_ALIGNED (UINT64, VtableData)) {
     return FALSE;
   }
-  VtableData = (UINT64 *)Tmp;
   //
   // Assumption: Not ARM (ARM requires an alignment to the function pointer
   //             retrieved from VtableData.
   //
-  MaxSymbols     = (*MaxSize / sizeof (*SolveSymbols));
-  VtableMaxSize /= VTABLE_ENTRY_SIZE_64;
+  MaxSymbols     = (*MaxSize / sizeof (*SolveSymbols)); // FIXME valid for both?
+  VtableMaxSize /= MachoContext->Is32Bit ? VTABLE_ENTRY_SIZE_32 : VTABLE_ENTRY_SIZE_64;
 
   SymIndex = 0;
 
   for (
-    EntryOffset = VTABLE_HEADER_LEN_64;
+    EntryOffset = VTABLE_HEADER_LEN;
     EntryOffset < VtableMaxSize;
     ++EntryOffset
     ) {
-    if (VtableData[EntryOffset] == 0) {
+    if ((MachoContext->Is32Bit ? ((UINT32 *) VtableData)[EntryOffset] : ((UINT64 *) VtableData)[EntryOffset]) == 0) {
       Result = OcOverflowAddU64 (
-                 VtableSymbol->Value,
-                 (EntryOffset * VTABLE_ENTRY_SIZE_64),
+                 MachoContext->Is32Bit ? VtableSymbol->Symbol32.Value : VtableSymbol->Symbol64.Value,
+                 (EntryOffset * (MachoContext->Is32Bit ? VTABLE_ENTRY_SIZE_32 : VTABLE_ENTRY_SIZE_64)),
                  &FileOffset
                  );
       if (Result) {
         return FALSE;
       }
 
-      Result = MachoGetSymbolByExternRelocationOffset64 (
+      Result = MachoGetSymbolByExternRelocationOffset (
                  MachoContext,
                  FileOffset,
                  &Symbol
@@ -552,9 +550,9 @@ InternalInitializeVtablePatchData (
         // If the VTable entry is 0 and it is not referenced by a Relocation,
         // it is the end of the table.
         //
-        *MaxSize      -= (SymIndex * sizeof (*SolveSymbols));
+        *MaxSize      -= (SymIndex * sizeof (*SolveSymbols)); // FIXME valid for both?
         *VtableDataPtr = VtableData;
-        *NumEntries    = (EntryOffset - VTABLE_HEADER_LEN_64);
+        *NumEntries    = (EntryOffset - VTABLE_HEADER_LEN);
         *NumSymbols    = SymIndex;
         return TRUE;
       }
@@ -581,28 +579,29 @@ InternalPatchByVtables64 (
   OC_VTABLE_PATCH_ENTRY *EntryWalker;
   UINT32                MaxSize;
 
-  OC_MACHO_CONTEXT     *MachoContext;
-  CONST MACH_HEADER_64 *MachHeader;
-  UINT32               Index;
-  UINT32               NumTables;
-  UINT32               NumEntries;
-  UINT32               NumEntriesTemp;
-  UINT32               NumPatched;
-  BOOLEAN              Result;
-  CONST MACH_NLIST_64  *Smcp;
-  CONST CHAR8          *Name;
-  CONST MACH_NLIST_64  *MetaClass;
-  CONST PRELINKED_VTABLE *SuperVtable;
-  CONST PRELINKED_VTABLE *MetaVtable;
-  CONST VOID           *OcSymbolDummy;
-  MACH_NLIST_64        *SymbolDummy;
-  CHAR8                ClassName[SYM_MAX_NAME_LEN];
-  CHAR8                SuperClassName[SYM_MAX_NAME_LEN];
-  CHAR8                VtableName[SYM_MAX_NAME_LEN];
-  CHAR8                SuperVtableName[SYM_MAX_NAME_LEN];
-  CHAR8                FinalSymbolName[SYM_MAX_NAME_LEN];
-  BOOLEAN              SuccessfulIteration;
-  PRELINKED_VTABLE     *CurrentVtable;
+  OC_MACHO_CONTEXT        *MachoContext;
+  CONST MACH_HEADER_ANY   *MachHeader;
+  UINT32                  Index;
+  UINT32                  NumTables;
+  UINT32                  NumEntries;
+  UINT32                  NumEntriesTemp;
+  UINT32                  NumPatched;
+  BOOLEAN                 Result;
+  CONST MACH_NLIST_ANY    *Smcp;
+  CONST CHAR8             *Name;
+  CONST MACH_NLIST_ANY    *MetaClass;
+  CONST PRELINKED_VTABLE  *SuperVtable;
+  CONST PRELINKED_VTABLE  *MetaVtable;
+  CONST VOID              *OcSymbolDummy;
+  MACH_NLIST_ANY          *SymbolDummy;
+  CHAR8                   ClassName[SYM_MAX_NAME_LEN];
+  CHAR8                   SuperClassName[SYM_MAX_NAME_LEN];
+  CHAR8                   VtableName[SYM_MAX_NAME_LEN];
+  CHAR8                   SuperVtableName[SYM_MAX_NAME_LEN];
+  CHAR8                   FinalSymbolName[SYM_MAX_NAME_LEN];
+  BOOLEAN                 SuccessfulIteration;
+  PRELINKED_VTABLE        *CurrentVtable;
+
   //
   // LinkBuffer is at least as big as __LINKEDIT, so it can store all symbols.
   //
@@ -611,7 +610,7 @@ InternalPatchByVtables64 (
 
   MachoContext = &Kext->Context.MachContext;
 
-  MachHeader = MachoGetMachHeader64 (MachoContext);
+  MachHeader = MachoGetMachHeader (MachoContext);
   ASSERT (MachHeader != NULL);
   //
   // Retrieve all SMCPs.
@@ -622,11 +621,11 @@ InternalPatchByVtables64 (
 
   for (
     Index = 0;
-    (Smcp = MachoGetSymbolByIndex64 (MachoContext, Index)) != NULL;
+    (Smcp = MachoGetSymbolByIndex (MachoContext, Index)) != NULL;
     ++Index
     ) {
-    Name = MachoGetSymbolName64 (MachoContext, Smcp);
-    if (((Smcp->Type & MACH_N_TYPE_STAB) == 0)
+    Name = MachoGetSymbolName (MachoContext, Smcp);
+    if ((((Context->Is32Bit ? Smcp->Symbol32.Type : Smcp->Symbol64.Type) & MACH_N_TYPE_STAB) == 0)
      && MachoSymbolNameIsSmcp (MachoContext, Name)) {
       if (MaxSize < sizeof (*EntryWalker)) {
         return FALSE;
@@ -637,7 +636,7 @@ InternalPatchByVtables64 (
       // number of vtables we're expecting, because every pointer will have a
       // class vtable and a MetaClass vtable.
       //
-      Result = MachoGetVtableSymbolsFromSmcp64 (
+      Result = MachoGetVtableSymbolsFromSmcp (
                  MachoContext,
                  Name,
                  &EntryWalker->Vtable,
@@ -715,7 +714,7 @@ InternalPatchByVtables64 (
         continue;
       }
 
-      Name = MachoGetSymbolName64 (MachoContext, Smcp);
+      Name = MachoGetSymbolName (MachoContext, Smcp);
       //
       // We walk over the super metaclass pointer symbols because classes
       // with them are the only ones that need patching.  Then we double the
@@ -749,7 +748,7 @@ InternalPatchByVtables64 (
       //
       // Find the SMCP's meta class symbol
       //
-      MetaClass = MachoGetMetaclassSymbolFromSmcpSymbol64 (
+      MetaClass = MachoGetMetaclassSymbolFromSmcpSymbol (
                     MachoContext,
                     Smcp
                     );
@@ -761,7 +760,7 @@ InternalPatchByVtables64 (
       //
       Result = MachoGetClassNameFromMetaClassPointer (
                  MachoContext,
-                 MachoGetSymbolName64 (MachoContext, MetaClass),
+                 MachoGetSymbolName (MachoContext, MetaClass),
                  sizeof (SuperClassName),
                  SuperClassName
                  );
@@ -815,7 +814,7 @@ InternalPatchByVtables64 (
         return FALSE;
       }
 
-      SymbolDummy = MachoGetLocalDefinedSymbolByName64 (
+      SymbolDummy = MachoGetLocalDefinedSymbolByName (
                   MachoContext,
                   FinalSymbolName
                   );
@@ -825,7 +824,7 @@ InternalPatchByVtables64 (
       //
       // Patch the class's vtable
       //
-      Result = InternalInitializeVtableByEntriesAndRelocations64 (
+      Result = InternalInitializeVtableByEntriesAndRelocations (
                  Context,
                  Kext,
                  SuperVtable,
@@ -879,7 +878,7 @@ InternalPatchByVtables64 (
       // case, we just reduce the expect number of vtables by 1.
       // Only i386 does not support strict patchting.
       //
-      Result = InternalInitializeVtableByEntriesAndRelocations64 (
+      Result = InternalInitializeVtableByEntriesAndRelocations (
                  Context,
                  Kext,
                  SuperVtable,

--- a/Library/OcAppleKernelLib/Vtables.c
+++ b/Library/OcAppleKernelLib/Vtables.c
@@ -1,6 +1,5 @@
 /** @file
   Library handling KEXT prelinking.
-  Currently limited to Intel 64 architectures.
 
 Copyright (c) 2018, Download-Fritz.  All rights reserved.<BR>
 This program and the accompanying materials are licensed and made available

--- a/Library/OcMachoLib/CxxSymbols.c
+++ b/Library/OcMachoLib/CxxSymbols.c
@@ -393,3 +393,31 @@ MachoSymbolNameIsCxx (
   ASSERT (Name != NULL);
   return AsciiStrnCmp (Name, CXX_PREFIX, L_STR_LEN (CXX_PREFIX)) == 0;
 }
+
+MACH_NLIST_ANY *
+MachoGetMetaclassSymbolFromSmcpSymbol (
+  IN OUT OC_MACHO_CONTEXT     *Context,
+  IN     CONST MACH_NLIST_ANY  *Smcp
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    (MACH_NLIST_ANY *) MachoGetMetaclassSymbolFromSmcpSymbol32 (Context, &Smcp->Symbol32) :
+    (MACH_NLIST_ANY *) MachoGetMetaclassSymbolFromSmcpSymbol64 (Context, &Smcp->Symbol64);
+}
+
+BOOLEAN
+MachoGetVtableSymbolsFromSmcp (
+  IN OUT OC_MACHO_CONTEXT     *Context,
+  IN     CONST CHAR8          *SmcpName,
+  OUT    CONST MACH_NLIST_ANY **Vtable,
+  OUT    CONST MACH_NLIST_ANY **MetaVtable
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    MachoGetVtableSymbolsFromSmcp32 (Context, SmcpName, (CONST MACH_NLIST **) Vtable, (CONST MACH_NLIST **) MetaVtable) :
+    MachoGetVtableSymbolsFromSmcp64 (Context, SmcpName, (CONST MACH_NLIST_64 **) Vtable, (CONST MACH_NLIST_64 **) MetaVtable);
+}

--- a/Library/OcMachoLib/Header.c
+++ b/Library/OcMachoLib/Header.c
@@ -655,8 +655,20 @@ MachoExpandImage (
   ASSERT (Context != NULL);
 
   return Context->Is32Bit ?
-    InternalMachoExpandImage32 (Context, Destination, DestinationSize, Strip, (UINT32 *) FileOffset) :
-    InternalMachoExpandImage64 (Context, Destination, DestinationSize, Strip, FileOffset);
+    InternalMachoExpandImage32 (Context, FALSE, Destination, DestinationSize, Strip, (UINT32 *) FileOffset) :
+    InternalMachoExpandImage64 (Context, FALSE, Destination, DestinationSize, Strip, FileOffset);
+}
+
+UINT32
+MachoGetExpandedImageSize (
+  IN  OC_MACHO_CONTEXT   *Context
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    MACHO_ALIGN (InternalMachoExpandImage32 (Context, TRUE, NULL, 0, FALSE, NULL)) :
+    MACHO_ALIGN (InternalMachoExpandImage64 (Context, TRUE, NULL, 0, FALSE, NULL));
 }
 
 BOOLEAN

--- a/Library/OcMachoLib/Header.c
+++ b/Library/OcMachoLib/Header.c
@@ -648,14 +648,15 @@ MachoExpandImage (
   IN  OC_MACHO_CONTEXT   *Context,
   OUT UINT8              *Destination,
   IN  UINT32             DestinationSize,
-  IN  BOOLEAN            Strip
+  IN  BOOLEAN            Strip,
+  OUT UINT64             *FileOffset OPTIONAL
   )
 {
   ASSERT (Context != NULL);
 
   return Context->Is32Bit ?
-    InternalMachoExpandImage32 (Context, Destination, DestinationSize, Strip) :
-    InternalMachoExpandImage64 (Context, Destination, DestinationSize, Strip);
+    InternalMachoExpandImage32 (Context, Destination, DestinationSize, Strip, (UINT32 *) FileOffset) :
+    InternalMachoExpandImage64 (Context, Destination, DestinationSize, Strip, FileOffset);
 }
 
 BOOLEAN

--- a/Library/OcMachoLib/Header.c
+++ b/Library/OcMachoLib/Header.c
@@ -187,6 +187,20 @@ MachoGetSectionByName (
     (MACH_SECTION_ANY *) MachoGetSectionByName64 (Context, &Segment->Segment64, SectionName);
 }
 
+MACH_SECTION_ANY *
+MachoGetSegmentSectionByName (
+  IN OUT OC_MACHO_CONTEXT  *Context,
+  IN     CONST CHAR8       *SegmentName,
+  IN     CONST CHAR8       *SectionName
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    (MACH_SECTION_ANY *) MachoGetSegmentSectionByName32 (Context, SegmentName, SectionName) :
+    (MACH_SECTION_ANY *) MachoGetSegmentSectionByName64 (Context, SegmentName, SectionName);
+}
+
 /**
   Initialises the symbol information of Context.
 

--- a/Library/OcMachoLib/Header.c
+++ b/Library/OcMachoLib/Header.c
@@ -72,6 +72,17 @@ MachoGetVmSize (
     InternalMachoGetVmSize32 (Context) : InternalMachoGetVmSize64 (Context);
 }
 
+UINT64
+MachoGetLastAddress (
+  IN OUT OC_MACHO_CONTEXT  *Context
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    InternalMachoGetLastAddress32 (Context) : InternalMachoGetLastAddress64 (Context);
+}
+
 MACH_LOAD_COMMAND *
 MachoGetNextCommand (
   IN OUT OC_MACHO_CONTEXT         *Context,
@@ -132,6 +143,34 @@ MachoGetNextSegment (
   return Context->Is32Bit ?
     (MACH_SEGMENT_COMMAND_ANY *) MachoGetNextSegment32 (Context, Segment != NULL ? &Segment->Segment32 : NULL) :
     (MACH_SEGMENT_COMMAND_ANY *) MachoGetNextSegment64 (Context, Segment != NULL ? &Segment->Segment64 : NULL);
+}
+
+MACH_SECTION_ANY *
+MachoGetNextSection (
+  IN OUT OC_MACHO_CONTEXT         *Context,
+  IN     MACH_SEGMENT_COMMAND_ANY *Segment,
+  IN     MACH_SECTION_ANY         *Section  OPTIONAL
+  )
+{
+  ASSERT (Context != NULL);
+  ASSERT (Segment != NULL);
+
+  return Context->Is32Bit ?
+    (MACH_SECTION_ANY *) MachoGetNextSection32 (Context, &Segment->Segment32, Section != NULL ? &Section->Section32 : NULL) :
+    (MACH_SECTION_ANY *) MachoGetNextSection64 (Context, &Segment->Segment64, Section != NULL ? &Section->Section64 : NULL);
+}
+
+MACH_SEGMENT_COMMAND_ANY *
+MachoGetSegmentByName (
+  IN OUT OC_MACHO_CONTEXT  *Context,
+  IN     CONST CHAR8       *SegmentName
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    (MACH_SEGMENT_COMMAND_ANY *) MachoGetSegmentByName32 (Context, SegmentName) :
+    (MACH_SEGMENT_COMMAND_ANY *) MachoGetSegmentByName64 (Context, SegmentName);
 }
 
 MACH_SECTION_ANY *
@@ -449,6 +488,59 @@ InternalRetrieveSymtabs (
   // Retrieve the symbol information for Context from itself.
   //
   return MachoInitialiseSymtabsExternal (Context, Context);
+}
+
+UINT32
+MachoGetSymbolTable (
+  IN OUT OC_MACHO_CONTEXT     *Context,
+     OUT CONST MACH_NLIST_ANY **SymbolTable,
+     OUT CONST CHAR8          **StringTable OPTIONAL,
+     OUT CONST MACH_NLIST_ANY **LocalSymbols OPTIONAL,
+     OUT UINT32               *NumLocalSymbols OPTIONAL,
+     OUT CONST MACH_NLIST_ANY **ExternalSymbols OPTIONAL,
+     OUT UINT32               *NumExternalSymbols OPTIONAL,
+     OUT CONST MACH_NLIST_ANY **UndefinedSymbols OPTIONAL,
+     OUT UINT32               *NumUndefinedSymbols OPTIONAL
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    MachoGetSymbolTable32 (
+      Context,
+      (CONST MACH_NLIST **) SymbolTable,
+      StringTable,
+      (CONST MACH_NLIST **) LocalSymbols,
+      NumLocalSymbols,
+      (CONST MACH_NLIST **) ExternalSymbols,
+      NumExternalSymbols, 
+      (CONST MACH_NLIST **) UndefinedSymbols,
+      NumUndefinedSymbols
+      ) :
+    MachoGetSymbolTable64 (
+      Context,
+      (CONST MACH_NLIST_64 **) SymbolTable,
+      StringTable,
+      (CONST MACH_NLIST_64 **) LocalSymbols,
+      NumLocalSymbols,
+      (CONST MACH_NLIST_64 **) ExternalSymbols,
+      NumExternalSymbols, 
+      (CONST MACH_NLIST_64 **) UndefinedSymbols,
+      NumUndefinedSymbols
+      );
+}
+
+UINT32
+MachoGetIndirectSymbolTable (
+  IN OUT OC_MACHO_CONTEXT     *Context,
+     OUT CONST MACH_NLIST_ANY **SymbolTable
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    MachoGetIndirectSymbolTable32 (Context, (CONST MACH_NLIST **) SymbolTable) :
+    MachoGetIndirectSymbolTable64 (Context, (CONST MACH_NLIST_64 **) SymbolTable);
 }
 
 UINT64

--- a/Library/OcMachoLib/Header.c
+++ b/Library/OcMachoLib/Header.c
@@ -160,6 +160,19 @@ MachoGetNextSection (
     (MACH_SECTION_ANY *) MachoGetNextSection64 (Context, &Segment->Segment64, Section != NULL ? &Section->Section64 : NULL);
 }
 
+MACH_SECTION_ANY *
+MachoGetSectionByIndex (
+  IN OUT OC_MACHO_CONTEXT  *Context,
+  IN     UINT32            Index
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    (MACH_SECTION_ANY *) MachoGetSectionByIndex32 (Context, Index) :
+    (MACH_SECTION_ANY *) MachoGetSectionByIndex64 (Context, Index);
+}
+
 MACH_SEGMENT_COMMAND_ANY *
 MachoGetSegmentByName (
   IN OUT OC_MACHO_CONTEXT  *Context,
@@ -622,7 +635,7 @@ MachoGetFilePointerByAddress (
   ASSERT (Context != NULL);
 
   if (Context->Is32Bit) {
-    ASSERT (Address > MAX_UINT32);
+    ASSERT (Address < MAX_UINT32);
   }
 
   return Context->Is32Bit ?

--- a/Library/OcMachoLib/HeaderX.h
+++ b/Library/OcMachoLib/HeaderX.h
@@ -290,8 +290,8 @@ MACH_X (InternalMachoExpandImage) (
   MACH_UINT_X               CopyFileOffset;
   MACH_UINT_X               CopyFileSize;
   MACH_UINT_X               CopyVmSize;
-  UINTN                     RelocationsSize;
-  UINTN                     SymtabSize;
+  UINT32                    RelocationsSize;
+  UINT32                    SymtabSize;
   UINT32                    CurrentDelta;
   UINT32                    OriginalDelta;
   MACH_UINT_X               CurrentSize;

--- a/Library/OcMachoLib/HeaderX.h
+++ b/Library/OcMachoLib/HeaderX.h
@@ -290,8 +290,8 @@ MACH_X (InternalMachoExpandImage) (
   MACH_UINT_X               CopyFileOffset;
   MACH_UINT_X               CopyFileSize;
   MACH_UINT_X               CopyVmSize;
-  MACH_UINT_X               RelocationsSize;
-  MACH_UINT_X               SymtabSize;
+  UINTN                     RelocationsSize;
+  UINTN                     SymtabSize;
   UINT32                    CurrentDelta;
   UINT32                    OriginalDelta;
   MACH_UINT_X               CurrentSize;

--- a/Library/OcMachoLib/HeaderX.h
+++ b/Library/OcMachoLib/HeaderX.h
@@ -331,6 +331,7 @@ MACH_X (InternalMachoExpandImage) (
   // Align header size to page size if this is an MH_OBJECT.
   // The header does not exist in a segment in MH_OBJECT files.
   //
+  HeaderSizeAligned = 0;
   if (IsObject) {
     HeaderSizeAligned = MACHO_ALIGN (HeaderSize);
     if (!CalculateSizeOnly) {

--- a/Library/OcMachoLib/HeaderX.h
+++ b/Library/OcMachoLib/HeaderX.h
@@ -387,7 +387,7 @@ MACH_X (InternalMachoExpandImage) (
       // Some kexts seem to have empty space after header and before segment.
       //
       if (CopyFileOffset > HeaderSize) {
-        CurrentDelta -= CopyFileOffset - HeaderSize;
+        CurrentDelta -= (UINT32) (CopyFileOffset - HeaderSize);
       }
       if (FileOffset != NULL) {
         *FileOffset = HeaderSizeAligned;

--- a/Library/OcMachoLib/HeaderX.h
+++ b/Library/OcMachoLib/HeaderX.h
@@ -310,6 +310,9 @@ MACH_X (InternalMachoExpandImage) (
   }
   CopyMem (Destination, Header, HeaderSize);
 
+
+    DEBUG ((DEBUG_INFO, "here2\n"));
+
   CurrentDelta = 0;
   FirstSegment = NULL;
   CurrentSize  = 0;
@@ -331,6 +334,9 @@ MACH_X (InternalMachoExpandImage) (
       FirstSegment = Segment;
     }
 
+
+    DEBUG ((DEBUG_INFO, "here3\n"));
+
     //
     // Do not overwrite header.
     //
@@ -348,6 +354,9 @@ MACH_X (InternalMachoExpandImage) (
         return 0;
       }
     }
+
+
+    DEBUG ((DEBUG_INFO, "here4\n"));
     //
     // Ensure that it still fits. In legit files segments are ordered.
     // We do not care for other (the file will be truncated).
@@ -373,9 +382,11 @@ MACH_X (InternalMachoExpandImage) (
     DstSegment->FileOffset += CurrentDelta;
     DstSegment->FileSize    = DstSegment->Size;
 
-    if (DstSegment->VirtualAddress - (DstSegment->FileOffset - Context->ContainerOffset) != FirstSegment->VirtualAddress) {
+    /*if (DstSegment->VirtualAddress - (DstSegment->FileOffset - Context->ContainerOffset) != FirstSegment->VirtualAddress) {
       return 0;
-    }
+    }*/
+
+    DEBUG ((DEBUG_INFO, "here\n"));
 
     //
     // We need to update fields in SYMTAB and DYSYMTAB. Tables have to be present before 0 FileSize
@@ -731,7 +742,7 @@ MACH_X (MachoGetMachHeader) (
 }
 
 MACH_UINT_X
-MACH_X (MachoGetLastAddress) (
+MACH_X (InternalMachoGetLastAddress) (
   IN OUT OC_MACHO_CONTEXT  *Context
   )
 {

--- a/Library/OcMachoLib/HeaderX.h
+++ b/Library/OcMachoLib/HeaderX.h
@@ -382,7 +382,7 @@ MACH_X (InternalMachoExpandImage) (
     DstSegment->FileOffset += CurrentDelta;
     DstSegment->FileSize    = DstSegment->Size;
 
-    /*if (DstSegment->VirtualAddress - (DstSegment->FileOffset - Context->ContainerOffset) != FirstSegment->VirtualAddress) {
+    /*if (DstSegment->VirtualAddress - (DstSegment->FileOffset - Context->ContainerOffset) != FirstSegment->VirtualAddress) { // FIXME: This is invalid on 32-bit
       return 0;
     }*/
 

--- a/Library/OcMachoLib/OcMachoLibInternal.h
+++ b/Library/OcMachoLib/OcMachoLibInternal.h
@@ -153,6 +153,32 @@ InternalMachoGetVmSize64 (
   );
 
 /**
+  Returns the last virtual address of a 32-bit Mach-O.
+
+  @param[in] Context  Context of the Mach-O.
+
+  @retval 0  The binary is malformed.
+
+**/
+UINT32
+InternalMachoGetLastAddress32 (
+  IN OUT OC_MACHO_CONTEXT  *Context
+  );
+
+/**
+  Returns the last virtual address of a 64-bit Mach-O.
+
+  @param[in] Context  Context of the Mach-O.
+
+  @retval 0  The binary is malformed.
+
+**/
+UINT64
+InternalMachoGetLastAddress64 (
+  IN OUT OC_MACHO_CONTEXT  *Context
+  );
+
+/**
   Retrieves the next 32-bit Load Command of type LoadCommandType.
 
   @param[in,out] Context          Context of the Mach-O.

--- a/Library/OcMachoLib/OcMachoLibInternal.h
+++ b/Library/OcMachoLib/OcMachoLibInternal.h
@@ -247,11 +247,12 @@ InternalMachoGetFilePointerByAddress64 (
 /**
   Expand 32-bit Mach-O image to Destination (make segment file sizes equal to vm sizes).
 
-  @param[in]  Context          Context of the Mach-O.
-  @param[out] Destination      Output buffer.
-  @param[in]  DestinationSize  Output buffer maximum size.
-  @param[in]  Strip            Output with stripped prelink commands.
-  @param[in]  FileOffset       Pointer to the file offset of the first segment.
+  @param[in]  Context             Context of the Mach-O.
+  @param[in]  CalculateSizeOnly   TRUE to only calcuate a size and not actually expand the image.
+  @param[out] Destination         Output buffer.
+  @param[in]  DestinationSize     Output buffer maximum size.
+  @param[in]  Strip               Output with stripped prelink commands.
+  @param[in]  FileOffset          Pointer to the file offset of the first segment.
 
   @returns  New image size or 0 on failure.
 
@@ -259,6 +260,7 @@ InternalMachoGetFilePointerByAddress64 (
 UINT32
 InternalMachoExpandImage32 (
   IN  OC_MACHO_CONTEXT   *Context,
+  IN  BOOLEAN            CalculateSizeOnly,
   OUT UINT8              *Destination,
   IN  UINT32             DestinationSize,
   IN  BOOLEAN            Strip,
@@ -268,11 +270,12 @@ InternalMachoExpandImage32 (
 /**
   Expand 64-bit Mach-O image to Destination (make segment file sizes equal to vm sizes).
 
-  @param[in]  Context          Context of the Mach-O.
-  @param[out] Destination      Output buffer.
-  @param[in]  DestinationSize  Output buffer maximum size.
-  @param[in]  Strip            Output with stripped prelink commands.
-  @param[in]  FileOffset       Pointer to the file offset of the first segment.
+  @param[in]  Context             Context of the Mach-O.
+  @param[in]  CalculateSizeOnly   TRUE to only calcuate a size and not actually expand the image.
+  @param[out] Destination         Output buffer.
+  @param[in]  DestinationSize     Output buffer maximum size.
+  @param[in]  Strip               Output with stripped prelink commands.
+  @param[in]  FileOffset          Pointer to the file offset of the first segment.
 
   @returns  New image size or 0 on failure.
 
@@ -280,6 +283,7 @@ InternalMachoExpandImage32 (
 UINT32
 InternalMachoExpandImage64 (
   IN  OC_MACHO_CONTEXT   *Context,
+  IN  BOOLEAN            CalculateSizeOnly,
   OUT UINT8              *Destination,
   IN  UINT32             DestinationSize,
   IN  BOOLEAN            Strip,

--- a/Library/OcMachoLib/OcMachoLibInternal.h
+++ b/Library/OcMachoLib/OcMachoLibInternal.h
@@ -251,6 +251,7 @@ InternalMachoGetFilePointerByAddress64 (
   @param[out] Destination      Output buffer.
   @param[in]  DestinationSize  Output buffer maximum size.
   @param[in]  Strip            Output with stripped prelink commands.
+  @param[in]  FileOffset       Pointer to the file offset of the first segment.
 
   @returns  New image size or 0 on failure.
 
@@ -260,7 +261,8 @@ InternalMachoExpandImage32 (
   IN  OC_MACHO_CONTEXT   *Context,
   OUT UINT8              *Destination,
   IN  UINT32             DestinationSize,
-  IN  BOOLEAN            Strip
+  IN  BOOLEAN            Strip,
+  OUT UINT32             *FileOffset OPTIONAL
   );
 
 /**
@@ -270,6 +272,7 @@ InternalMachoExpandImage32 (
   @param[out] Destination      Output buffer.
   @param[in]  DestinationSize  Output buffer maximum size.
   @param[in]  Strip            Output with stripped prelink commands.
+  @param[in]  FileOffset       Pointer to the file offset of the first segment.
 
   @returns  New image size or 0 on failure.
 
@@ -279,7 +282,8 @@ InternalMachoExpandImage64 (
   IN  OC_MACHO_CONTEXT   *Context,
   OUT UINT8              *Destination,
   IN  UINT32             DestinationSize,
-  IN  BOOLEAN            Strip
+  IN  BOOLEAN            Strip,
+  OUT UINT64             *FileOffset OPTIONAL
   );
 
 /**

--- a/Library/OcMachoLib/Relocations.c
+++ b/Library/OcMachoLib/Relocations.c
@@ -172,7 +172,7 @@ InternalLookupSectionRelocationByOffset (
           //
           // Filter out the other relocation type.
           //
-          if (Relocation->Extern != (External ? 1 : 0)) {
+          if (Relocation->Extern != (UINT32)(External ? 1 : 0)) {
             continue;
           }
 

--- a/Library/OcMachoLib/Relocations.c
+++ b/Library/OcMachoLib/Relocations.c
@@ -22,6 +22,21 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include "OcMachoLibInternal.h"
 
 /**
+  Returns whether the Relocation's type indicates a Pair for the Intel 32
+  platform.
+  
+  @param[in] Type  The Relocation's type to verify.
+
+**/
+BOOLEAN
+MachoRelocationIsPairIntel32 (
+  IN UINT8  Type
+  )
+{
+  return (Type == MachGenericRelocSectDiff || Type == MachGenericRelocLocalSectDiff);
+}
+
+/**
   Returns whether the Relocation's type indicates a Pair for the Intel 64
   platform.
   

--- a/Library/OcMachoLib/Symbols.c
+++ b/Library/OcMachoLib/Symbols.c
@@ -133,6 +133,23 @@ MachoGetSymbolByExternRelocationOffset (
 }
 
 BOOLEAN
+MachoRelocateSymbol (
+  IN OUT OC_MACHO_CONTEXT   *Context,
+  IN     UINT64             LinkAddress,
+  IN OUT MACH_NLIST_ANY     *Symbol
+  )
+{
+  ASSERT (Context != NULL);
+  if (Context->Is32Bit) {
+    ASSERT (LinkAddress < MAX_UINT32);
+  }
+
+  return Context->Is32Bit ?
+    MachoRelocateSymbol32 (Context, (UINT32) LinkAddress, &Symbol->Symbol32) :
+    MachoRelocateSymbol64 (Context, LinkAddress, &Symbol->Symbol64) ; 
+}
+
+BOOLEAN
 MachoSymbolGetFileOffset (
   IN OUT OC_MACHO_CONTEXT       *Context,
   IN     CONST  MACH_NLIST_ANY  *Symbol,

--- a/Library/OcMachoLib/Symbols.c
+++ b/Library/OcMachoLib/Symbols.c
@@ -24,6 +24,45 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 
 #include "OcMachoLibInternal.h"
 
+BOOLEAN
+MachoSymbolIsDefined (
+  IN OUT OC_MACHO_CONTEXT *Context,
+  IN CONST MACH_NLIST_ANY *Symbol
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    MachoSymbolIsDefined32 (&Symbol->Symbol32) :
+    MachoSymbolIsDefined64 (&Symbol->Symbol64);
+}
+
+BOOLEAN
+MachoSymbolIsLocalDefined (
+  IN OUT OC_MACHO_CONTEXT     *Context,
+  IN     CONST MACH_NLIST_ANY *Symbol
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    MachoSymbolIsLocalDefined32 (Context, &Symbol->Symbol32) :
+    MachoSymbolIsLocalDefined64 (Context, &Symbol->Symbol64);
+}
+
+MACH_NLIST_ANY *
+MachoGetLocalDefinedSymbolByName (
+  IN OUT OC_MACHO_CONTEXT   *Context,
+  IN     CONST CHAR8        *Name
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    (MACH_NLIST_ANY *) MachoGetLocalDefinedSymbolByName32 (Context, Name) :
+    (MACH_NLIST_ANY *) MachoGetLocalDefinedSymbolByName64 (Context, Name);
+}
+
 MACH_NLIST_ANY *
 MachoGetSymbolByIndex (
   IN OUT OC_MACHO_CONTEXT  *Context,
@@ -34,7 +73,7 @@ MachoGetSymbolByIndex (
 
   return Context->Is32Bit ?
     (MACH_NLIST_ANY *) MachoGetSymbolByIndex32 (Context, Index) :
-    (MACH_NLIST_ANY *) MachoGetSymbolByIndex64 (Context, Index);  
+    (MACH_NLIST_ANY *) MachoGetSymbolByIndex64 (Context, Index);
 }
 
 CONST CHAR8 *
@@ -47,7 +86,20 @@ MachoGetSymbolName (
 
   return Context->Is32Bit ?
     MachoGetSymbolName32 (Context, &Symbol->Symbol32) :
-    MachoGetSymbolName64 (Context, &Symbol->Symbol64);  
+    MachoGetSymbolName64 (Context, &Symbol->Symbol64);
+}
+
+CONST CHAR8 *
+MachoGetIndirectSymbolName (
+  IN OUT OC_MACHO_CONTEXT     *Context,
+  IN     CONST MACH_NLIST_ANY *Symbol
+  )
+{
+  ASSERT (Context != NULL);
+
+  return Context->Is32Bit ?
+    MachoGetIndirectSymbolName32 (Context, &Symbol->Symbol32) :
+    MachoGetIndirectSymbolName64 (Context, &Symbol->Symbol64);
 }
 
 BOOLEAN
@@ -60,7 +112,24 @@ MachoIsSymbolValueInRange (
 
   return Context->Is32Bit ?
     MachoIsSymbolValueInRange32 (Context, &Symbol->Symbol32) :
-    MachoIsSymbolValueInRange64 (Context, &Symbol->Symbol64);  
+    MachoIsSymbolValueInRange64 (Context, &Symbol->Symbol64);
+}
+
+BOOLEAN
+MachoGetSymbolByExternRelocationOffset (
+  IN OUT OC_MACHO_CONTEXT   *Context,
+  IN     UINT64             Address,
+  OUT    MACH_NLIST_ANY     **Symbol
+  )
+{
+  ASSERT (Context != NULL);
+  if (Context->Is32Bit) {
+    ASSERT (Address < MAX_UINT32);
+  }
+
+  return Context->Is32Bit ?
+    MachoGetSymbolByExternRelocationOffset32 (Context, (UINT32) Address, (MACH_NLIST **) Symbol) :
+    MachoGetSymbolByExternRelocationOffset64 (Context, Address, (MACH_NLIST_64 **) Symbol) ; 
 }
 
 BOOLEAN
@@ -75,7 +144,7 @@ MachoSymbolGetFileOffset (
 
   return Context->Is32Bit ?
     MachoSymbolGetFileOffset32 (Context, &Symbol->Symbol32, FileOffset, MaxSize) :
-    MachoSymbolGetFileOffset64 (Context, &Symbol->Symbol64, FileOffset, MaxSize);  
+    MachoSymbolGetFileOffset64 (Context, &Symbol->Symbol64, FileOffset, MaxSize);
 }
 
 BOOLEAN

--- a/Library/OcMachoLib/SymbolsX.h
+++ b/Library/OcMachoLib/SymbolsX.h
@@ -429,6 +429,7 @@ MACH_X (MachoGetSymbolByRelocationOffset) (
   CONST MACH_UINT_X           *Data;
   MACH_NLIST_X                *Sym;
   MACH_UINT_X                 AddressTop;
+  UINT32                      MaxSize;
 
   VOID                        *Tmp;
 
@@ -453,7 +454,10 @@ MACH_X (MachoGetSymbolByRelocationOffset) (
   if (Relocation != NULL) {
     Sym = NULL;
 
-    Tmp = (VOID *)((UINTN)Context->MachHeader + (UINTN)Address);
+    Tmp = (VOID *) MachoGetFilePointerByAddress (Context, Address, &MaxSize);
+    if (Tmp == NULL || MaxSize < sizeof (MACH_UINT_X)) {
+      return FALSE;
+    }
 
     if (OC_TYPE_ALIGNED (MACH_UINT_X, Tmp)) {
       Data = (MACH_UINT_X *)Tmp;

--- a/Library/OcMachoLib/SymbolsX.h
+++ b/Library/OcMachoLib/SymbolsX.h
@@ -308,7 +308,7 @@ MACH_X (MachoSymbolIsLocalDefined) (
   ASSERT (Context->SymbolTable != NULL);
 
   if ((DySymtab == NULL) || (DySymtab->NumUndefinedSymbols == 0)) {
-    return TRUE;
+    return FALSE; // FIXME: Required under 32-bit during vtable parent resolution, if using MH_OBJECT.
   }
   //
   // The symbol must have been declared locally prior to solving.  As there is

--- a/Platform/OpenCore/OpenCoreKernel.c
+++ b/Platform/OpenCore/OpenCoreKernel.c
@@ -716,7 +716,7 @@ OcKernelProcessPrelinked (
   EFI_STATUS           Status;
   PRELINKED_CONTEXT    Context;
 
-  Status = PrelinkedContextInit (&Context, Kernel, *KernelSize, AllocatedSize);
+  Status = PrelinkedContextInit (&Context, Kernel, *KernelSize, AllocatedSize, Is32Bit);
 
   if (!EFI_ERROR (Status)) {
     OcKernelInjectKexts (Config, CacheTypePrelinked, &Context, DarwinVersion, Is32Bit, LinkedExpansion, ReservedExeSize);

--- a/Utilities/TestKextInject/KextInject.c
+++ b/Utilities/TestKextInject/KextInject.c
@@ -649,7 +649,7 @@ int wrap_main(int argc, char** argv) {
     FailedToProcess = TRUE;
   }
 
-  Status = PrelinkedContextInit (&Context, Prelinked, PrelinkedSize, AllocSize);
+  Status = PrelinkedContextInit (&Context, Prelinked, PrelinkedSize, AllocSize, FALSE);
 
   if (!EFI_ERROR (Status)) {
     Status = PrelinkedInjectPrepare (&Context, LinkedExpansion, ReservedExeSize);

--- a/Utilities/TestKextInject/KextInject.c
+++ b/Utilities/TestKextInject/KextInject.c
@@ -785,7 +785,7 @@ INT32 LLVMFuzzerTestOneInput(CONST UINT8 *Data, UINTN Size) {
     return 0;
   }
 
-  EFI_STATUS Status = PrelinkedContextInit (&Context, Prelinked, PrelinkedSize, AllocSize);
+  EFI_STATUS Status = PrelinkedContextInit (&Context, Prelinked, PrelinkedSize, AllocSize, FALSE);
 
   if (EFI_ERROR (Status)) {
     free (Prelinked);

--- a/Utilities/TestMacho/Macho.c
+++ b/Utilities/TestMacho/Macho.c
@@ -46,7 +46,7 @@ static int FeedMacho(void *file, uint32_t size) {
   int code = 0;
 
   MACH_HEADER_64 *Hdr = MachoGetMachHeader64 (&Context);
-  if (Hdr && MachoGetFileSize(&Context) > 10 && MachoGetLastAddress64(&Context) != 10) {
+  if (Hdr && MachoGetFileSize(&Context) > 10 && MachoGetLastAddress(&Context) != 10) {
     memcpy(&Header, Hdr, sizeof(Header));
     code++;
   }


### PR DESCRIPTION
32-bit prelinked kernel support

- [x] 32-bit prelinking for 10.6 and 10.7 (v2 and v3 prelinkedkernels)
- [ ] ~~32-bit prelinking for 10.4 and 10.5 (v1)~~
- [ ] Paired 32-bit relocations
- [x] Support for injected kexts depending on other injected kexts