### PR TITLE
OcStorageLib: Uninstall EfiDevicePathProtocol on OcStorageFree

### DIFF
--- a/Library/OcStorageLib/OcStorageLib.c
+++ b/Library/OcStorageLib/OcStorageLib.c
@@ -317,6 +317,15 @@ OcStorageFree (
   IN OUT OC_STORAGE_CONTEXT            *Context
   )
 {
+  if (Context->DummyStorageHandle != NULL) {
+    gBS->UninstallProtocolInterface (
+      Context->DummyStorageHandle,
+      &gEfiDevicePathProtocolGuid,
+      &mDummyBootDevicePath
+      );
+    Context->DummyStorageHandle = NULL;
+  }
+
   if (Context->Storage != NULL) {
     Context->Storage->Close (Context->Storage);
     Context->Storage = NULL;


### PR DESCRIPTION
`EfiDevicePathProtocol` is installed by `OcStorageInitFromFs` but never uninstalled. As it stands, this prevents any application which calls `OcStorageInitFromFs` (even when correctly followed later by calling `OcStorageFree` to clean up) from being able to exit cleanly, as per the comment below.

This PR uninstalls the protocol in what seems to be the obvious correct place.