### PR TITLE
Updated Sample.plist

### DIFF
--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -967,7 +967,11 @@
 			</array>
 			<key>7C436110-AB2A-4BBB-A880-FE41995C9F82</key>
 			<array>
+				<string>SystemAudioVolume</string>
 				<string>boot-args</string>
+				<string>csr-active-config</string>
+				<string>prev-lang:kbd</string>
+				<string>run-efi-updater</string>
 			</array>
 		</dict>
 		<key>LegacyEnable</key>


### PR DESCRIPTION
Summary: Added entries in NVRAM/Delete/7C436110-AB2A-4BBB-A880-FE41995C9F82

Comment: It can happen sometimes that you have wrong prev-lang:kbd (or other variables) on boot because NVRAM sets it wrongly. By adding NVRAM entries in Delete section, you're sure that each variable will be removed and added according to NVRAM/Add/7C436110-AB2A-4BBB-A880-FE41995C9F82