### PR TITLE
Support reordering Bootstrap by the FW

### DIFF
--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -101,11 +101,6 @@ typedef UINT32 OC_BOOT_ENTRY_TYPE;
 #define OC_BOOT_SYSTEM              (OC_BOOT_RESET_NVRAM)
 
 /**
-  Cached Bootstrap Boot Option index.
-**/
-#define OC_BOOTSTRAP_INDEX_VARIABLE_NAME  L"bootstrap-index"
-
-/**
   Picker mode.
 **/
 typedef enum OC_PICKER_MODE_ {
@@ -1316,11 +1311,13 @@ OcGetBootOrder (
   @retval EFI_SUCCESS on success.
 **/
 EFI_STATUS
-OcRegisterBootOption (
+OcRegisterBootstrapBootOption (
   IN CONST CHAR16    *OptionName,
   IN EFI_HANDLE      DeviceHandle,
   IN CONST CHAR16    *FilePath,
-  IN BOOLEAN         ShortForm
+  IN BOOLEAN         ShortForm,
+  IN CHAR16          *MatchSuffix,
+  IN UINTN           MatchSuffixLen
   );
 
 /**

--- a/Include/Acidanthera/Library/OcDevicePathLib.h
+++ b/Include/Acidanthera/Library/OcDevicePathLib.h
@@ -154,6 +154,21 @@ OcFileDevicePathNameLen (
   );
 
 /**
+  Retrieve the length of the full file path described by DevicePath.
+
+  @param[in] DevicePath  The Device Path to inspect.
+
+  @returns   The length of the full file path.
+  @retval 0  DevicePath does not start with a File Path node or contains
+             non-terminating nodes that are not File Path nodes.
+
+**/
+UINTN
+OcFileDevicePathFullNameLen (
+  IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath
+  );
+
+/**
   Retrieve the size of the full file path described by DevicePath.
 
   @param[in] DevicePath  The Device Path to inspect.
@@ -377,11 +392,20 @@ OcGetNextLoadOptionDevicePath (
   IN EFI_DEVICE_PATH_PROTOCOL  *FullPath
   );
 
+/*
+  Checks DevicePath for whether it ends with file path Suffix.
+
+  @param[in] DevicePath    The Device Path to check.
+  @param[in] Suffix        The suffix to check for.
+  @param[in] SuffixLen  Must be equal to StrLen(Suffix).
+
+  @returns  Whether DevicePath ends with Suffix.
+*/
 BOOLEAN
 OcDevicePathHasFilePathSuffix (
   IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
   IN CHAR16                    *Suffix,
-  IN UINTN                     SuffixSize
+  IN UINTN                     SuffixLen
   );
 
 #endif // OC_DEVICE_PATH_LIB_H

--- a/Include/Acidanthera/Library/OcDevicePathLib.h
+++ b/Include/Acidanthera/Library/OcDevicePathLib.h
@@ -377,4 +377,11 @@ OcGetNextLoadOptionDevicePath (
   IN EFI_DEVICE_PATH_PROTOCOL  *FullPath
   );
 
+BOOLEAN
+OcDevicePathHasFilePathSuffix (
+  IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
+  IN CHAR16                    *Suffix,
+  IN UINTN                     SuffixSize
+  );
+
 #endif // OC_DEVICE_PATH_LIB_H

--- a/Library/OcBootManagementLib/BootManagementInternal.h
+++ b/Library/OcBootManagementLib/BootManagementInternal.h
@@ -112,25 +112,17 @@ InternalDebugBootEnvironment (
   IN UINTN                    BootOrderCount
   );
 
-/**
-  Retrieves booting relevant data from an UEFI Boot#### option.
-  If BootName is NULL, a BDS-style process is assumed and inactive as well as
-  non-Boot type applications are ignored.
-
-  @param[in]  BootOption        The boot option's index.
-  @param[out] BootName          On output, the boot option's description.
-  @param[out] OptionalDataSize  On output, the optional data size.
-  @param[out] OptionalData      On output, a pointer to the optional data.
-
-  @returns Device path allocated from pool or NULL.
-**/
-EFI_DEVICE_PATH_PROTOCOL *
+EFI_LOAD_OPTION *
 InternalGetBootOptionData (
-  IN  UINT16   BootOption,
-  IN  EFI_GUID *BootGuid,
-  OUT CHAR16   **BootName  OPTIONAL,
-  OUT UINT32   *OptionalDataSize  OPTIONAL,
-  OUT VOID     **OptionalData  OPTIONAL
+  OUT UINTN           *OptionSize,
+  IN  UINT16          BootOption,
+  IN  CONST EFI_GUID  *BootGuid
+  );
+
+EFI_DEVICE_PATH_PROTOCOL *
+InternalGetBootOptionPath (
+  IN EFI_LOAD_OPTION  *LoadOption,
+  IN UINTN            LoadOptionSize
   );
 
 /**
@@ -175,6 +167,15 @@ InternalFileSystemForHandle (
 EFI_STATUS
 InternalSystemActionResetNvram (
   VOID
+  );
+
+EFI_LOAD_OPTION *
+InternalGetBoostrapOptionData (
+  OUT UINTN                    *LoadOptionSize,
+  OUT UINT16                   *BootOption,
+  OUT EFI_DEVICE_PATH_PROTOCOL **LoadPath,
+  IN  UINT16                   *BootOptions,
+  IN  UINTN                    NumBootOptions
   );
 
 #endif // BOOT_MANAGEMENET_INTERNAL_H

--- a/Library/OcBootManagementLib/BootManagementInternal.h
+++ b/Library/OcBootManagementLib/BootManagementInternal.h
@@ -169,13 +169,4 @@ InternalSystemActionResetNvram (
   VOID
   );
 
-EFI_LOAD_OPTION *
-InternalGetBoostrapOptionData (
-  OUT UINTN                    *LoadOptionSize,
-  OUT UINT16                   *BootOption,
-  OUT EFI_DEVICE_PATH_PROTOCOL **LoadPath,
-  IN  UINT16                   *BootOptions,
-  IN  UINTN                    NumBootOptions
-  );
-
 #endif // BOOT_MANAGEMENET_INTERNAL_H

--- a/Library/OcBootManagementLib/DefaultEntryChoice.c
+++ b/Library/OcBootManagementLib/DefaultEntryChoice.c
@@ -1026,7 +1026,7 @@ InternalRegisterBootstrapBootOption (
     CurrOptionExists = Option != NULL;
     if (CurrOptionExists) {
       CurrOptionValid  = IsDevicePathEqual (ReferencePath, CurrDevicePath);
-      FreePool (CurrDevicePath);
+      FreePool (Option);
     }
   } else {
     BootOrderSize = 0;

--- a/Library/OcBootManagementLib/DefaultEntryChoice.c
+++ b/Library/OcBootManagementLib/DefaultEntryChoice.c
@@ -911,7 +911,7 @@ InternalGetBoostrapOptionData (
   }
 
   *LoadPath   = CurrDevicePath;
-  *BootOption = BootOptionIndex;
+  *BootOption = BootOptions[BootOptionIndex];
   return CurrLoadOption;
 }
 

--- a/Library/OcBootManagementLib/DefaultEntryChoice.c
+++ b/Library/OcBootManagementLib/DefaultEntryChoice.c
@@ -993,8 +993,10 @@ InternalRegisterBootstrapBootOption (
     Status
     ));
 
+  BootOrder = NULL;
+
   if (Status == EFI_BUFFER_TOO_SMALL && BootOrderSize > 0 && BootOrderSize % sizeof (UINT16) == 0) {
-    BootOrder = AllocatePool (BootOrderSize + sizeof (UINT16));
+    BootOrder = AllocateZeroPool (BootOrderSize + sizeof (UINT16));
     if (BootOrder == NULL) {
       DEBUG ((DEBUG_INFO, "OCB: Failed to allocate boot order\n"));
       return EFI_OUT_OF_RESOURCES;
@@ -1034,9 +1036,10 @@ InternalRegisterBootstrapBootOption (
 
   DEBUG ((
     DEBUG_INFO,
-    "OCB: Have existing option %d, valid %d\n",
-    CurrOptionExists,
-    CurrOptionValid
+    "OCB: %a existing option at Boot%04x, %a\n",
+    CurrOptionExists ? "Have" : "No",
+    BootOrder[1],
+    CurrOptionValid ? "valid" : "invalid"
     ));
 
   if (!CurrOptionValid) {

--- a/Library/OcBootManagementLib/OcBootManagementLib.inf
+++ b/Library/OcBootManagementLib/OcBootManagementLib.inf
@@ -50,6 +50,7 @@
 [Packages]
   OpenCorePkg/OpenCorePkg.dec
   MdePkg/MdePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
 
 [Guids]
   gAppleApfsContainerInfoGuid                   ## SOMETIMES_CONSUMES

--- a/Library/OcBootManagementLib/VariableManagement.c
+++ b/Library/OcBootManagementLib/VariableManagement.c
@@ -254,7 +254,6 @@ InternalGetBootstrapBootData (
   EFI_STATUS               Status;
   UINTN                    BootOrderSize;
   UINT16                   *BootOrder;
-  UINT16                   OptionIndex;
   VOID                     *OptionData;
 
   BootOrderSize = 0;
@@ -295,13 +294,13 @@ InternalGetBootstrapBootData (
     FreePool (BootOrder);
     return NULL;
   }
-
-  OptionData = InternalGetBoostrapOptionData (
+  //
+  // OpenCore moved Bootstrap to BootOrder[0] on initialisation.
+  //
+  OptionData = InternalGetBootOptionData (
     OptionSize,
-    &OptionIndex,
-    NULL,
-    BootOrder,
-    BootOrderSize / sizeof (UINT16)
+    BootOrder[0],
+    &gEfiGlobalVariableGuid
     );
 
   FreePool (BootOrder);
@@ -382,36 +381,6 @@ OcDeleteVariables (
       BootOptionSize,
       BootOption
       );
-    if (!EFI_ERROR (Status)) {
-      Status = gRT->SetVariable (
-        OC_BOOTSTRAP_INDEX_VARIABLE_NAME,
-        &gOcVendorVariableGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (BootOptionIndex),
-        &BootOptionIndex
-        );
-      if (EFI_ERROR (Status)) {
-        //
-        // Discard the inconsistent Bootstrap info to prevent duplication on
-        // next boot.
-        //
-        gRT->SetVariable (
-          OC_BOOTSTRAP_INDEX_VARIABLE_NAME,
-          &gOcVendorVariableGuid,
-          EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-          0,
-          NULL
-          );
-
-        gRT->SetVariable (
-          L"Boot0000",
-          &gEfiGlobalVariableGuid,
-          EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-          0,
-          NULL
-          );
-      }
-    }
     if (!EFI_ERROR (Status)) {
       Status = gRT->SetVariable (
         EFI_BOOT_ORDER_VARIABLE_NAME,

--- a/Library/OcBootManagementLib/VariableManagement.c
+++ b/Library/OcBootManagementLib/VariableManagement.c
@@ -248,7 +248,8 @@ DeleteVariables (
 
 VOID *
 InternalGetBootstrapBootData (
-  OUT UINTN  *OptionSize
+  OUT UINTN   *OptionSize,
+  OUT UINT16  *Option
   )
 {
   EFI_STATUS               Status;
@@ -302,6 +303,7 @@ InternalGetBootstrapBootData (
     BootOrder[0],
     &gEfiGlobalVariableGuid
     );
+  *Option = BootOrder[0];
 
   FreePool (BootOrder);
 
@@ -320,7 +322,6 @@ OcDeleteVariables (
   UINT32                       BootProtect;
   VOID                         *BootOption;
   UINTN                        BootOptionSize;
-  CHAR16                       BootOptionVariable[L_STR_LEN (L"Boot####") + 1];
   UINT16                       BootOptionIndex;
 
   DEBUG ((DEBUG_INFO, "OCB: NVRAM cleanup...\n"));
@@ -356,13 +357,13 @@ OcDeleteVariables (
   }
 
   if ((BootProtect & OC_BOOT_PROTECT_VARIABLE_BOOTSTRAP) != 0) {
-    BootOption = InternalGetBootstrapBootData (&BootOptionSize);
+    BootOption = InternalGetBootstrapBootData (&BootOptionSize, &BootOptionIndex);
     if (BootOption != NULL) {
       DEBUG ((
         DEBUG_INFO,
-        "OCB: Found %g:%s for preservation of %u bytes\n",
+        "OCB: Found %g:Boot%04x for preservation of %u bytes\n",
         &gEfiGlobalVariableGuid,
-        BootOptionVariable,
+        BootOptionIndex,
         (UINT32) BootOptionSize
         ));
     } else {
@@ -391,7 +392,7 @@ OcDeleteVariables (
         );
     }
 
-    DEBUG ((DEBUG_INFO, "OCB: Restored %s - %r\n", BootOptionVariable, Status));
+    DEBUG ((DEBUG_INFO, "OCB: Set bootstrap option to Boot%04x - %r\n", BootOptionIndex, Status));
     FreePool (BootOption);
   }
 

--- a/Library/OcDevicePathLib/OcDevicePathLib.c
+++ b/Library/OcDevicePathLib/OcDevicePathLib.c
@@ -1231,3 +1231,49 @@ OcGetNumDevicePathInstances (
 
   return NumInstances;
 }
+
+BOOLEAN
+OcDevicePathHasFilePathSuffix (
+  IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
+  IN CHAR16                    *Suffix,
+  IN UINTN                     SuffixSize
+  )
+{
+  FILEPATH_DEVICE_PATH *FilePath;
+  UINTN                PathNameSize;
+  UINTN                PathNameAllocSize;
+  CHAR16               *PathName;
+  INTN                 Result;
+
+  FilePath = (FILEPATH_DEVICE_PATH *) FindDevicePathNodeWithType (
+    DevicePath,
+    MEDIA_DEVICE_PATH,
+    MEDIA_FILEPATH_DP
+    );
+  if (FilePath == NULL) {
+    return FALSE;
+  }
+
+  PathNameSize = OcFileDevicePathFullNameSize (&FilePath->Header);
+  if (PathNameSize < SuffixSize) {
+    return FALSE;
+  }
+
+  PathName = AllocatePool (PathNameSize);
+  if (PathName == NULL) {
+    return FALSE;
+  }
+
+  PathNameAllocSize = PathNameSize;
+
+  OcFileDevicePathFullName (PathName, FilePath, PathNameSize);
+
+  Result = OcStriCmp (
+    &PathName[PathNameSize - SuffixSize],
+    Suffix
+    );
+
+  FreePool (PathName);
+
+  return Result == 0;
+}

--- a/Library/OcDevicePathLib/OcDevicePathLib.c
+++ b/Library/OcDevicePathLib/OcDevicePathLib.c
@@ -1035,6 +1035,47 @@ OcFileDevicePathNameLen (
 }
 
 /**
+  Retrieve the length of the full file path described by DevicePath.
+
+  @param[in] DevicePath  The Device Path to inspect.
+
+  @returns   The length of the full file path.
+  @retval 0  DevicePath does not start with a File Path node or contains
+             non-terminating nodes that are not File Path nodes.
+
+**/
+UINTN
+OcFileDevicePathFullNameLen (
+  IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath
+  )
+{
+  UINTN                      PathLength;
+  CONST FILEPATH_DEVICE_PATH *FilePath;
+
+  ASSERT (DevicePath != NULL);
+  ASSERT (IsDevicePathValid (DevicePath, 0));
+
+  PathLength = 0;
+  do {
+    //
+    // On the first iteration, this ensures the path is not immediately
+    // terminated.
+    //
+    if (DevicePath->Type    != MEDIA_DEVICE_PATH
+     || DevicePath->SubType != MEDIA_FILEPATH_DP) {
+      return 0;
+    }
+
+    FilePath    = (FILEPATH_DEVICE_PATH *)DevicePath;
+    PathLength += OcFileDevicePathNameLen (FilePath);
+
+    DevicePath = NextDevicePathNode (DevicePath);
+  } while (!IsDevicePathEnd (DevicePath));
+
+  return PathLength;
+}
+
+/**
   Retrieve the size of the full file path described by DevicePath.
 
   @param[in] DevicePath  The Device Path to inspect.
@@ -1049,29 +1090,7 @@ OcFileDevicePathFullNameSize (
   IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath
   )
 {
-  UINTN                      PathSize;
-  CONST FILEPATH_DEVICE_PATH *FilePath;
-
-  ASSERT (DevicePath != NULL);
-  ASSERT (IsDevicePathValid (DevicePath, 0));
-
-  PathSize = 1;
-  do {
-    //
-    // On the first iteration, this ensures the path is not immediately
-    // terminated.
-    //
-    if (DevicePath->Type    != MEDIA_DEVICE_PATH
-     || DevicePath->SubType != MEDIA_FILEPATH_DP) {
-      return 0;
-    }
-
-    FilePath  = (FILEPATH_DEVICE_PATH *)DevicePath;
-    PathSize += OcFileDevicePathNameLen (FilePath);
-
-    DevicePath = NextDevicePathNode (DevicePath);
-  } while (!IsDevicePathEnd (DevicePath));
-  return PathSize * sizeof (*FilePath->PathName);
+  return (OcFileDevicePathFullNameLen (DevicePath) + 1) * sizeof (CHAR16);
 }
 
 /**
@@ -1236,14 +1255,18 @@ BOOLEAN
 OcDevicePathHasFilePathSuffix (
   IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
   IN CHAR16                    *Suffix,
-  IN UINTN                     SuffixSize
+  IN UINTN                     SuffixLen
   )
 {
   FILEPATH_DEVICE_PATH *FilePath;
+  UINTN                PathNameLen;
   UINTN                PathNameSize;
-  UINTN                PathNameAllocSize;
   CHAR16               *PathName;
   INTN                 Result;
+  //
+  // OcStrinCmp will be needed in case of a mismatch.
+  //
+  ASSERT (SuffixLen == StrLen (Suffix));
 
   FilePath = (FILEPATH_DEVICE_PATH *) FindDevicePathNodeWithType (
     DevicePath,
@@ -1254,22 +1277,22 @@ OcDevicePathHasFilePathSuffix (
     return FALSE;
   }
 
-  PathNameSize = OcFileDevicePathFullNameSize (&FilePath->Header);
-  if (PathNameSize < SuffixSize) {
+  PathNameLen = OcFileDevicePathFullNameLen (&FilePath->Header);
+  if (PathNameLen < SuffixLen) {
     return FALSE;
   }
+
+  PathNameSize = (PathNameLen + 1) * sizeof (CHAR16);
 
   PathName = AllocatePool (PathNameSize);
   if (PathName == NULL) {
     return FALSE;
   }
 
-  PathNameAllocSize = PathNameSize;
-
   OcFileDevicePathFullName (PathName, FilePath, PathNameSize);
 
   Result = OcStriCmp (
-    &PathName[PathNameSize - SuffixSize],
+    &PathName[PathNameLen - SuffixLen],
     Suffix
     );
 

--- a/Platform/OpenCore/OpenCoreMisc.c
+++ b/Platform/OpenCore/OpenCoreMisc.c
@@ -623,7 +623,14 @@ RegisterBootstrap (
     BootstrapPath = AllocatePool (BootstrapSize);
     if (BootstrapPath != NULL) {
       UnicodeSPrint (BootstrapPath, BootstrapSize, L"%s\\%s", RootPath, OPEN_CORE_BOOTSTRAP_PATH);
-      OcRegisterBootOption (L"OpenCore", LoadHandle, BootstrapPath, ShortForm);
+      OcRegisterBootstrapBootOption (
+        L"OpenCore",
+        LoadHandle,
+        BootstrapPath,
+        ShortForm,
+        OPEN_CORE_BOOTSTRAP_PATH,
+        L_STR_LEN (OPEN_CORE_BOOTSTRAP_PATH)
+        );
       FreePool (BootstrapPath);
       return OC_BOOT_PROTECT_VARIABLE_BOOTSTRAP;
     }


### PR DESCRIPTION
The firmware may move our boot option away from bootstrap-index. Scan BootOrder for the option by DP suffix. Implicitly fixes issues with boot entry duplication.