### PR TITLE
OpenCorePlatform: Fix reading Smbios.SystemUuid from wrong section

### DIFF
--- a/Library/OcMainLib/OpenCorePlatform.c
+++ b/Library/OcMainLib/OpenCorePlatform.c
@@ -216,7 +216,7 @@ OcPlatformUpdateSmbios (
       Data.SystemSerialNumber = OC_BLOB_GET (&Config->PlatformInfo.Smbios.SystemSerialNumber);
     }
 
-    if (!EFI_ERROR (AsciiStrToGuid (OC_BLOB_GET (&Config->PlatformInfo.DataHub.SystemUuid), &Uuid))) {
+    if (!EFI_ERROR (AsciiStrToGuid (OC_BLOB_GET (&Config->PlatformInfo.Smbios.SystemUuid), &Uuid))) {
       Data.SystemUUID         = &Uuid;
     }
 


### PR DESCRIPTION
I've double-checked the behaviour before and after this change - when `Automatic` = `false`, OC was previously loading the Smbios SystemUuid value from the DataHub section, as the code appeared to say (and which I am almost sure - especially as there is no comment there - was wrong), and after the change correctly loads it from the Smbios section.