### PR TITLE
Fix some incorrect spellings of possessive "its" throughout the project

### DIFF
--- a/Include/Acidanthera/Library/OcDeviceTreeLib.h
+++ b/Include/Acidanthera/Library/OcDeviceTreeLib.h
@@ -125,7 +125,7 @@ DTLookupEntry (
 /**
   An Entry Iterator maintains three variables that are of interest to clients.
   First is an "OutermostScope" which defines the outer boundry of the iteration.
-  This is defined by the starting entry and includes that entry plus all of it's
+  This is defined by the starting entry and includes that entry plus all of its
   embedded entries. Second is a "currentScope" which is the entry the iterator is
   currently in. And third is a "currentPosition" which is the last entry returned
   during an iteration.
@@ -165,7 +165,7 @@ DTEnterEntry (
 
 /**
   Exit to Parent Entry
-  Move an Entry Iterator out of the current entry back into the scope of it's parent
+  Move an Entry Iterator out of the current entry back into the scope of its parent
   entry. The currentPosition of the iterator is reset to the current entry (the
   previous currentScope), so the next iteration call will continue where it left off.
   This position is returned in parameter "currentPosition".

--- a/Include/Acidanthera/Library/OcMiscLib.h
+++ b/Include/Acidanthera/Library/OcMiscLib.h
@@ -174,7 +174,7 @@ MultThenDivU64x64x32 (
   bit of PcdDebugProperyMask is set, then this macro evaluates the integer
   expression specified by Expression.  If the value of Expression differs from ExpectedValue, then
   DebugPrint() is called passing in the source filename, source line number,
-  Expression, it's value and ExpectedValue; then ASSERT(FALSE) is called to
+  Expression, its value and ExpectedValue; then ASSERT(FALSE) is called to
   cause a breakpoint, deadloop or no-op depending on PcdDebugProperyMask.
 
   @param  Expression  Integer expression (should be convertible to INTN).

--- a/Include/Apple/IndustryStandard/AppleMachoImage.h
+++ b/Include/Apple/IndustryStandard/AppleMachoImage.h
@@ -2178,9 +2178,9 @@ typedef union {
 // sections in different files.
 //
 // The n_value field for all symbol table entries (including N_STAB's) gets
-// updated by the link editor based on the value of it's n_sect field and where
+// updated by the link editor based on the value of its n_sect field and where
 // the section n_sect references gets relocated.  If the value of the n_sect
-// field is NO_SECT then it's n_value field is not changed by the link editor.
+// field is NO_SECT then its n_value field is not changed by the link editor.
 //
 #define NO_SECT     0  ///< symbol is not in any section
 #define MAX_SECT  255  ///< 1 thru 255 inclusive
@@ -2314,7 +2314,7 @@ typedef struct {
 #define MACH_RELOC_ABSOLUTE  0U    ///< absolute relocation type for Mach-O files
 
 //
-// The r_address is not really the address as it's name indicates but an
+// The r_address is not really the address as its name indicates but an
 // offset.  In 4.3BSD a.out objects this offset is from the start of the
 // "segment" for which relocation entry is for (text or data).  For Mach-O
 // object files it is also an offset but from the start of the "section" for

--- a/Library/DuetBdsLib/BdsConnect.c
+++ b/Library/DuetBdsLib/BdsConnect.c
@@ -219,7 +219,7 @@ BdsLibConnectDevicePath (
   If the handle is bus type handler, all childrens also will be connected recursively
   by gBS->ConnectController().
 
-  @retval EFI_SUCCESS           All handles and it's child handle have been connected
+  @retval EFI_SUCCESS           All handles and their child handles have been connected
   @retval EFI_STATUS            Error status returned by of gBS->LocateHandleBuffer().
 
 **/

--- a/Library/OcAppleImg4Lib/libDER/DER_Decode.c
+++ b/Library/OcAppleImg4Lib/libDER/DER_Decode.c
@@ -167,7 +167,7 @@ DERReturn DERParseBitString(
 
 /* 
  * Given a BOOLEAN, in the form of its raw content bytes, 
- * obtain it's value.
+ * obtain its value.
  */
 DERReturn DERParseBoolean(
 	const DERItem	*contents,

--- a/Library/OcAppleImg4Lib/libDER/DER_Decode.h
+++ b/Library/OcAppleImg4Lib/libDER/DER_Decode.h
@@ -69,7 +69,7 @@ DERReturn DERParseBitString(
 
 /* 
  * Given a BOOLEAN, in the form of its raw content bytes, 
- * obtain it's value.
+ * obtain its value.
  */
 DERReturn DERParseBoolean(
 	const DERItem	*contents,

--- a/Library/OcDataHubLib/DataHub.h
+++ b/Library/OcDataHubLib/DataHub.h
@@ -85,7 +85,7 @@ typedef struct {
 #define DATA_ENTRY_FROM_LINK(link)  CR (link, EFI_DATA_ENTRY, Link, EFI_DATA_ENTRY_SIGNATURE)
 
 //
-// Private data to contain the filter driver Event and it's
+// Private data to contain the filter driver Event and its
 //  associated EFI_TPL.
 //
 #define EFI_DATA_HUB_FILTER_DRIVER_SIGNATURE  SIGNATURE_32 ('D', 'h', 'F', 'd')

--- a/Platform/CrScreenshotDxe/README.md
+++ b/Platform/CrScreenshotDxe/README.md
@@ -21,7 +21,7 @@ It's a normal EDK2-compatible DXE driver, just add it to your package's DSC file
 ## Usage
 Load the driver, insert FAT32-formatted USB drive and press F10 to take screenshots from primary graphic console available at the moment. 
 
-To indicate it's status, the driver shows a small colored rectangle in top-left corner of the screen for half a second.
+To indicate its status, the driver shows a small colored rectangle in top-left corner of the screen for half a second.
 
 Rectangle color codes:
 - Yellow - no writable FS found, screenshot is not taken

--- a/Utilities/LogoutHook/nvramdump.c
+++ b/Utilities/LogoutHook/nvramdump.c
@@ -26,7 +26,7 @@ static io_registry_entry_t gOptionsRef;
 // GetOFVariable(name, nameRef, valueRef)
 //
 //   Get the named firmware variable.
-//   Return it and it's symbol in valueRef and nameRef.
+//   Return it and its symbol in valueRef and nameRef.
 //
 static kern_return_t GetOFVariable(char *name, CFStringRef *nameRef,
                                    CFTypeRef *valueRef)


### PR DESCRIPTION
This fixes some wrong language in the documentation (source code comments and Markdown files), but the purpose of the pull request is really to ask whether you'd accept a pull request for a feature I intend to implement, namely a way to blacklist (via config.plist) certain entries, for example via specifying the partition UUID, so that AddBootEntryFromBootOption will not add them to the boot choices. If it is not an upstreamable change, I wouldn't bother creating this feature, since then the maintenance burden for the change is greater than the gain I'd get (my use case is a multiboot situation with Chromium OS, where I prefer a custom Entries entry for booting its grubx64.efi directly, rather than relying on the bcfg/efibootmgr nvram BootOption) as opposed to just manually deleting the bootx64.efi from the Chromium OS drive's ESP after each CROS update (my motherboard's firmware seemingly autogenerates partition style boot options when it detects an ESP with EFI/BOOT/BOOTx64.efi present).
