### PR TITLE
Clarify Function Names in OcApfsLib

### DIFF
--- a/Include/Acidanthera/Library/OcApfsLib.h
+++ b/Include/Acidanthera/Library/OcApfsLib.h
@@ -94,7 +94,7 @@ OcApfsConnectParentDevice (
   @retval EFI_SUCCESS if the device was connected.
 **/
 EFI_STATUS
-OcApfsConnectDevice (
+OcApfsConnectHandle (
   IN EFI_HANDLE  Handle,
   IN BOOLEAN     VerifyPolicy
   );

--- a/Library/OcApfsLib/OcApfsConnect.c
+++ b/Library/OcApfsLib/OcApfsConnect.c
@@ -476,7 +476,7 @@ OcApfsConfigure (
 }
 
 EFI_STATUS
-OcApfsConnectDevice (
+OcApfsConnectHandle (
   IN EFI_HANDLE  Handle,
   IN BOOLEAN     VerifyPolicy
   )

--- a/Library/OcApfsLib/OcApfsLib.c
+++ b/Library/OcApfsLib/OcApfsLib.c
@@ -47,7 +47,7 @@ ApfsNewPartitionArrived (
       &Handle
       );
     if (!EFI_ERROR (Status)) {
-      OcApfsConnectDevice (Handle, TRUE);
+      OcApfsConnectHandle (Handle, TRUE);
     } else {
       break;
     }
@@ -148,7 +148,7 @@ OcApfsConnectParentDevice (
         }
       }
 
-      Status2 = OcApfsConnectDevice (
+      Status2 = OcApfsConnectHandle (
         HandleBuffer[Index],
         VerifyPolicy
         );

--- a/Platform/OpenCore/OpenCoreUefi.c
+++ b/Platform/OpenCore/OpenCoreUefi.c
@@ -559,7 +559,7 @@ OcLoadBooterUefiSupport (
         Patch->Replace    = OC_BLOB_GET (&UserPatch->Replace);
 
         Patch->Comment    = OC_BLOB_GET (&UserPatch->Comment);
-        
+
         if (UserPatch->Mask.Size > 0) {
           Patch->Mask     = OC_BLOB_GET (&UserPatch->Mask);
         }


### PR DESCRIPTION
OcApfsLib has two functions with very similar naming
- OcApfsConnectDevice
- ApfsConnectDevice

This introduces some potential confusion especially when using as a 3rd party external library. 

This PR tries to remove such with the following changes that also seems to slightly better reflect what they do:
- OcApfsConnectDevice   ->    OcApfsConnectHandle
- ApfsConnectDevice       ->    OcApfsConnectDevice

PS: There are some other functions in `Library/OcApfsLib/OcApfsConnect.c` that are not canonically named that I haven't changed and one of these, `ApfsCheckOpenCoreScanPolicy`, does not appear to be used anywhere.