### PR TITLE
[OpenDuet] Fix undefined behavior due to uninited memory (issue 1326)

### DIFF
--- a/Legacy/BootPlatform/BiosVideo/LegacyBiosThunk.c
+++ b/Legacy/BootPlatform/BiosVideo/LegacyBiosThunk.c
@@ -43,6 +43,8 @@ InitializeBiosIntCaller (
                   );
   ASSERT_EFI_ERROR (Status);
 
+  ZeroMem ((VOID*)(UINTN) LegacyRegionBase, LegacyRegionSize);
+
   ThunkContext->RealModeBuffer     = (VOID*)(UINTN)LegacyRegionBase;
   ThunkContext->RealModeBufferSize = LegacyRegionSize;
   ThunkContext->ThunkAttributes    = THUNK_ATTRIBUTE_BIG_REAL_MODE|THUNK_ATTRIBUTE_DISABLE_A20_MASK_INT_15;

--- a/Legacy/BootPlatform/CpuDxe/CpuDxe.c
+++ b/Legacy/BootPlatform/CpuDxe/CpuDxe.c
@@ -1162,6 +1162,8 @@ InitializeBiosIntCaller (
                   );
   ASSERT_EFI_ERROR (Status);
 
+  ZeroMem ((VOID*)(UINTN) LegacyRegionBase, LegacyRegionSize);
+
   mThunkContext.RealModeBuffer     = (VOID*)(UINTN)LegacyRegionBase;
   mThunkContext.RealModeBufferSize = LegacyRegionSize;
   mThunkContext.ThunkAttributes    = 3;


### PR DESCRIPTION
Garbage from memory was poped to CPU flags on return from legacy BIOS int86 calls.