### PR TITLE
Don't enable ACPI patches for OSes other than macOS

### DIFF
--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -211,6 +211,8 @@
 			<false/>
 			<key>NormalizeHeaders</key>
 			<false/>
+			<key>OnlyForMacOS</key>
+			<false/>
 			<key>RebaseRegions</key>
 			<false/>
 			<key>ResetHwSig</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -211,6 +211,8 @@
 			<false/>
 			<key>NormalizeHeaders</key>
 			<false/>
+			<key>OnlyForMacOS</key>
+			<false/>
 			<key>RebaseRegions</key>
 			<false/>
 			<key>ResetHwSig</key>

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -80,6 +80,7 @@
 #define OC_ACPI_QUIRKS_FIELDS(_, __) \
   _(BOOLEAN                     , FadtEnableReset     ,     , FALSE  , ()) \
   _(BOOLEAN                     , NormalizeHeaders    ,     , FALSE  , ()) \
+  _(BOOLEAN                     , OnlyForMacOS        ,     , FALSE  , ()) \
   _(BOOLEAN                     , RebaseRegions       ,     , FALSE  , ()) \
   _(BOOLEAN                     , ResetHwSig          ,     , FALSE  , ()) \
   _(BOOLEAN                     , ResetLogoStatus     ,     , FALSE  , ())

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -136,6 +136,7 @@ OC_SCHEMA
 mAcpiQuirksSchema[] = {
   OC_SCHEMA_BOOLEAN_IN ("FadtEnableReset",  OC_GLOBAL_CONFIG, Acpi.Quirks.FadtEnableReset),
   OC_SCHEMA_BOOLEAN_IN ("NormalizeHeaders", OC_GLOBAL_CONFIG, Acpi.Quirks.NormalizeHeaders),
+  OC_SCHEMA_BOOLEAN_IN ("OnlyForMacOS",     OC_GLOBAL_CONFIG, Acpi.Quirks.OnlyForMacOS),
   OC_SCHEMA_BOOLEAN_IN ("RebaseRegions",    OC_GLOBAL_CONFIG, Acpi.Quirks.RebaseRegions),
   OC_SCHEMA_BOOLEAN_IN ("ResetHwSig",       OC_GLOBAL_CONFIG, Acpi.Quirks.ResetHwSig),
   OC_SCHEMA_BOOLEAN_IN ("ResetLogoStatus",  OC_GLOBAL_CONFIG, Acpi.Quirks.ResetLogoStatus),

--- a/Platform/OpenCore/OpenCore.c
+++ b/Platform/OpenCore/OpenCore.c
@@ -79,6 +79,11 @@ OcStartImage (
 
   OldMode = OcConsoleControlSetMode (EfiConsoleControlScreenGraphics);
 
+  if((Chosen->Type & OC_BOOT_APPLE_ANY) && mOpenCoreConfiguration.Acpi.Quirks.OnlyForMacOS){
+    DEBUG ((DEBUG_INFO, "OC: OcLoadAcpiSupport only for macOS...\n"));
+    OcLoadAcpiSupport (&mOpenCoreStorage, &mOpenCoreConfiguration);
+  }
+    
   Status = gBS->StartImage (
     ImageHandle,
     ExitDataSize,
@@ -123,8 +128,10 @@ OcMain (
   OcMiscMiddleInit (Storage, &mOpenCoreConfiguration, LoadPath, &mLoadHandle);
   DEBUG ((DEBUG_INFO, "OC: OcLoadUefiSupport...\n"));
   OcLoadUefiSupport (Storage, &mOpenCoreConfiguration, &mOpenCoreCpuInfo);
-  DEBUG ((DEBUG_INFO, "OC: OcLoadAcpiSupport...\n"));
-  OcLoadAcpiSupport (&mOpenCoreStorage, &mOpenCoreConfiguration);
+  if(!mOpenCoreConfiguration.Acpi.Quirks.OnlyForMacOS){
+    DEBUG ((DEBUG_INFO, "OC: OcLoadAcpiSupport for any OS...\n"));
+    OcLoadAcpiSupport (&mOpenCoreStorage, &mOpenCoreConfiguration);
+  }
   DEBUG ((DEBUG_INFO, "OC: OcLoadPlatformSupport...\n"));
   OcLoadPlatformSupport (&mOpenCoreConfiguration, &mOpenCoreCpuInfo);
   DEBUG ((DEBUG_INFO, "OC: OcLoadDevPropsSupport...\n"));


### PR DESCRIPTION
There is no need to patch ACPI on operating systems as Windows or Linux so this mod disable acpi support when selected entry is not any of macOS entries.