### PR TITLE
DataBase: Update Apple locations

### DIFF
--- a/Utilities/macserial/modelinfo.h
+++ b/Utilities/macserial/modelinfo.h
@@ -114,6 +114,7 @@ static const char *AppleLocations[] = {
   "CMV",
   "YM0",
   "DGK",
+  "FVF"
 };
 
 static const char *AppleLocationNames[] = {
@@ -130,6 +131,7 @@ static const char *AppleLocationNames[] = {
   "Unknown",
   "Unknown",
   "China (Hon Hai/Foxconn)",
+  "Unknown",
   "Unknown"
 };
 


### PR DESCRIPTION
Add new Apple location name from MacBookPro14,1 serial number