### PR TITLE
ocvalidate: Support for error count cumulation during OcConfigurationInit call

### DIFF
--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -710,17 +710,19 @@ typedef enum {
 /**
   Initialize configuration with plist data.
 
-  @param[out]  Config   Configuration structure.
-  @param[in]   Buffer   Configuration buffer in plist format.
-  @param[in]   Size     Configuration buffer size.
+  @param[out]     Config      Configuration structure.
+  @param[in]      Buffer      Configuration buffer in plist format.
+  @param[in]      Size        Configuration buffer size.
+  @param[in,out]  ErrorCount  Errors detected duing initialisation. Optional.
 
   @retval  EFI_SUCCESS on success
 **/
 EFI_STATUS
 OcConfigurationInit (
-  OUT OC_GLOBAL_CONFIG   *Config,
-  IN  VOID               *Buffer,
-  IN  UINT32             Size
+  OUT      OC_GLOBAL_CONFIG   *Config,
+  IN       VOID               *Buffer,
+  IN       UINT32             Size,
+  IN  OUT  UINT32             *ErrorCount  OPTIONAL
   );
 
 /**

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -719,7 +719,7 @@ typedef enum {
 **/
 EFI_STATUS
 OcConfigurationInit (
-  OUT      OC_GLOBAL_CONFIG   *Config,
+      OUT  OC_GLOBAL_CONFIG   *Config,
   IN       VOID               *Buffer,
   IN       UINT32             Size,
   IN  OUT  UINT32             *ErrorCount  OPTIONAL

--- a/Include/Acidanthera/Library/OcSerializeLib.h
+++ b/Include/Acidanthera/Library/OcSerializeLib.h
@@ -31,10 +31,11 @@ typedef union OC_SCHEMA_INFO_ OC_SCHEMA_INFO;
 typedef
 VOID
 (*OC_APPLY) (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   );
 
 //
@@ -165,10 +166,11 @@ LookupConfigSchema (
 //
 VOID
 ParseSerializedDict (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   );
 
 //
@@ -176,10 +178,11 @@ ParseSerializedDict (
 //
 VOID
 ParseSerializedValue (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   );
 
 //
@@ -187,10 +190,11 @@ ParseSerializedValue (
 //
 VOID
 ParseSerializedBlob (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   );
 
 //
@@ -198,10 +202,11 @@ ParseSerializedBlob (
 //
 VOID
 ParseSerializedArray (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   );
 
 //
@@ -210,10 +215,11 @@ ParseSerializedArray (
 //
 VOID
 ParseSerializedMap (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   );
 
 //
@@ -222,10 +228,11 @@ ParseSerializedMap (
 //
 BOOLEAN
 ParseSerialized (
-  OUT VOID                *Serialized,
-  IN  OC_SCHEMA_INFO      *RootSchema,
-  IN  VOID                *PlistBuffer,
-  IN  UINT32              PlistSize
+  OUT      VOID                *Serialized,
+  IN       OC_SCHEMA_INFO      *RootSchema,
+  IN       VOID                *PlistBuffer,
+  IN       UINT32              PlistSize,
+  IN  OUT  UINT32              *ErrorCount  OPTIONAL
   );
 
 //

--- a/Include/Acidanthera/Library/OcSerializeLib.h
+++ b/Include/Acidanthera/Library/OcSerializeLib.h
@@ -31,7 +31,7 @@ typedef union OC_SCHEMA_INFO_ OC_SCHEMA_INFO;
 typedef
 VOID
 (*OC_APPLY) (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -166,7 +166,7 @@ LookupConfigSchema (
 //
 VOID
 ParseSerializedDict (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -178,7 +178,7 @@ ParseSerializedDict (
 //
 VOID
 ParseSerializedValue (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -190,19 +190,7 @@ ParseSerializedValue (
 //
 VOID
 ParseSerializedBlob (
-  OUT      VOID            *Serialized,
-  IN       XML_NODE        *Node,
-  IN       OC_SCHEMA_INFO  *Info,
-  IN       CONST CHAR8     *Context     OPTIONAL,
-  IN  OUT  UINT32          *ErrorCount  OPTIONAL
-  );
-
-//
-// Apply interface to parse serialized array
-//
-VOID
-ParseSerializedArray (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -215,7 +203,19 @@ ParseSerializedArray (
 //
 VOID
 ParseSerializedMap (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
+  );
+
+//
+// Apply interface to parse serialized array
+//
+VOID
+ParseSerializedArray (
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -228,7 +228,7 @@ ParseSerializedMap (
 //
 BOOLEAN
 ParseSerialized (
-  OUT      VOID                *Serialized,
+      OUT  VOID                *Serialized,
   IN       OC_SCHEMA_INFO      *RootSchema,
   IN       VOID                *PlistBuffer,
   IN       UINT32              PlistSize,

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -801,7 +801,7 @@ mRootConfigurationInfo = {
 
 EFI_STATUS
 OcConfigurationInit (
-  OUT      OC_GLOBAL_CONFIG   *Config,
+      OUT  OC_GLOBAL_CONFIG   *Config,
   IN       VOID               *Buffer,
   IN       UINT32             Size,
   IN  OUT  UINT32             *ErrorCount  OPTIONAL

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -810,7 +810,7 @@ OcConfigurationInit (
   BOOLEAN  Success;
 
   OC_GLOBAL_CONFIG_CONSTRUCT (Config, sizeof (*Config));
-  Success = ParseSerialized (Config, &mRootConfigurationInfo, Buffer, Size, ErrorCount != NULL ? ErrorCount : NULL);
+  Success = ParseSerialized (Config, &mRootConfigurationInfo, Buffer, Size, ErrorCount);
 
   if (!Success) {
     OC_GLOBAL_CONFIG_DESTRUCT (Config, sizeof (*Config));

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -801,15 +801,16 @@ mRootConfigurationInfo = {
 
 EFI_STATUS
 OcConfigurationInit (
-  OUT OC_GLOBAL_CONFIG   *Config,
-  IN  VOID               *Buffer,
-  IN  UINT32             Size
+  OUT      OC_GLOBAL_CONFIG   *Config,
+  IN       VOID               *Buffer,
+  IN       UINT32             Size,
+  IN  OUT  UINT32             *ErrorCount  OPTIONAL
   )
 {
   BOOLEAN  Success;
 
   OC_GLOBAL_CONFIG_CONSTRUCT (Config, sizeof (*Config));
-  Success = ParseSerialized (Config, &mRootConfigurationInfo, Buffer, Size);
+  Success = ParseSerialized (Config, &mRootConfigurationInfo, Buffer, Size, ErrorCount != NULL ? ErrorCount : NULL);
 
   if (!Success) {
     OC_GLOBAL_CONFIG_DESTRUCT (Config, sizeof (*Config));

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -504,7 +504,7 @@ OcMiscEarlyInit (
   if (ConfigData != NULL) {
     DEBUG ((DEBUG_INFO, "OC: Loaded configuration of %u bytes\n", ConfigDataSize));
 
-    Status = OcConfigurationInit (Config, ConfigData, ConfigDataSize);
+    Status = OcConfigurationInit (Config, ConfigData, ConfigDataSize, NULL);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "OC: Failed to parse configuration!\n"));
       CpuDeadLoop ();

--- a/Library/OcMainLib/OpenCoreNvram.c
+++ b/Library/OcMainLib/OpenCoreNvram.c
@@ -290,7 +290,7 @@ OcLoadLegacyNvram (
   }
 
   OC_NVRAM_STORAGE_CONSTRUCT (&Nvram, sizeof (Nvram));
-  IsValid = ParseSerialized (&Nvram, &mNvramStorageRootSchema, FileBuffer, FileSize);
+  IsValid = ParseSerialized (&Nvram, &mNvramStorageRootSchema, FileBuffer, FileSize, NULL);
   FreePool (FileBuffer);
 
   if (!IsValid || Nvram.Version != OC_NVRAM_STORAGE_VERSION) {

--- a/Library/OcSerializeLib/OcSerializeLib.c
+++ b/Library/OcSerializeLib/OcSerializeLib.c
@@ -159,7 +159,7 @@ ParseSerializedDict (
       continue;
     }
 
-    NewSchema->Apply (Serialized, CurrentValue, &NewSchema->Info, CurrentKey, ErrorCount != NULL ? ErrorCount : ErrorCount);
+    NewSchema->Apply (Serialized, CurrentValue, &NewSchema->Info, CurrentKey, ErrorCount);
   }
 
   DEBUG_CODE_BEGIN ();
@@ -409,7 +409,7 @@ ParseSerializedMap (
       }
     }
 
-    Info->List.Schema->Apply (NewValue, ChildNode, &Info->List.Schema->Info, CurrentKey, ErrorCount != NULL ? ErrorCount : ErrorCount);
+    Info->List.Schema->Apply (NewValue, ChildNode, &Info->List.Schema->Info, CurrentKey, ErrorCount);
   }
 }
 
@@ -456,7 +456,7 @@ ParseSerializedArray (
       continue;
     }
 
-    Info->List.Schema->Apply (NewValue, ChildNode, &Info->List.Schema->Info, Context, ErrorCount != NULL ? ErrorCount : ErrorCount);
+    Info->List.Schema->Apply (NewValue, ChildNode, &Info->List.Schema->Info, Context, ErrorCount);
   }
 }
 

--- a/Library/OcSerializeLib/OcSerializeLib.c
+++ b/Library/OcSerializeLib/OcSerializeLib.c
@@ -91,10 +91,11 @@ LookupConfigSchema (
 
 VOID
 ParseSerializedDict (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   )
 {
   UINT32         DictSize;
@@ -112,6 +113,9 @@ ParseSerializedDict (
 
     if (CurrentKey == NULL) {
       DEBUG ((DEBUG_WARN, "OCS: No serialized key at %u index, context <%a>!\n", Index, Context));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
       continue;
     }
 
@@ -131,6 +135,9 @@ ParseSerializedDict (
 
     if (NewSchema == NULL) {
       DEBUG ((DEBUG_WARN, "OCS: No schema for %a at %u index, context <%a>!\n", CurrentKey, Index, Context));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
       continue;
     }
 
@@ -146,10 +153,13 @@ ParseSerializedDict (
         XmlNodeName (OldValue),
         Context
         ));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
       continue;
     }
 
-    NewSchema->Apply (Serialized, CurrentValue, &NewSchema->Info, CurrentKey);
+    NewSchema->Apply (Serialized, CurrentValue, &NewSchema->Info, CurrentKey, ErrorCount != NULL ? ErrorCount : ErrorCount);
   }
 
   DEBUG_CODE_BEGIN ();
@@ -178,6 +188,9 @@ ParseSerializedDict (
         Info->Dict.Schema[Index].Name,
         Context
         ));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
     }
   }
 
@@ -186,10 +199,11 @@ ParseSerializedDict (
 
 VOID
 ParseSerializedValue (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   )
 {
   BOOLEAN  Result;
@@ -227,15 +241,19 @@ ParseSerializedValue (
       XmlNodeContent (Node) != NULL ? XmlNodeContent (Node) : "empty",
       Context
       ));
+    if (ErrorCount != NULL) {
+      ++*ErrorCount;
+    }
   }
 }
 
 VOID
 ParseSerializedBlob (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   )
 {
   BOOLEAN  Result;
@@ -267,6 +285,9 @@ ParseSerializedBlob (
       GetSchemaTypeName (Info->Blob.Type),
       Context
       ));
+    if (ErrorCount != NULL) {
+      ++*ErrorCount;
+    }
     return;
   }
 
@@ -282,6 +303,9 @@ ParseSerializedBlob (
       GetSchemaTypeName (Info->Value.Type),
       Context
       ));
+    if (ErrorCount != NULL) {
+      ++*ErrorCount;
+    }
     return;
   }
 
@@ -308,15 +332,19 @@ ParseSerializedBlob (
       XmlNodeContent (Node) != NULL ? XmlNodeContent (Node) : "empty",
       Context
       ));
+    if (ErrorCount != NULL) {
+      ++*ErrorCount;
+    }
   }
 }
 
 VOID
 ParseSerializedMap (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   )
 {
   UINT32       DictSize;
@@ -337,6 +365,9 @@ ParseSerializedMap (
 
     if (CurrentKeyLen == 0) {
       DEBUG ((DEBUG_INFO, "OCS: No get serialized key at %u index!\n", Index));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
       continue;
     }
 
@@ -349,6 +380,9 @@ ParseSerializedMap (
 
     if (PlistNodeCast (ChildNode, Info->List.Schema->Type) == NULL) {
       DEBUG ((DEBUG_INFO, "OCS: No valid serialized value at %u index!\n", Index));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
       continue;
     }
 
@@ -359,6 +393,9 @@ ParseSerializedMap (
       );
     if (Success == FALSE) {
       DEBUG ((DEBUG_INFO, "OCS: Couldn't insert dict serialized at %u index!\n", Index));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
       continue;
     }
 
@@ -367,18 +404,22 @@ ParseSerializedMap (
       AsciiStrnCpyS ((CHAR8 *) NewKeyValue, CurrentKeyLen, CurrentKey, CurrentKeyLen - 1);
     } else {
       DEBUG ((DEBUG_INFO, "OCS: Couldn't allocate key name at %u index!\n", Index));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
     }
 
-    Info->List.Schema->Apply (NewValue, ChildNode, &Info->List.Schema->Info, CurrentKey);
+    Info->List.Schema->Apply (NewValue, ChildNode, &Info->List.Schema->Info, CurrentKey, ErrorCount != NULL ? ErrorCount : ErrorCount);
   }
 }
 
 VOID
 ParseSerializedArray (
-  OUT VOID            *Serialized,
-  IN  XML_NODE        *Node,
-  IN  OC_SCHEMA_INFO  *Info,
-  IN  CONST CHAR8     *Context  OPTIONAL
+  OUT      VOID            *Serialized,
+  IN       XML_NODE        *Node,
+  IN       OC_SCHEMA_INFO  *Info,
+  IN       CONST CHAR8     *Context     OPTIONAL,
+  IN  OUT  UINT32          *ErrorCount  OPTIONAL
   )
 {
   UINT32    ArraySize;
@@ -396,6 +437,9 @@ ParseSerializedArray (
 
     if (ChildNode == NULL) {
       DEBUG ((DEBUG_INFO, "OCS: Couldn't get array serialized at %u index!\n", Index));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
       continue;
     }
 
@@ -406,19 +450,23 @@ ParseSerializedArray (
       );
     if (Success == FALSE) {
       DEBUG ((DEBUG_INFO, "OCS: Couldn't insert array serialized at %u index!\n", Index));
+      if (ErrorCount != NULL) {
+        ++*ErrorCount;
+      }
       continue;
     }
 
-    Info->List.Schema->Apply (NewValue, ChildNode, &Info->List.Schema->Info, Context);
+    Info->List.Schema->Apply (NewValue, ChildNode, &Info->List.Schema->Info, Context, ErrorCount != NULL ? ErrorCount : ErrorCount);
   }
 }
 
 BOOLEAN
 ParseSerialized (
-  OUT VOID            *Serialized,
-  IN  OC_SCHEMA_INFO  *RootSchema,
-  IN  VOID            *PlistBuffer,
-  IN  UINT32          PlistSize
+  OUT      VOID                *Serialized,
+  IN       OC_SCHEMA_INFO      *RootSchema,
+  IN       VOID                *PlistBuffer,
+  IN       UINT32              PlistSize,
+  IN  OUT  UINT32              *ErrorCount  OPTIONAL
   )
 {
   XML_DOCUMENT        *Document;
@@ -428,6 +476,9 @@ ParseSerialized (
 
   if (Document == NULL) {
     DEBUG ((DEBUG_INFO, "OCS: Couldn't parse serialized file!\n"));
+    if (ErrorCount != NULL) {
+      ++*ErrorCount;
+    }
     return FALSE;
   }
 
@@ -436,6 +487,9 @@ ParseSerialized (
   if (RootDict == NULL) {
     DEBUG ((DEBUG_INFO, "OCS: Couldn't get serialized root!\n"));
     XmlDocumentFree (Document);
+    if (ErrorCount != NULL) {
+      ++*ErrorCount;
+    }
     return FALSE;
   }
 
@@ -443,7 +497,8 @@ ParseSerialized (
     Serialized,
     RootDict,
     RootSchema,
-    "root"
+    "root",
+    ErrorCount
     );
 
   XmlDocumentFree (Document);

--- a/Library/OcSerializeLib/OcSerializeLib.c
+++ b/Library/OcSerializeLib/OcSerializeLib.c
@@ -91,7 +91,7 @@ LookupConfigSchema (
 
 VOID
 ParseSerializedDict (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -199,7 +199,7 @@ ParseSerializedDict (
 
 VOID
 ParseSerializedValue (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -249,7 +249,7 @@ ParseSerializedValue (
 
 VOID
 ParseSerializedBlob (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -340,7 +340,7 @@ ParseSerializedBlob (
 
 VOID
 ParseSerializedMap (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -415,7 +415,7 @@ ParseSerializedMap (
 
 VOID
 ParseSerializedArray (
-  OUT      VOID            *Serialized,
+      OUT  VOID            *Serialized,
   IN       XML_NODE        *Node,
   IN       OC_SCHEMA_INFO  *Info,
   IN       CONST CHAR8     *Context     OPTIONAL,
@@ -462,7 +462,7 @@ ParseSerializedArray (
 
 BOOLEAN
 ParseSerialized (
-  OUT      VOID                *Serialized,
+      OUT  VOID                *Serialized,
   IN       OC_SCHEMA_INFO      *RootSchema,
   IN       VOID                *PlistBuffer,
   IN       UINT32              PlistSize,

--- a/Library/OcStorageLib/OcStorageLib.c
+++ b/Library/OcStorageLib/OcStorageLib.c
@@ -151,7 +151,7 @@ OcStorageInitializeVault (
   }
 
   OC_STORAGE_VAULT_CONSTRUCT (&Context->Vault, sizeof (Context->Vault));
-  if (!ParseSerialized (&Context->Vault, &mVaultSchema, Vault, VaultSize)) {
+  if (!ParseSerialized (&Context->Vault, &mVaultSchema, Vault, VaultSize, NULL)) {
     OC_STORAGE_VAULT_DESTRUCT (&Context->Vault, sizeof (Context->Vault));
     DEBUG ((DEBUG_ERROR, "OCST: Invalid vault data\n"));
     return EFI_INVALID_PARAMETER;

--- a/Utilities/ocvalidate/ocvalidate.c
+++ b/Utilities/ocvalidate/ocvalidate.c
@@ -106,7 +106,6 @@ int ENTRY_POINT(int argc, const char *argv[]) {
   // Initialise config structure to be checked, and exit on error.
   //
   Status = OcConfigurationInit (&Config, ConfigFileBuffer, ConfigFileSize, &ErrorCount);
-  DEBUG ((DEBUG_WARN, "ErrorCount after OcConfigurationInit - %u!\n", ErrorCount));
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Invalid config\n"));
     return -1;

--- a/Utilities/ocvalidate/ocvalidate.c
+++ b/Utilities/ocvalidate/ocvalidate.c
@@ -69,6 +69,8 @@ int ENTRY_POINT(int argc, const char *argv[]) {
   EFI_STATUS         Status;
   UINT32             ErrorCount;
 
+  ErrorCount = 0;
+
   //
   // Enable PCD debug logging.
   //
@@ -103,7 +105,8 @@ int ENTRY_POINT(int argc, const char *argv[]) {
   //
   // Initialise config structure to be checked, and exit on error.
   //
-  Status = OcConfigurationInit (&Config, ConfigFileBuffer, ConfigFileSize);
+  Status = OcConfigurationInit (&Config, ConfigFileBuffer, ConfigFileSize, &ErrorCount);
+  DEBUG ((DEBUG_WARN, "ErrorCount after OcConfigurationInit - %u!\n", ErrorCount));
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Invalid config\n"));
     return -1;
@@ -113,7 +116,7 @@ int ENTRY_POINT(int argc, const char *argv[]) {
   // Print a newline that splits errors between OcConfigurationInit and config checkers.
   //
   DEBUG ((DEBUG_ERROR, "\n"));
-  ErrorCount = CheckConfig (&Config);
+  ErrorCount += CheckConfig (&Config);
 
   OcConfigurationFree (&Config);
   FreePool (ConfigFileBuffer);
@@ -148,7 +151,7 @@ INT32 LLVMFuzzerTestOneInput(CONST UINT8 *Data, UINTN Size) {
   NewData = AllocatePool (Size);
   if (NewData != NULL) {
     CopyMem (NewData, Data, Size);
-    OcConfigurationInit (&Config, NewData, Size);
+    OcConfigurationInit (&Config, NewData, Size, NULL);
     OcConfigurationFree (&Config);
     FreePool (NewData);
   }


### PR DESCRIPTION
This PR adds support for error count cumulation during serialisation check in OcSerializeLib, which closes https://github.com/acidanthera/bugtracker/issues/1467 as well.