### PR TITLE
ocvalidate: allow OEM special string in Generic/SystemUUID

### DIFF
--- a/Utilities/ocvalidate/README.md
+++ b/Utilities/ocvalidate/README.md
@@ -98,6 +98,7 @@ Utility to validate whether a `config.plist` matches requirements and convention
 #### Generic
 - SystemProductName: Only real Mac models are accepted.
 - SystemMemoryStatus: Only `Auto`, `Upgradable`, or `Soldered` are accepted.
+- SystemUUID: Only empty string, `OEM` or valid UUID are accepted.
 - ProcessorType: Only known first byte can be set.
 
 ### UEFI

--- a/Utilities/ocvalidate/ValidatePlatformInfo.c
+++ b/Utilities/ocvalidate/ValidatePlatformInfo.c
@@ -94,8 +94,10 @@ CheckPlatformInfoGeneric (
   }
 
   AsciiSystemUUID     = OC_BLOB_GET (&UserPlatformInfo->Generic.SystemUuid);
-  if (AsciiSystemUUID[0] != '\0' && !AsciiGuidIsLegal (AsciiSystemUUID)) {
-    DEBUG ((DEBUG_WARN, "PlatformInfo->Generic->SystemUUID is borked!\n"));
+  if (AsciiSystemUUID[0] != '\0'
+    && AsciiStrCmp (AsciiSystemUUID, "OEM") != 0
+    && !AsciiGuidIsLegal (AsciiSystemUUID)) {
+    DEBUG ((DEBUG_WARN, "PlatformInfo->Generic->SystemUUID is borked (Can only be empty, special string OEM or valid UUID)!\n"));
     ++ErrorCount;
   }
 


### PR DESCRIPTION
 - tested!
 - have used "special string OEM" instead of just "OEM" in warning, to try to avoid same sort of ambiguity in wording addressed in https://github.com/acidanthera/OpenCorePkg/pull/208