### PR TITLE
Clean up keys after done with signing vault

### DIFF
--- a/Utilities/CreateVault/sign.command
+++ b/Utilities/CreateVault/sign.command
@@ -5,7 +5,12 @@ abort() {
   exit 1
 }
 
-if [ ! -x /usr/bin/dirname ] || [ ! -x /bin/chmod ] || [ ! -x /bin/mkdir ] || [ ! -x /usr/bin/openssl ] || [ ! -x /bin/rm ] || [ ! -x /usr/bin/strings ] || [ ! -x /usr/bin/grep ] || [ ! -x /usr/bin/cut ] || [ ! -x /bin/dd ] ; then
+cleanup() {
+  echo "Cleaning up keys"
+  rm -rf "${KeyPath}"
+}
+
+if [ ! -x /usr/bin/dirname ] || [ ! -x /bin/chmod ] || [ ! -x /bin/mkdir ] || [ ! -x /usr/bin/openssl ] || [ ! -x /bin/rm ] || [ ! -x /usr/bin/strings ] || [ ! -x /usr/bin/grep ] || [ ! -x /usr/bin/cut ] || [ ! -x /bin/dd ] || [ ! -x /usr/bin/uuidgen ] ; then
   abort "Unix environment is broken!"
 fi
 
@@ -17,7 +22,7 @@ if [ "$OCPath" = "" ]; then
   OCPath=../../EFI/OC
 fi
 
-KeyPath="/tmp/Keys"
+KeyPath="/tmp/Keys-$(/usr/bin/uuidgen)"
 OCBin="${OCPath}/OpenCore.efi"
 RootCA="${KeyPath}/ca.pem"
 PrivKey="${KeyPath}/privatekey.cer"
@@ -44,6 +49,8 @@ if [ ! -x ./RsaTool ] || [ ! -x ./create_vault.sh ]; then
     abort "Failed to find create_vault.sh!"
   fi
 fi
+
+trap cleanup EXIT ERR INT TERM
 
 if [ ! -d "${KeyPath}" ]; then
   /bin/mkdir -p "${KeyPath}" || abort "Failed to create path ${KeyPath}"
@@ -77,10 +84,7 @@ fi
 
 /bin/dd of="${OCBin}" if="${PubKey}" bs=1 seek="${off}" count=528 conv=notrunc || abort "Failed to bin-patch ${OCBin}"
 
-echo "Cleaning up keys"
-if [ -d "${KeyPath}" ]; then
-  rm -rf "${KeyPath}" | abort "Failed to clean up keys ${KeyPath}!"
-fi
+
 
 echo "All done!"
 exit 0

--- a/Utilities/CreateVault/sign.command
+++ b/Utilities/CreateVault/sign.command
@@ -84,6 +84,5 @@ fi
 
 /bin/dd of="${OCBin}" if="${PubKey}" bs=1 seek="${off}" count=528 conv=notrunc || abort "Failed to bin-patch ${OCBin}"
 
-
 echo "All done!"
 exit 0

--- a/Utilities/CreateVault/sign.command
+++ b/Utilities/CreateVault/sign.command
@@ -17,7 +17,7 @@ if [ "$OCPath" = "" ]; then
   OCPath=../../EFI/OC
 fi
 
-KeyPath="${OCPath}/Keys"
+KeyPath="/tmp/Keys"
 OCBin="${OCPath}/OpenCore.efi"
 RootCA="${KeyPath}/ca.pem"
 PrivKey="${KeyPath}/privatekey.cer"
@@ -76,6 +76,11 @@ if [ "${off}" -le 16 ]; then
 fi
 
 /bin/dd of="${OCBin}" if="${PubKey}" bs=1 seek="${off}" count=528 conv=notrunc || abort "Failed to bin-patch ${OCBin}"
+
+echo "Cleaning up keys"
+if [ -d "${KeyPath}" ]; then
+  rm -rf "${KeyPath}" | abort "Failed to clean up keys ${KeyPath}!"
+fi
 
 echo "All done!"
 exit 0

--- a/Utilities/CreateVault/sign.command
+++ b/Utilities/CreateVault/sign.command
@@ -50,7 +50,7 @@ if [ ! -x ./RsaTool ] || [ ! -x ./create_vault.sh ]; then
   fi
 fi
 
-trap cleanup EXIT ERR INT TERM
+trap cleanup EXIT INT TERM
 
 if [ ! -d "${KeyPath}" ]; then
   /bin/mkdir -p "${KeyPath}" || abort "Failed to create path ${KeyPath}"
@@ -83,7 +83,6 @@ if [ "${off}" -le 16 ]; then
 fi
 
 /bin/dd of="${OCBin}" if="${PubKey}" bs=1 seek="${off}" count=528 conv=notrunc || abort "Failed to bin-patch ${OCBin}"
-
 
 
 echo "All done!"


### PR DESCRIPTION
Hi,

I notice the attached sign.command that it leaves Keys folder in EFI/OC/
To my understanding, those keys no longer need during the boot process. Its public key was compiled into opencore.efi
I think it would be safer to remove those keys after done with this script
Also, I put the folder Keys under temp folder "/tmp" to prevent create_vault from processing them.