### PR TITLE
OcMiscLib: Fix FindPattern on last byte of data

### DIFF
--- a/Library/OcMiscLib/DataPatcher.c
+++ b/Library/OcMiscLib/DataPatcher.c
@@ -36,7 +36,7 @@ FindPattern (
     return -1;
   }
 
-  while (DataOff + PatternSize < DataSize) {
+  while (DataOff + PatternSize <= DataSize) {
     Matches = TRUE;
     for (Index = 0; Index < PatternSize; ++Index) {
       if ((PatternMask == NULL && Data[DataOff + Index] != Pattern[Index])


### PR DESCRIPTION
In the rare case that we need to patch the last portion of data, FindPattern will stop 1 byte earlier.