### PR TITLE
[Sample.plist and SampleCustom.plist] Update HfsPlus driver name

### DIFF
--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1095,7 +1095,7 @@
 		<true/>
 		<key>Drivers</key>
 		<array>
-			<string>HfsPlus.efi</string>
+			<string>OpenHfsPlus.efi</string>
 			<string>OpenRuntime.efi</string>
 			<string>#OpenCanopy.efi</string>
 			<string>#AudioDxe.efi</string>


### PR DESCRIPTION
Hi there,
I don't know if this "typo" will ever be considered but: probably you forgot to rename HfsPlus into OpenHfsPlus.efi
Regards
dreamwhite
