### PR TITLE
Down keys - WIP

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -6216,6 +6216,24 @@ functioning. Feature highlights:
 
 \begin{enumerate}
 
+  \item
+  \texttt{DownkeysHandler}\\
+  \textbf{Type}: \texttt{plist\ string}\\
+  \textbf{Failsafe}: \texttt{Auto}\\
+  \textbf{Description}: Configure additional keyboard handling to enable more fluent re-rendering within
+  bootpicker. When applied, affects both \texttt{Builtin} bootpicker and OpenCanopy. For best UI experience
+  this setting should always be enabled when \texttt{KeySupport} is disabled,
+  and should normally be disabled when \texttt{KeySupport} is enabled. On
+  some less common configurations (particularly some PS/2 keyboards) enabling this setting together with
+  \texttt{KeySupport} is required to obtain correct bootpicker key repeat behaviour.
+
+  \begin{itemize}
+  \tightlist
+  \item \texttt{Auto} --- Performs automatic choice based on \texttt{KeySupport} setting.
+  \item \texttt{Enabled} --- Add additional downkey handling.
+  \item \texttt{Disabled} --- Do not add additional downkey handling.
+  \end{itemize}
+
 \item
   \texttt{KeyFiltering}\\
   \textbf{Type}: \texttt{plist\ boolean}\\

--- a/Include/Acidanthera/Library/OcAppleKeyMapLib.h
+++ b/Include/Acidanthera/Library/OcAppleKeyMapLib.h
@@ -1,5 +1,6 @@
 /** @file
   Copyright (C) 2019, Download-Fritz. All rights reserved.
+  Additions (downkeys support) copyright (C) 2021 Mike Beaton. All rights reserved.
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -21,6 +22,111 @@
   Default buffer size for key map.
 **/
 #define OC_KEY_MAP_DEFAULT_SIZE 8
+
+/**
+  Default buffer size for held keys in downkeys support.
+**/
+#define OC_HELD_KEYS_DEFAULT_SIZE 8
+
+/**
+  Default initial and subsequent key repeat delays in milliseconds.
+**/
+#define OC_DOWNKEYS_DEFAULT_INITIAL_DELAY    350
+#define OC_DOWNKEYS_DEFAULT_SUBSEQUENT_DELAY 80
+
+/**
+  Info for tracking key repeat timing in downkeys support.
+**/
+typedef struct {
+  INT64             KeyTime;
+  APPLE_KEY_CODE    Key;
+} OC_HELD_KEY_INFO;
+
+/**
+  Repeat key context.
+**/
+typedef struct {
+  UINT64                             InitialDelay;
+  UINT64                             SubsequentDelay;
+  UINT64                             PreviousTime;
+  APPLE_KEY_MAP_AGGREGATOR_PROTOCOL  *KeyMap;
+  OC_HELD_KEY_INFO                   *KeysHeld;
+  UINTN                              NumKeysHeld;
+  UINTN                              MaxKeysHeld;
+} OC_KEY_REPEAT_CONTEXT;
+
+/** Initialise OC key repeat context. (No later  matching uninitialize call exists or is required.)
+
+  @param[out] Context                 Key repeat context structure to initialise.
+  @param[in]  KeyMap                  The key map aggregator protocol instance to use.
+  @param[in]  MaxKeysHeld             Number of entries in user allocated held keys buffer.
+  @param[in]  KeysHeld                Caller allocated held keys buffer to use.
+                                      Optional, but if not provided OcGetUpDownKeys can only
+                                      return the underlying data from KeyMap->GetKeyStrokes
+                                      (i.e. up key, held key and repeat handling are not supported).
+  @param[in]  InitialDelay            Key repeat initial delay.
+                                      Same time units as CurrentTime passed to subsequent
+                                      calls of OcGetUpDownKeys.
+  @param[in]  SubsequentDelay         Key repeat subsequent delay.
+                                      Same time units as CurrentTime passed to subsequent
+                                      calls of OcGetUpDownKeys.
+  @param[in]  PreventInitialRepeat    If true, set up buffer so that keys held at init do not
+                                      repeat until released and then pressed again.
+
+  @retval EFI_SUCCESS                 The repeat context has been initialised.
+  @retval other                       An error returned by a sub-operation.
+**/
+EFI_STATUS
+OcInitKeyRepeatContext(
+     OUT OC_KEY_REPEAT_CONTEXT              *Context,
+  IN     APPLE_KEY_MAP_AGGREGATOR_PROTOCOL  *KeyMap,
+  IN     UINTN                              MaxKeysHeld,
+  IN     OC_HELD_KEY_INFO                   *KeysHeld       OPTIONAL,
+  IN     UINT64                             InitialDelay,
+  IN     UINT64                             SubsequentDelay,
+  IN     BOOLEAN                            PreventInitialRepeat
+  );
+
+/** Returns all key transitions and key modifiers into the appropiate buffers.
+
+  @param[in,out]  RepeatContext       On input the previous (or newly initialised) repeat context.
+                                      On output the newly updated key repeat context; values of
+                                      interest to the caller are not intended to be read from the
+                                      context, but from the other parameters above.
+  @param[out]     Modifiers           The key modifiers currently applicable.
+  @param[in,out]  NumKeysUp           On input the number of keys allocated for KeysUp. Ignored
+                                      if KeysUp is null.
+                                      On output the number of up keys detected, with their keycodes
+                                      returned into KeysUp if present.
+  @param[out]     KeysUp              A Pointer to a optional caller-allocated buffer in which new
+                                      up keycodes get returned.
+  @param[in,out]  NumKeysDown         On input with KeysDown non-null, the number of keys
+                                      allocated for KeysDown and the total number of keys to check.
+                                      On input and with KeysDown null, this parameter still
+                                      represents the total number of keys to check.
+                                      On output the number of down keys detected, with their
+                                      keycodes returned into KeysDown if present.
+  @param[out]     KeysDown            A Pointer to an optional caller-allocated buffer in which new
+                                      down keycodes get returned.
+  @param[in]  CurrentTime             Current time (arbitrary units with sufficient resolution).
+                                      Need not be valid on initial call only.
+
+  @retval EFI_SUCCESS                 The requested key transitions and states have been returned
+                                      or updated as requested in the various out parameters.
+  @retval EFI_UNSUPPORTED             Unsupported buffer/size combination.
+  @retval other                       An error returned by a sub-operation.
+**/
+EFI_STATUS
+EFIAPI
+OcGetUpDownKeys (
+  IN OUT OC_KEY_REPEAT_CONTEXT              *RepeatContext,
+     OUT APPLE_MODIFIER_MAP                 *Modifiers,
+  IN OUT UINTN                              *NumKeysUp,
+     OUT APPLE_KEY_CODE                     *KeysUp       OPTIONAL,
+  IN OUT UINTN                              *NumKeysDown,
+     OUT APPLE_KEY_CODE                     *KeysDown     OPTIONAL,
+  IN     UINT64                             CurrentTime
+  );
 
 /**
   Returns the previously install Apple Key Map Database protocol.
@@ -85,15 +191,20 @@ OcKeyMapHasKey (
 /**
   Performs keyboard input flush.
 
-  @param[in] KeyMap        Apple Key Map Aggregator protocol.
-  @param[in] Key           Key to wait for removal or 0.
-  @param[in] FlushConsole  Also flush console input.
+  @param[in] KeyMap             Apple Key Map Aggregator protocol.
+  @param[in] Key                Key to wait for removal or 0.
+  @param[in] FlushConsole       Also flush console input.
+  @param[in] EnableFlush        If false, return immediately and do nothing.
+  @param[in] ShowRunningKeys    If true, emit flush GetKeyStrokes calls to
+                                running keys debug view in builtin picker.
 **/
 VOID
 OcKeyMapFlush (
   IN APPLE_KEY_MAP_AGGREGATOR_PROTOCOL  *KeyMap,
   IN APPLE_KEY_CODE                     Key,
-  IN BOOLEAN                            FlushConsole
+  IN BOOLEAN                            FlushConsole,
+  IN BOOLEAN                            EnableFlush,
+  IN BOOLEAN                            ShowRunningKeys
   );
 
 #endif // OC_APPLE_KEY_MAP_LIB_H

--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -549,7 +549,6 @@ INTN
      OUT BOOLEAN                            *SetDefault  OPTIONAL
   );
 
-
 /**
   Play audio file for context.
 **/
@@ -1025,14 +1024,16 @@ OcIsAppleHibernateWake (
   Check pressed hotkeys and update booter context based on this.
 
   @param[in,out]  Context       Picker context.
+
+  @return                       Located Apple Key Map Aggregator protocol instance.
 **/
-VOID
+APPLE_KEY_MAP_AGGREGATOR_PROTOCOL *
 OcLoadPickerHotKeys (
-  IN OUT OC_PICKER_CONTEXT  *Context
+  IN OUT OC_PICKER_CONTEXT                  *Context
   );
 
 /**
-  Default index mapping macros.
+  Key index mappings.
 **/
 #define OC_INPUT_STR            "123456789ABCDEFGHIJKLMNOPQRSTUVXWZ"
 #define OC_INPUT_MAX            L_STR_LEN (OC_INPUT_STR)
@@ -1049,14 +1050,39 @@ OcLoadPickerHotKeys (
 #define OC_INPUT_MORE           -11       ///< Show more entries (press space)
 #define OC_INPUT_VOICE_OVER     -12       ///< Toggle VoiceOver (press CMD+F5)
 #define OC_INPUT_INTERNAL       -13       ///< Accepted internal hotkey (e.g. Apple)
-#define OC_INPUT_FUNCTIONAL(x) (-20 - (x))  ///< Functional hotkeys
+#define OC_INPUT_MODIFIERS_ONLY -20       ///< No key press, returned early to allow GUI response to modifiers
+#define OC_INPUT_FUNCTIONAL(x) (-20 - (x))  ///< Function hotkeys
+
+#if defined(OC_SHOW_RUNNING_KEYS)
+/**
+  Running display of held keys, in builtin picker only.
+
+  @param[in]      NumKeysUp       Number of keys that went up.
+  @param[in]      NumKeysDown     Number of keys that went down.
+  @param[in]      NumKeysHeld     Number of keys held.
+  @param[in]      Modifiers       Key modifiers.
+  @param[in]      CallerID        Caller ID to display if not using downkeys handler.
+  @param[in]      UsingDownkeys   Set to true if using downkeys handler in the kb loop.
+**/
+VOID
+OcShowRunningKeys (
+  UINTN                     NumKeysUp,
+  UINTN                     NumKeysDown,
+  UINTN                     NumKeysHeld,
+  APPLE_MODIFIER_MAP        Modifiers,
+  CHAR16                    CallerID,
+  BOOLEAN                   UsingDownkeys
+  );
+#endif
 
 /**
   Obtains key index from user input.
 
   @param[in,out]  Context      Picker context.
   @param[in]      KeyMap       Apple Key Map Aggregator protocol.
-  @param[out]     SetDefault   Set boot option as default, optional.
+  @param[out]     SetDefault   Pass back whether to set selected boot option as default.
+                               Optional, when not present key combinations which would attempt to
+                               set default boot will not detect.
 
   @returns key index [0, OC_INPUT_MAX) or OC_INPUT_* value.
   @returns OC_INPUT_TIMEOUT when no key is pressed.
@@ -1071,12 +1097,40 @@ OcGetAppleKeyIndex (
   );
 
 /**
+  Initialise held keys buffer. Call before looped calls to OcWaitForAppleKeyIndex or OcGetAppleKeyIndex.
+
+  @param[in]      Input         Input config section.
+  @param[in]      KeyMap        Apple Key Map Aggregator protocol.
+**/
+VOID
+OcInitDownkeys (
+    // TODO: !
+    //IN OC_UEFI_INPUT                          *Input,
+    //IN APPLE_KEY_MAP_AGGREGATOR_PROTOCOL      *KeyMap
+  );
+
+/**
+  Calculate timeout end time in correct format for OcWaitForAppleKeyIndex.
+
+  @param[in]      Timeout       Required timeout in milliseconds.
+
+  @returns Now plus timeout, expressed in system nanosecond clock.
+**/
+UINT64
+OcWaitForAppleKeyIndexGetEndTime(
+  IN UINTN    Timeout
+  );
+
+/**
   Waits for key index from user input.
 
   @param[in,out]  Context      Picker context.
   @param[in]      KeyMap       Apple Key Map Aggregator protocol.
-  @param[in]      Timeout      Timeout to wait for in milliseconds.
-  @param[out]     SetDefault   Set boot option as default, optional.
+  @param[in]      EndTime      Time at which to end timeout, system nanosecond clock.
+  @param[in,out]  SetDefault   On input, previous OC key modifiers.
+                               On output, new OC key modifiers. Invalid
+                               key w/ new modifiers is returned immediately
+                               when modifiers change, to allow UI update.
 
   @returns key index [0, OC_INPUT_MAX) or OC_INPUT_* value.
 **/
@@ -1084,8 +1138,8 @@ INTN
 OcWaitForAppleKeyIndex (
   IN OUT OC_PICKER_CONTEXT                  *Context,
   IN     APPLE_KEY_MAP_AGGREGATOR_PROTOCOL  *KeyMap,
-  IN     UINTN                              Timeout,
-     OUT BOOLEAN                            *SetDefault  OPTIONAL
+  IN     UINT64                             EndTime,
+  IN OUT BOOLEAN                            *SetDefault  OPTIONAL
   );
 
 /**

--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -1055,6 +1055,40 @@ OcLoadPickerHotKeys (
 
 #if defined(OC_SHOW_RUNNING_KEYS)
 /**
+  Initialise running display of held keys, for builtin picker only.
+
+  @param[in]      TscFrequency      Send in current understood TSC frequency.
+**/
+VOID
+OcInitRunningKeys (
+  UINT64 TscFrequency
+  );
+
+/**
+  Instrument old path kb loop delay.
+
+  @param[in]      LoopDelayStart    Delay start in TSC asm ticks.
+  @param[in]      LoopDelayEnd      Delay end in TSC asm ticks.
+**/
+VOID
+OcInstrumentLoopDelay (
+  UINT64 LoopDelayStart,
+  UINT64 LoopDelayEnd
+  );
+
+/**
+  Instrument old path kb flush delay.
+
+  @param[in]      FlushDelayStart   Delay start in TSC asm ticks.
+  @param[in]      FlushDelayEnd     Delay end in TSC asm ticks.
+**/
+VOID
+OcInstrumentFlushDelay (
+  UINT64 FlushDelayStart,
+  UINT64 FlushDelayEnd
+  );
+
+/**
   Running display of held keys, in builtin picker only.
 
   @param[in]      NumKeysUp       Number of keys that went up.

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -599,6 +599,7 @@ typedef enum {
 /// Input is a set of options to support advanced input.
 ///
 #define OC_UEFI_INPUT_FIELDS(_, __) \
+  _(OC_STRING                   , DownkeysHandler    ,     , OC_STRING_CONSTR ("Auto", _, __)  , OC_DESTR (OC_STRING)) \
   _(OC_STRING                   , KeySupportMode     ,     , OC_STRING_CONSTR ("Auto", _, __)  , OC_DESTR (OC_STRING)) \
   _(OC_STRING                   , PointerSupportMode ,     , OC_STRING_CONSTR ("", _, __)      , OC_DESTR (OC_STRING)) \
   _(UINT32                      , TimerResolution    ,     , 0                                 , ()) \

--- a/Include/Acidanthera/Library/OcDebugLogLib.h
+++ b/Include/Acidanthera/Library/OcDebugLogLib.h
@@ -52,6 +52,18 @@
 #endif
 
 /**
+  Detail debug support - only compile DETAIL_DEBUG calls if DEBUG_DETAIL is defined at top of consumer source file
+**/
+#if defined(DEBUG_DETAIL)
+  #define DETAIL_DEBUG(Expression) \
+    do {                           \
+      DEBUG (Expression);          \
+    } while (FALSE)
+#else
+  #define DETAIL_DEBUG(Expression)
+#endif
+
+/**
   Install or update the OcLog protocol with specified options.
 
   @param[in] Options        Logging options.

--- a/Include/Acidanthera/Library/OcTimerLib.h
+++ b/Include/Acidanthera/Library/OcTimerLib.h
@@ -27,4 +27,16 @@ RecalculateTSC (
   VOID
   );
 
+/**
+  Return cached PerformanceCounterFrequency value. For instrumentation purposes only.
+
+  @retval               The timer frequency in use.
+
+**/
+UINT64
+EFIAPI
+GetTscFrequency (
+  VOID
+  );
+
 #endif // OC_TIMER_LIB_H

--- a/Library/OcAppleKeyMapLib/OcAppleKeyMapLib.c
+++ b/Library/OcAppleKeyMapLib/OcAppleKeyMapLib.c
@@ -2,9 +2,8 @@
 
 AppleKeyMapAggregator
 
-Copyright (c) 2018, vit9696
-
-All rights reserved.
+Copyright (c) 2018, vit9696. All rights reserved.
+Additions (downkeys support) copyright (c) 2021 Mike Beaton. All rights reserved.
 
 This program and the accompanying materials
 are licensed and made available under the terms and conditions of the BSD License
@@ -15,6 +14,12 @@ THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
 WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 
 **/
+
+#if defined(OC_TARGET_DEBUG) || defined(OC_TARGET_NOOPT)
+//#define DEBUG_DETAIL
+#endif
+#define OC_SHOW_RUNNING_KEYS
+
 #include <AppleMacEfi.h>
 #include <IndustryStandard/AppleHid.h>
 #include <Protocol/AppleKeyMapAggregator.h>
@@ -24,10 +29,25 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/OcAppleKeyMapLib.h>
+#include <Library/OcDebugLogLib.h>
 #include <Library/OcMiscLib.h>
 #include <Library/TimerLib.h>
 #include <Library/UefiBootServicesTableLib.h>
+#if defined(OC_SHOW_RUNNING_KEYS)
+#include <Library/OcBootManagementLib.h>
+#include <Library/UefiLib.h>
+#endif
 
+#if defined(OC_SHOW_RUNNING_KEYS)
+STATIC INT32                mRunningColumn;
+
+#define MAX_RUNNING_COLUMN  80
+
+#define UP_DOWN_HELD_DISPLAY_OFFSET   4
+#define ID_DISPLAY_OFFSET             UP_DOWN_HELD_DISPLAY_OFFSET
+#define X_DISPLAY_OFFSET              5
+#define MODIFIER_DISPLAY_OFFSET       6
+#endif
 
 // KEY_MAP_AGGREGATOR_DATA_SIGNATURE
 #define KEY_MAP_AGGREGATOR_DATA_SIGNATURE  \
@@ -118,6 +138,210 @@ InternalGetKeyStrokesByIndex (
   }
 
   return KeyStrokesInfo;
+}
+
+EFI_STATUS
+OcInitKeyRepeatContext(
+     OUT OC_KEY_REPEAT_CONTEXT              *Context,
+  IN     APPLE_KEY_MAP_AGGREGATOR_PROTOCOL  *KeyMap,
+  IN     UINTN                              MaxKeysHeld,
+  IN     OC_HELD_KEY_INFO                   *KeysHeld       OPTIONAL,
+  IN     UINT64                             InitialDelay,
+  IN     UINT64                             SubsequentDelay,
+  IN     BOOLEAN                            PreventInitialRepeat
+  )
+{
+  EFI_STATUS                        Status;
+  APPLE_MODIFIER_MAP                Modifiers;
+  UINTN                             NumKeysUp;
+  UINTN                             NumKeysDown;
+ 
+  Context->KeyMap           = KeyMap;
+
+  Context->NumKeysHeld      = 0;
+  Context->MaxKeysHeld      = MaxKeysHeld;
+  Context->KeysHeld         = KeysHeld;
+
+  Context->InitialDelay     = InitialDelay;
+  Context->SubsequentDelay  = SubsequentDelay;
+  Context->PreviousTime     = 0;
+
+  if (KeysHeld == NULL || PreventInitialRepeat == FALSE) {
+    Status = EFI_SUCCESS;
+  } else {
+    //
+    // Prevent any keys which are down at init from appearring as immediate down key strokes or even repeating until released and then pressed again
+    //
+    NumKeysDown = MaxKeysHeld;
+
+    Status = OcGetUpDownKeys (
+      Context,
+      &Modifiers,
+      &NumKeysUp, NULL,
+      &NumKeysDown, NULL,
+      MAX_INT64 >> 1 // == far future, creates massive but manageable -ve delta on next call
+      );
+  }
+
+  return Status;
+}
+
+EFI_STATUS
+EFIAPI
+OcGetUpDownKeys (
+  IN OUT OC_KEY_REPEAT_CONTEXT              *RepeatContext,
+     OUT APPLE_MODIFIER_MAP                 *Modifiers,
+  IN OUT UINTN                              *NumKeysUp,
+     OUT APPLE_KEY_CODE                     *KeysUp       OPTIONAL,
+  IN OUT UINTN                              *NumKeysDown,
+     OUT APPLE_KEY_CODE                     *KeysDown     OPTIONAL,
+  IN     UINT64                             CurrentTime
+  )
+{
+  EFI_STATUS                        Status;
+  UINTN                             NumRawKeys;
+  APPLE_KEY_CODE                    RawKeys[OC_KEY_MAP_DEFAULT_SIZE];
+  UINTN                             NumKeysHeldInCopy;
+  UINTN                             MaxKeysHeldInCopy;
+  OC_HELD_KEY_INFO                  KeysHeldCopy[OC_HELD_KEYS_DEFAULT_SIZE];
+  UINTN                             Index;
+  UINTN                             Index2;
+  APPLE_KEY_CODE                    Key;
+  INT64                             KeyTime;
+  UINT64                            DeltaTime;
+  BOOLEAN                           FoundHeldKey;
+
+  ASSERT (Modifiers != NULL);
+  ASSERT (NumKeysUp != NULL);
+  ASSERT (NumKeysDown != NULL);
+  ASSERT (RepeatContext != NULL);
+  ASSERT (RepeatContext->KeyMap != NULL);
+  ASSERT (RepeatContext->NumKeysHeld <= RepeatContext->MaxKeysHeld);
+
+  DeltaTime = CurrentTime - RepeatContext->PreviousTime;
+  RepeatContext->PreviousTime = CurrentTime;
+
+  if (RepeatContext->KeysHeld != NULL) {
+    //
+    // All held keys could potentially go into keys up
+    // 
+    if (KeysUp != NULL && RepeatContext->MaxKeysHeld > *NumKeysUp) {
+      DEBUG ((DEBUG_ERROR, "OCKM: MaxKeysHeld %d exceeds NumKeysUp %d\n", RepeatContext->MaxKeysHeld, *NumKeysUp));
+      return EFI_UNSUPPORTED;
+    }
+
+    //
+    // All requested keys could potentially go into held keys
+    // (NumKeysDown is always used as the requested number of keys to scan, even if there is no KeysDown buffer to return down keycodes)
+    //
+    if (KeysDown != NULL && *NumKeysDown > RepeatContext->MaxKeysHeld) {
+      DEBUG ((DEBUG_ERROR, "OCKM: Number of keys requested %d exceeds MaxKeysHeld %d\n", *NumKeysDown, RepeatContext->MaxKeysHeld));
+      return EFI_UNSUPPORTED;
+    }
+
+    //
+    // Clone live entries of KeysHeld buffer 
+    //
+    MaxKeysHeldInCopy = ARRAY_SIZE (KeysHeldCopy);
+    if (RepeatContext->MaxKeysHeld > MaxKeysHeldInCopy) {
+      DEBUG ((DEBUG_ERROR, "OCKM: MaxKeysHeld %d exceeds supported copy space %d\n", RepeatContext->MaxKeysHeld, MaxKeysHeldInCopy));
+      return EFI_UNSUPPORTED;
+    }
+
+    CopyMem (KeysHeldCopy, RepeatContext->KeysHeld, RepeatContext->NumKeysHeld * sizeof(RepeatContext->KeysHeld[0]));
+    NumKeysHeldInCopy = RepeatContext->NumKeysHeld;
+  } else {
+    NumKeysHeldInCopy = 0;
+  }
+
+  NumRawKeys  = ARRAY_SIZE (RawKeys);
+  if (*NumKeysDown > NumRawKeys) {
+    DEBUG ((DEBUG_ERROR, "OCKM: Number of keys requested %d exceeds supported raw key bufsize %d\n", *NumKeysDown, NumRawKeys));
+    return EFI_UNSUPPORTED;
+  }
+
+  Status = RepeatContext->KeyMap->GetKeyStrokes (
+    RepeatContext->KeyMap,
+    Modifiers,
+    &NumRawKeys,
+    RawKeys
+    );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (KeysDown != NULL && NumRawKeys > *NumKeysDown) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  DETAIL_DEBUG ((DEBUG_INFO, "OCKM: [%p] %ld %ld %ld\n", RepeatContext, RepeatContext->InitialDelay, RepeatContext->SubsequentDelay, DeltaTime));
+  DETAIL_DEBUG ((DEBUG_INFO, "OCKM: [%p] I u:%d d:%d n:%d h:%d r:%d m:%d\n", RepeatContext, *NumKeysUp, *NumKeysDown, RepeatContext->MaxKeysHeld, RepeatContext->NumKeysHeld, NumRawKeys, *Modifiers));
+
+  *NumKeysUp = 0;
+  *NumKeysDown = 0;
+  RepeatContext->NumKeysHeld = 0;
+
+  //
+  // Loop through all keys which are currently down
+  //
+  for (Index = 0; Index < NumRawKeys; ++Index) {
+    Key = RawKeys[Index];
+    if (RepeatContext->KeysHeld != NULL) {
+      RepeatContext->KeysHeld[RepeatContext->NumKeysHeld].Key = Key;
+    }
+
+    FoundHeldKey = FALSE;
+    for (Index2 = 0; Index2 < NumKeysHeldInCopy; Index2++) {
+      if (KeysHeldCopy[Index2].Key == Key) {
+        FoundHeldKey = TRUE;
+        KeyTime = KeysHeldCopy[Index2].KeyTime + DeltaTime;
+        KeysHeldCopy[Index2].Key = 0; // Mark held key as still down
+        DETAIL_DEBUG ((DEBUG_INFO, "OCKM: [%p] Still down 0x%X %ld\n", RepeatContext, Key, KeyTime));
+        if (RepeatContext->InitialDelay != 0 && KeyTime >= 0) {
+          if (KeysDown != NULL) {
+            KeysDown[*NumKeysDown] = Key;
+          }
+          (*NumKeysDown)++;
+          KeyTime -= RepeatContext->SubsequentDelay;
+          DETAIL_DEBUG ((DEBUG_INFO, "OCKM: [%p] Repeating 0x%X %ld\n", RepeatContext, Key, KeyTime));
+        }
+        break;
+      }
+    }
+
+    if (!FoundHeldKey) {
+      if (KeysDown != NULL) {
+        KeysDown[*NumKeysDown] = Key;
+      }
+      (*NumKeysDown)++;
+      KeyTime = -(INT64) RepeatContext->InitialDelay;
+      DETAIL_DEBUG ((DEBUG_INFO, "OCKM: [%p] New down 0x%X %ld\n", RepeatContext, Key, KeyTime));
+    }
+
+    if (RepeatContext->KeysHeld != NULL) {
+      RepeatContext->KeysHeld[RepeatContext->NumKeysHeld].KeyTime = KeyTime;
+      RepeatContext->NumKeysHeld++;
+    }
+  }
+
+  //
+  // Process remaining held keys
+  //
+  for (Index = 0; Index < NumKeysHeldInCopy; Index++) {
+    Key = KeysHeldCopy[Index].Key;
+    if (Key != 0) {
+      DETAIL_DEBUG ((DEBUG_INFO, "OCKM: [%p] Gone up 0x%X %ld\n", RepeatContext, Key, KeysHeldCopy[Index].KeyTime));
+      if (KeysUp != NULL) {
+        KeysUp[*NumKeysUp] = Key;
+      }
+      (*NumKeysUp)++;
+    }
+  }
+
+  DETAIL_DEBUG ((DEBUG_INFO, "OCKM: [%p] O u:%d d:%d n:%d h:%d r:%d\n", RepeatContext, *NumKeysUp, *NumKeysDown, RepeatContext->MaxKeysHeld, RepeatContext->NumKeysHeld, NumRawKeys));
+
+  return Status;
 }
 
 // InternalGetKeyStrokes
@@ -256,11 +480,95 @@ OcKeyMapHasKey (
   return OcKeyMapHasKeys (Keys, NumKeys, &KeyCode, 1, FALSE);
 }
 
+#if defined(OC_SHOW_RUNNING_KEYS)
+//
+// Defined here not in HotKeySupport.c to allow successful link to
+// OcKeyMapFlush in apps that only need OcAppleKeyMapLib.
+//
+VOID
+OcShowRunningKeys (
+  UINTN                     NumKeysUp,
+  UINTN                     NumKeysDown,
+  UINTN                     NumKeysHeld,
+  APPLE_MODIFIER_MAP        Modifiers,
+  CHAR16                    CallerID,
+  BOOLEAN                   UsingDownkeys
+  )
+{
+  INT32                              RestoreRow;
+  INT32                              RestoreColumn;
+
+  CHAR16                             Code[3];
+
+  Code[1]        = L' ';
+  Code[2]        = L'\0';
+
+  if (mRunningColumn < 0 || mRunningColumn >= MAX_RUNNING_COLUMN) {
+    mRunningColumn = 0;
+  }
+
+  RestoreRow     = gST->ConOut->Mode->CursorRow;
+  RestoreColumn  = gST->ConOut->Mode->CursorColumn;
+
+  if (UsingDownkeys) {
+    //
+    // Show downkeys info when in use
+    //
+    gST->ConOut->SetCursorPosition (gST->ConOut, mRunningColumn, RestoreRow + UP_DOWN_HELD_DISPLAY_OFFSET);
+    if (NumKeysUp > 0) {
+      Code[0] = L'U';
+    } else if (NumKeysDown > 0) {
+      Code[0] = L'D';
+    } else if (NumKeysHeld > 0) {
+      Code[0] = L'-';
+    } else {
+      Code[0] = L' ';
+    }
+    gST->ConOut->OutputString (gST->ConOut, Code);
+  } else {
+    //
+    // Show caller ID for flush or non-flush
+    //
+    gST->ConOut->SetCursorPosition (gST->ConOut, mRunningColumn, RestoreRow + ID_DISPLAY_OFFSET);
+    Code[0] = CallerID;
+    gST->ConOut->OutputString (gST->ConOut, Code);
+  }
+
+  //
+  // Key held info
+  //
+  gST->ConOut->SetCursorPosition (gST->ConOut, mRunningColumn, RestoreRow + X_DISPLAY_OFFSET);
+  if (NumKeysHeld > 0) {
+    Code[0] = L'X';
+  } else {
+    Code[0] = L'.';
+  }
+  gST->ConOut->OutputString (gST->ConOut, Code);
+
+  //
+  // Modifiers info
+  //
+  gST->ConOut->SetCursorPosition (gST->ConOut, mRunningColumn, RestoreRow + MODIFIER_DISPLAY_OFFSET);
+  if (Modifiers == 0) {
+    Code[0] = L' ';
+    gST->ConOut->OutputString (gST->ConOut, Code);
+  } else {
+    Print(L"%d", Modifiers);
+  }
+
+  mRunningColumn++;
+
+  gST->ConOut->SetCursorPosition (gST->ConOut, RestoreColumn, RestoreRow);
+}
+#endif
+
 VOID
 OcKeyMapFlush (
   IN APPLE_KEY_MAP_AGGREGATOR_PROTOCOL  *KeyMap,
   IN APPLE_KEY_CODE                     Key,
-  IN BOOLEAN                            FlushConsole
+  IN BOOLEAN                            FlushConsole,
+  IN BOOLEAN                            EnableFlush,
+  IN BOOLEAN                            ShowRunningKeys
   )
 {
   EFI_STATUS          Status;
@@ -269,16 +577,32 @@ OcKeyMapFlush (
   EFI_INPUT_KEY       EfiKey;
   APPLE_KEY_CODE      Keys[OC_KEY_MAP_DEFAULT_SIZE];
 
+  if (!EnableFlush) {
+    return;
+  }
+
   ASSERT (KeyMap != NULL);
 
+  //
+  // Key flush support for use on systems with EFI driver level key repeat; on newer
+  // and Apple hardware, will hang until all keys (including control keys) come up.
+  //
   while (TRUE) {
     NumKeys = ARRAY_SIZE (Keys);
+    DETAIL_DEBUG ((DEBUG_INFO, "OCKM: 3 %d\n", NumKeys));
     Status = KeyMap->GetKeyStrokes (
       KeyMap,
       &Modifiers,
       &NumKeys,
       Keys
       );
+    DETAIL_DEBUG ((DEBUG_INFO, "OCKM: 4 %d\n", NumKeys));
+
+#if defined(OC_SHOW_RUNNING_KEYS)
+    if (ShowRunningKeys) {
+      OcShowRunningKeys (0, 0, NumKeys, Modifiers, L'f', FALSE); // flush
+    }
+#endif
 
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "OCKM: GetKeyStrokes failure - %r\n", Status));
@@ -286,10 +610,12 @@ OcKeyMapFlush (
     }
 
     if (Key != 0 && !OcKeyMapHasKey (Keys, NumKeys, Key) && Modifiers == 0) {
+      DETAIL_DEBUG ((DEBUG_INFO, "OCKM: Break on key 0x%X\n", Key));
       break;
     }
 
     if (Key == 0 && NumKeys == 0 && Modifiers == 0) {
+      DETAIL_DEBUG ((DEBUG_INFO, "OCKM: Break on empty\n"));
       break;
     }
 

--- a/Library/OcBootManagementLib/HotKeySupport.c
+++ b/Library/OcBootManagementLib/HotKeySupport.c
@@ -1,5 +1,6 @@
 /** @file
   Copyright (C) 2019, vit9696. All rights reserved.
+  Additions (downkeys support) copyright (C) 2021 Mike Beaton. All rights reserved.
 
   All rights reserved.
 
@@ -12,6 +13,11 @@
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 **/
 
+#if defined(OC_TARGET_DEBUG) || defined(OC_TARGET_NOOPT)
+//#define DEBUG_DETAIL
+#endif
+#define OC_SHOW_RUNNING_KEYS
+
 #include "BootManagementInternal.h"
 
 #include <Guid/AppleVariable.h>
@@ -23,10 +29,23 @@
 #include <Library/OcTimerLib.h>
 #include <Library/OcAppleKeyMapLib.h>
 #include <Library/OcBootManagementLib.h>
+#include <Library/OcConfigurationLib.h>
+#include <Library/OcTemplateLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 
-VOID
+STATIC BOOLEAN              mUseDownkeys;
+
+OC_KEY_REPEAT_CONTEXT       mRepeatContext;
+OC_HELD_KEY_INFO            mRepeatKeysHeld[OC_HELD_KEYS_DEFAULT_SIZE];
+
+OC_KEY_REPEAT_CONTEXT       mDoNotRepeatContext;
+OC_HELD_KEY_INFO            mDoNotRepeatKeysHeld[OC_HELD_KEYS_DEFAULT_SIZE];
+
+//
+// Get hotkeys pressed at load
+//
+APPLE_KEY_MAP_AGGREGATOR_PROTOCOL *
 OcLoadPickerHotKeys (
   IN OUT OC_PICKER_CONTEXT  *Context
   )
@@ -56,8 +75,8 @@ OcLoadPickerHotKeys (
     );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "OCB: Missing AppleKeyMapAggregator - %r\n", Status));
-    return;
+    DEBUG ((DEBUG_ERROR, "OCHK: Missing AppleKeyMapAggregator - %r\n", Status));
+    return NULL;
   }
 
   NumKeys = ARRAY_SIZE (Keys);
@@ -69,8 +88,8 @@ OcLoadPickerHotKeys (
     );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "OCB: GetKeyStrokes - %r\n", Status));
-    return;
+    DEBUG ((DEBUG_ERROR, "OCHK: GetKeyStrokes - %r\n", Status));
+    return KeyMap;
   }
 
   //
@@ -92,19 +111,19 @@ OcLoadPickerHotKeys (
   HasKeyX    = OcKeyMapHasKey (Keys, NumKeys, AppleHidUsbKbUsageKeyX);
 
   if (HasOption && HasCommand && HasKeyP && HasKeyR) {
-    DEBUG ((DEBUG_INFO, "OCB: CMD+OPT+P+R causes NVRAM reset\n"));
+    DEBUG ((DEBUG_INFO, "OCHK: CMD+OPT+P+R causes NVRAM reset\n"));
     Context->PickerCommand = OcPickerResetNvram;
   } else if (HasCommand && HasKeyR) {
-    DEBUG ((DEBUG_INFO, "OCB: CMD+R causes recovery to boot\n"));
+    DEBUG ((DEBUG_INFO, "OCHK: CMD+R causes recovery to boot\n"));
     Context->PickerCommand = OcPickerBootAppleRecovery;
   } else if (HasKeyX) {
-    DEBUG ((DEBUG_INFO, "OCB: X causes macOS to boot\n"));
+    DEBUG ((DEBUG_INFO, "OCHK: X causes macOS to boot\n"));
     Context->PickerCommand = OcPickerBootApple;
   } else if (HasOption) {
-    DEBUG ((DEBUG_INFO, "OCB: OPT causes picker to show\n"));
+    DEBUG ((DEBUG_INFO, "OCHK: OPT causes picker to show\n"));
     Context->PickerCommand = OcPickerShowPicker;
   } else if (HasEscape) {
-    DEBUG ((DEBUG_INFO, "OCB: ESC causes picker to show as OC extension\n"));
+    DEBUG ((DEBUG_INFO, "OCHK: ESC causes picker to show as OC extension\n"));
     Context->PickerCommand = OcPickerShowPicker;
   } else {
     //
@@ -117,6 +136,70 @@ OcLoadPickerHotKeys (
     // N - Network boot, simply not supported (and bad for security).
     // T - Target disk mode, simply not supported (and bad for security).
     //
+  }
+
+  return KeyMap;
+}
+
+VOID
+OcInitDownkeys (
+    IN OC_UEFI_INPUT                          *Input,
+    IN APPLE_KEY_MAP_AGGREGATOR_PROTOCOL      *KeyMap
+  )
+{
+  EFI_STATUS                 Status;
+  CONST CHAR8                *DownkeysHandlerStr;
+
+  //
+  // Failsafe and Auto = opposite of KeySupport, which is recommended for most people
+  //
+  mUseDownkeys = !Input->KeySupport;
+
+  DownkeysHandlerStr = OC_BLOB_GET (&Input->DownkeysHandler);
+  if (AsciiStrCmp (DownkeysHandlerStr, "Enabled") == 0) {
+    mUseDownkeys = TRUE;
+  } else if (AsciiStrCmp (DownkeysHandlerStr, "Disabled") == 0) {
+    mUseDownkeys = FALSE;
+  } else if (AsciiStrCmp (DownkeysHandlerStr, "Auto") != 0) {
+    DEBUG ((DEBUG_WARN, "OCHK: Invalid downkeys handler mode %a\n", DownkeysHandlerStr));
+  }
+
+  if (mUseDownkeys) {
+    DEBUG ((DEBUG_INFO, "OCHK: InitDownkeys\n"));
+
+    //
+    // Standard repeat rate
+    //
+    Status = OcInitKeyRepeatContext(
+      &mRepeatContext,
+      KeyMap,
+      ARRAY_SIZE (mRepeatKeysHeld),
+      mRepeatKeysHeld,
+      OC_DOWNKEYS_DEFAULT_INITIAL_DELAY * 1000000ULL,
+      OC_DOWNKEYS_DEFAULT_SUBSEQUENT_DELAY * 1000000ULL,
+      TRUE
+    );
+      
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "OCHK: Init repeat context - %r\n", Status));
+    }
+
+    //
+    // No repeat context, e.g. for toggle and special command keys
+    //
+    Status = OcInitKeyRepeatContext(
+      &mDoNotRepeatContext,
+      KeyMap,
+      ARRAY_SIZE (mDoNotRepeatKeysHeld),
+      mDoNotRepeatKeysHeld,
+      0,
+      0,
+      TRUE
+    );
+      
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "OCHK: Init non-repeat context - %r\n", Status));
+    }
   }
 }
 
@@ -134,6 +217,10 @@ OcGetAppleKeyIndex (
   UINTN                              NumKeys;
   APPLE_MODIFIER_MAP                 Modifiers;
   APPLE_KEY_CODE                     Keys[OC_KEY_MAP_DEFAULT_SIZE];
+  UINTN                              NumKeysUp;
+  UINTN                              NumKeysDoNotRepeat;
+  APPLE_KEY_CODE                     KeysDoNotRepeat[OC_KEY_MAP_DEFAULT_SIZE];
+  BOOLEAN                            EnableFlush;
 
   BOOLEAN                            HasCommand;
   BOOLEAN                            HasShift;
@@ -143,21 +230,92 @@ OcGetAppleKeyIndex (
   BOOLEAN                            HasKeyV;
   BOOLEAN                            HasKeyMinus;
   BOOLEAN                            WantsZeroSlide;
-  BOOLEAN                            WantsDefault;
   UINT32                             CsrActiveConfig;
   UINTN                              CsrActiveConfigSize;
+  UINT64                             CurrentTime;
 
-  NumKeys = ARRAY_SIZE (Keys);
-  Status = KeyMap->GetKeyStrokes (
-    KeyMap,
-    &Modifiers,
-    &NumKeys,
-    Keys
-    );
+  ASSERT (ARRAY_SIZE (KeysDoNotRepeat) >= ARRAY_SIZE (Keys)); // for CopyMem in legacy codepath
 
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_WARN, "OCB: GetKeyStrokes - %r\n", Status));
-    return OC_INPUT_INVALID;
+  if (SetDefault != NULL) {
+    *SetDefault = 0;
+  }
+
+  if (mUseDownkeys) {
+    // Downkeys support, helps with fluent animation in OpenCanopy (will not hang waiting for keys), but
+    // does not include all fixes for legacy hardware present in previous approach (see esp. OcKeyMapFlush),
+    // and may function unpredictably in terms of key repeat behaviour on systems which have EFI driver level
+    // key repeat.
+    //
+    // TODO: Investigate using raw TSC timer instead
+    //
+    CurrentTime = GetTimeInNanoSecond (GetPerformanceCounter ());
+
+    //
+    // TO DO(?): We are using last collected modifiers for all keys, but should be correct or close enough not to matter
+    //
+    NumKeysUp           = 0;
+    NumKeys             = ARRAY_SIZE (Keys);
+    Status = OcGetUpDownKeys (
+      &mRepeatContext,
+      &Modifiers,
+      &NumKeysUp, NULL,
+      &NumKeys, Keys,
+      CurrentTime
+      );
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_WARN, "OCHK: GetUpDownKeys for RepeatContext - %r\n", Status));
+      return OC_INPUT_INVALID;
+    }
+
+#if defined(OC_SHOW_RUNNING_KEYS)
+    OcShowRunningKeys (NumKeysUp, NumKeys, mRepeatContext.NumKeysHeld, Modifiers, L' ', TRUE); // normal
+#endif
+
+    NumKeysUp           = 0;
+    NumKeysDoNotRepeat  = ARRAY_SIZE (KeysDoNotRepeat);
+    Status = OcGetUpDownKeys (
+      &mDoNotRepeatContext,
+      &Modifiers,
+      &NumKeysUp, NULL,
+      &NumKeysDoNotRepeat, KeysDoNotRepeat,
+      CurrentTime
+      );
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_WARN, "OCHK: GetUpDownKeys for DoNotRepeatContext - %r\n", Status));
+      return OC_INPUT_INVALID;
+    }
+
+    EnableFlush = FALSE;
+  } else {
+    // Legacy support, tuned to work correctly on many older systems, but hangs in
+    // call to OcKeyMapFlush below until all keys (including control keys) come up,
+    // on newer and Apple hardware, preventing fluid animation in OpenCanopy.
+    //
+    NumKeys             = ARRAY_SIZE (Keys);
+    DETAIL_DEBUG ((DEBUG_INFO, "OCHK: 1 %d\n", NumKeys));
+    Status = KeyMap->GetKeyStrokes (
+      KeyMap,
+      &Modifiers,
+      &NumKeys,
+      Keys
+      );
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_WARN, "OCHK: GetKeyStrokes - %r\n", Status));
+      return OC_INPUT_INVALID;
+    }
+    DETAIL_DEBUG ((DEBUG_INFO, "OCHK: 2 %d\n", NumKeys));
+
+#if defined(OC_SHOW_RUNNING_KEYS)
+    OcShowRunningKeys (0, 0, NumKeys, Modifiers, L' ', FALSE); // normal
+#endif
+
+    CopyMem (KeysDoNotRepeat, Keys, sizeof(Keys[0]) * NumKeys);
+    NumKeysDoNotRepeat = NumKeys;
+
+    EnableFlush = TRUE;
   }
 
   //
@@ -181,7 +339,7 @@ OcGetAppleKeyIndex (
     //
     if (HasShift) {
       if (OcGetArgumentFromCmd (Context->AppleBootArgs, "-x", L_STR_LEN ("-x"), NULL) == NULL) {
-        DEBUG ((DEBUG_INFO, "OCB: Shift means -x\n"));
+        DEBUG ((DEBUG_INFO, "OCHK: Shift means -x\n"));
         OcAppendArgumentToCmd (Context, Context->AppleBootArgs, "-x", L_STR_LEN ("-x"));
       }
       return OC_INPUT_INTERNAL;
@@ -192,7 +350,7 @@ OcGetAppleKeyIndex (
     //
     if (HasCommand && HasKeyV) {
       if (OcGetArgumentFromCmd (Context->AppleBootArgs, "-v", L_STR_LEN ("-v"), NULL) == NULL) {
-        DEBUG ((DEBUG_INFO, "OCB: CMD+V means -v\n"));
+        DEBUG ((DEBUG_INFO, "OCHK: CMD+V means -v\n"));
         OcAppendArgumentToCmd (Context, Context->AppleBootArgs, "-v", L_STR_LEN ("-v"));
       }
       return OC_INPUT_INTERNAL;
@@ -203,7 +361,7 @@ OcGetAppleKeyIndex (
     //
     if (HasCommand && HasKeyC && HasKeyMinus) {
       if (OcGetArgumentFromCmd (Context->AppleBootArgs, "-no_compat_check", L_STR_LEN ("-no_compat_check"), NULL) == NULL) {
-        DEBUG ((DEBUG_INFO, "OCB: CMD+C+MINUS means -no_compat_check\n"));
+        DEBUG ((DEBUG_INFO, "OCHK: CMD+C+MINUS means -no_compat_check\n"));
         OcAppendArgumentToCmd (Context, Context->AppleBootArgs, "-no_compat_check", L_STR_LEN ("-no_compat_check"));
       }
       return OC_INPUT_INTERNAL;
@@ -214,7 +372,7 @@ OcGetAppleKeyIndex (
     //
     if (HasCommand && HasKeyK) {
       if (AsciiStrStr (Context->AppleBootArgs, "kcsuffix=release") == NULL) {
-        DEBUG ((DEBUG_INFO, "OCB: CMD+K means kcsuffix=release\n"));
+        DEBUG ((DEBUG_INFO, "OCHK: CMD+K means kcsuffix=release\n"));
         OcAppendArgumentToCmd (Context, Context->AppleBootArgs, "kcsuffix=release", L_STR_LEN ("kcsuffix=release"));
       }
       return OC_INPUT_INTERNAL;
@@ -253,11 +411,11 @@ OcGetAppleKeyIndex (
 
       if (WantsZeroSlide) {
         if (AsciiStrStr (Context->AppleBootArgs, "slide=0") == NULL) {
-          DEBUG ((DEBUG_INFO, "OCB: CMD+S+MINUS means slide=0\n"));
+          DEBUG ((DEBUG_INFO, "OCHK: CMD+S+MINUS means slide=0\n"));
           OcAppendArgumentToCmd (Context, Context->AppleBootArgs, "slide=0", L_STR_LEN ("slide=0"));
         }
       } else if (OcGetArgumentFromCmd (Context->AppleBootArgs, "-s", L_STR_LEN ("-s"), NULL) == NULL) {
-        DEBUG ((DEBUG_INFO, "OCB: CMD+S means -s\n"));
+        DEBUG ((DEBUG_INFO, "OCHK: CMD+S means -s\n"));
         OcAppendArgumentToCmd (Context, Context->AppleBootArgs, "-s", L_STR_LEN ("-s"));
       }
       return OC_INPUT_INTERNAL;
@@ -265,98 +423,99 @@ OcGetAppleKeyIndex (
   }
 
   //
-  // Handle VoiceOver.
+  // Handle VoiceOver - non-repeating.
   //
   if ((Modifiers & (APPLE_MODIFIER_LEFT_COMMAND | APPLE_MODIFIER_RIGHT_COMMAND)) != 0
-    && OcKeyMapHasKey (Keys, NumKeys, AppleHidUsbKbUsageKeyF5)) {
-    OcKeyMapFlush (KeyMap, 0, TRUE);
+    && OcKeyMapHasKey (KeysDoNotRepeat, NumKeysDoNotRepeat, AppleHidUsbKbUsageKeyF5)) {
+    OcKeyMapFlush (KeyMap, 0, TRUE, EnableFlush, TRUE);
     return OC_INPUT_VOICE_OVER;
   }
 
   //
-  // Handle reload menu.
+  // Handle reload menu - non-repeating.
   //
-  if (OcKeyMapHasKey (Keys, NumKeys, AppleHidUsbKbUsageKeyEscape)
-   || OcKeyMapHasKey (Keys, NumKeys, AppleHidUsbKbUsageKeyZero)) {
-    OcKeyMapFlush (KeyMap, 0, TRUE);
+  if (OcKeyMapHasKey (KeysDoNotRepeat, NumKeysDoNotRepeat, AppleHidUsbKbUsageKeyEscape)
+   || OcKeyMapHasKey (KeysDoNotRepeat, NumKeysDoNotRepeat, AppleHidUsbKbUsageKeyZero)) {
+    OcKeyMapFlush (KeyMap, 0, TRUE, EnableFlush, TRUE);
     return OC_INPUT_ABORTED;
   }
 
-  if (OcKeyMapHasKey (Keys, NumKeys, AppleHidUsbKbUsageKeySpaceBar)) {
-    OcKeyMapFlush (KeyMap, 0, TRUE);
+  //
+  // Handle show or toggle auxiliary - non-repeating.
+  //
+  if (OcKeyMapHasKey (KeysDoNotRepeat, NumKeysDoNotRepeat, AppleHidUsbKbUsageKeySpaceBar)) {
+    OcKeyMapFlush (KeyMap, 0, TRUE, EnableFlush, TRUE);
     return OC_INPUT_MORE;
   }
 
   //
   // Default update is desired for Ctrl+Index and Ctrl+Enter.
   //
-  WantsDefault = Modifiers != 0 && (Modifiers & ~(APPLE_MODIFIER_LEFT_CONTROL | APPLE_MODIFIER_RIGHT_CONTROL)) == 0;
+  if (SetDefault != NULL
+    && Modifiers != 0
+    && (Modifiers & ~(APPLE_MODIFIER_LEFT_CONTROL | APPLE_MODIFIER_RIGHT_CONTROL)) == 0) {
+      *SetDefault = TRUE;
+  }
 
   //
   // Check exact match on index strokes.
   //
-  if ((Modifiers == 0 || WantsDefault) && NumKeys == 1) {
+  if ((Modifiers == 0 || (SetDefault != NULL && *SetDefault)) && NumKeys == 1) {
     if (Keys[0] == AppleHidUsbKbUsageKeyEnter
       || Keys[0] == AppleHidUsbKbUsageKeyReturn
       || Keys[0] == AppleHidUsbKbUsageKeyPadEnter) {
-      if (WantsDefault && SetDefault != NULL) {
-        *SetDefault = TRUE;
-      }
-      OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+      OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
       return OC_INPUT_CONTINUE;
     }
 
     if (Keys[0] == AppleHidUsbKbUsageKeyUpArrow) {
-      OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+      OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
       return OC_INPUT_UP;
     }
 
     if (Keys[0] == AppleHidUsbKbUsageKeyDownArrow) {
-      OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+      OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
       return OC_INPUT_DOWN;
     }
 
     if (Keys[0] == AppleHidUsbKbUsageKeyLeftArrow) {
-      OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+      OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
       return OC_INPUT_LEFT;
     }
 
     if (Keys[0] == AppleHidUsbKbUsageKeyRightArrow) {
-      OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+      OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
       return OC_INPUT_RIGHT;
     }
 
     if (Keys[0] == AppleHidUsbKbUsageKeyPgUp
       || Keys[0] == AppleHidUsbKbUsageKeyHome) {
-      OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+      OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
       return OC_INPUT_TOP;
     }
 
     if (Keys[0] == AppleHidUsbKbUsageKeyPgDn
       || Keys[0] == AppleHidUsbKbUsageKeyEnd) {
-      OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+      OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
       return OC_INPUT_BOTTOM;
     }
 
     STATIC_ASSERT (AppleHidUsbKbUsageKeyF1 + 11 == AppleHidUsbKbUsageKeyF12, "Unexpected encoding");
     if (Keys[0] >= AppleHidUsbKbUsageKeyF1 && Keys[0] <= AppleHidUsbKbUsageKeyF12) {
-      OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+      OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
       return OC_INPUT_FUNCTIONAL (Keys[0] - AppleHidUsbKbUsageKeyF1 + 1);
     }
 
     STATIC_ASSERT (AppleHidUsbKbUsageKeyF13 + 11 == AppleHidUsbKbUsageKeyF24, "Unexpected encoding");
     if (Keys[0] >= AppleHidUsbKbUsageKeyF13 && Keys[0] <= AppleHidUsbKbUsageKeyF24) {
-      OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+      OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
       return OC_INPUT_FUNCTIONAL (Keys[0] - AppleHidUsbKbUsageKeyF13 + 13);
     }
 
     STATIC_ASSERT (AppleHidUsbKbUsageKeyOne + 8 == AppleHidUsbKbUsageKeyNine, "Unexpected encoding");
     for (KeyCode = AppleHidUsbKbUsageKeyOne; KeyCode <= AppleHidUsbKbUsageKeyNine; ++KeyCode) {
       if (OcKeyMapHasKey (Keys, NumKeys, KeyCode)) {
-        if (WantsDefault && SetDefault != NULL) {
-          *SetDefault = TRUE;
-        }
-        OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+        OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
         return (INTN) (KeyCode - AppleHidUsbKbUsageKeyOne);
       }
     }
@@ -364,10 +523,7 @@ OcGetAppleKeyIndex (
     STATIC_ASSERT (AppleHidUsbKbUsageKeyA + 25 == AppleHidUsbKbUsageKeyZ, "Unexpected encoding");
     for (KeyCode = AppleHidUsbKbUsageKeyA; KeyCode <= AppleHidUsbKbUsageKeyZ; ++KeyCode) {
       if (OcKeyMapHasKey (Keys, NumKeys, KeyCode)) {
-        if (WantsDefault && SetDefault != NULL) {
-          *SetDefault = TRUE;
-        }
-        OcKeyMapFlush (KeyMap, Keys[0], TRUE);
+        OcKeyMapFlush (KeyMap, Keys[0], TRUE, EnableFlush, TRUE);
         return (INTN) (KeyCode - AppleHidUsbKbUsageKeyA + 9);
       }
     }
@@ -380,17 +536,29 @@ OcGetAppleKeyIndex (
   return OC_INPUT_TIMEOUT;
 }
 
+UINT64
+OcWaitForAppleKeyIndexGetEndTime(
+  IN UINTN    Timeout
+  )
+{
+  if (Timeout == 0) {
+    return 0ULL;
+  }
+
+  return GetTimeInNanoSecond (GetPerformanceCounter ()) + Timeout * 1000000u;
+}
+
 INTN
 OcWaitForAppleKeyIndex (
   IN OUT OC_PICKER_CONTEXT                  *Context,
   IN     APPLE_KEY_MAP_AGGREGATOR_PROTOCOL  *KeyMap,
-  IN     UINTN                              Timeout,
-     OUT BOOLEAN                            *SetDefault  OPTIONAL
+  IN     UINT64                             EndTime,
+  IN OUT BOOLEAN                            *SetDefault  OPTIONAL
   )
 {
   INTN                               ResultingKey;
   UINT64                             CurrTime;
-  UINT64                             EndTime;
+  BOOLEAN                            OldSetDefault;
 
   //
   // These hotkeys are normally parsed by boot.efi, and they work just fine
@@ -399,17 +567,15 @@ OcWaitForAppleKeyIndex (
   // within picker itself.
   //
 
-  CurrTime  = GetTimeInNanoSecond (GetPerformanceCounter ());
-  EndTime   = CurrTime + Timeout * 1000000ULL;
-
   if (SetDefault != NULL) {
-    *SetDefault = FALSE;
+    OldSetDefault = *SetDefault;
+    *SetDefault = 0;
   }
 
-  while (Timeout == 0 || CurrTime == 0 || CurrTime < EndTime) {
-    CurrTime    = GetTimeInNanoSecond (GetPerformanceCounter ());  
-
+  while (TRUE) {
     ResultingKey = OcGetAppleKeyIndex (Context, KeyMap, SetDefault);
+
+    CurrTime    = GetTimeInNanoSecond (GetPerformanceCounter ());  
 
     //
     // Requested for another iteration, handled Apple hotkey.
@@ -421,19 +587,32 @@ OcWaitForAppleKeyIndex (
     //
     // Abort the timeout when unrecognised keys are pressed.
     //
-    if (Timeout != 0 && ResultingKey == OC_INPUT_INVALID) {
-      return OC_INPUT_INVALID;
+    if (EndTime != 0 && ResultingKey == OC_INPUT_INVALID) {
+      break;
     }
 
     //
     // Found key, return it.
     //
     if (ResultingKey != OC_INPUT_INVALID && ResultingKey != OC_INPUT_TIMEOUT) {
-      return ResultingKey;
+      break;
+    }
+
+    //
+    // Return modifiers if they change, so we can optionally update UI
+    //
+    if (SetDefault != NULL && *SetDefault != OldSetDefault) {
+      ResultingKey = OC_INPUT_MODIFIERS_ONLY;
+      break;
+    }
+
+    if (EndTime != 0 && CurrTime != 0 && CurrTime >= EndTime) {
+      ResultingKey = OC_INPUT_TIMEOUT;
+      break;
     }
 
     MicroSecondDelay (10);
   }
 
-  return OC_INPUT_TIMEOUT;
+  return ResultingKey;
 }

--- a/Library/OcBootManagementLib/HotKeySupport.c
+++ b/Library/OcBootManagementLib/HotKeySupport.c
@@ -151,6 +151,11 @@ OcInitDownkeys (
   CONST CHAR8                *DownkeysHandlerStr;
 
   //
+  // NB initialise this whether downkeys support is used for kb loop or not
+  //
+  OcInitRunningKeys(GetTscFrequency());
+
+  //
   // Failsafe and Auto = opposite of KeySupport, which is recommended for most people
   //
   mUseDownkeys = !Input->KeySupport;
@@ -560,6 +565,10 @@ OcWaitForAppleKeyIndex (
   UINT64                             CurrTime;
   BOOLEAN                            OldSetDefault;
 
+#if defined(OC_SHOW_RUNNING_KEYS)
+  UINT64                             LoopDelayStart;
+#endif
+
   //
   // These hotkeys are normally parsed by boot.efi, and they work just fine
   // when ShowPicker is disabled. On some BSPs, however, they may fail badly
@@ -611,7 +620,13 @@ OcWaitForAppleKeyIndex (
       break;
     }
 
+#if defined(OC_SHOW_RUNNING_KEYS)
+    LoopDelayStart = AsmReadTsc();
+#endif
     MicroSecondDelay (10);
+#if defined(OC_SHOW_RUNNING_KEYS)
+    OcInstrumentLoopDelay(LoopDelayStart, AsmReadTsc());
+#endif
   }
 
   return ResultingKey;

--- a/Library/OcBootManagementLib/OcBootManagementLib.c
+++ b/Library/OcBootManagementLib/OcBootManagementLib.c
@@ -12,6 +12,10 @@
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 **/
 
+#if defined(OC_TARGET_DEBUG) || defined(OC_TARGET_NOOPT)
+//#define DISPLAY_SYSTEM_MS
+#endif
+
 #include "BootManagementInternal.h"
 
 #include <Guid/AppleFile.h>
@@ -105,21 +109,34 @@ RunShowMenu (
   return Status;
 }
 
+#if defined (DISPLAY_SYSTEM_MS)
+STATIC
+VOID
+DisplaySystemMs ()
+{
+  UINT64      CurrentMillis;
+
+  CurrentMillis = GetTimeInNanoSecond (GetPerformanceCounter ()) / 1000000ULL;
+  Print(L"%,Lu]", CurrentMillis);
+}
+#endif
+
 STATIC
 CHAR16
 GetPickerEntryCursor (
   IN  OC_BOOT_CONTEXT             *BootContext,
   IN  UINT32                      TimeOutSeconds,
   IN  INTN                        ChosenEntry,
-  IN  UINTN                       Index
+  IN  UINTN                       Index,
+  IN  BOOLEAN                     SetDefault
   )
-{  
+{
   if (TimeOutSeconds > 0 && BootContext->DefaultEntry->EntryIndex - 1 == Index) {
     return L'*';
   }
   
   if (ChosenEntry >= 0 && (UINTN) ChosenEntry == Index) {
-    return L'>';
+    return SetDefault ? L'+' : L'>';
   }
 
   return L' ';
@@ -140,6 +157,9 @@ OcShowSimpleBootMenu (
   INTN                               ChosenEntry;
   INTN                               OldChosenEntry;
   INT32                              FirstIndexRow;
+#if defined (DISPLAY_SYSTEM_MS)
+  INT32                              MillisColumn;
+#endif
   INT32                              StatusRow;
   INT32                              StatusColumn;
   CHAR16                             EntryCursor;
@@ -147,6 +167,7 @@ OcShowSimpleBootMenu (
   CHAR16                             Code[2];
   UINT32                             TimeOutSeconds;
   UINT32                             Count;
+  UINT64                             KeyEndTime;
   BOOLEAN                            SetDefault;
   BOOLEAN                            PlayedOnce;
   BOOLEAN                            PlayChosen;
@@ -160,6 +181,9 @@ OcShowSimpleBootMenu (
   EntryCursor    = L'\0';
   OldEntryCursor = L'\0';
   FirstIndexRow  = -1;
+
+  KeyIndex       = 0;
+  SetDefault     = FALSE;
 
   PlayedOnce     = FALSE;
   PlayChosen     = FALSE;
@@ -200,7 +224,7 @@ OcShowSimpleBootMenu (
       }
       
       if (ChosenEntry >= 0) {
-        EntryCursor = GetPickerEntryCursor(BootContext, TimeOutSeconds, ChosenEntry, ChosenEntry);
+        EntryCursor = GetPickerEntryCursor(BootContext, TimeOutSeconds, ChosenEntry, ChosenEntry, SetDefault);
       } else {
         EntryCursor = L'\0';
       }
@@ -217,6 +241,12 @@ OcShowSimpleBootMenu (
 
         gST->ConOut->SetCursorPosition (gST->ConOut, StatusColumn, StatusRow);
       }
+
+#if defined (DISPLAY_SYSTEM_MS)
+      gST->ConOut->SetCursorPosition (gST->ConOut, MillisColumn, 0);
+      DisplaySystemMs();
+      gST->ConOut->SetCursorPosition (gST->ConOut, StatusColumn, StatusRow);
+#endif
     } else {
       //
       // Render initial menu
@@ -234,12 +264,18 @@ OcShowSimpleBootMenu (
         gST->ConOut->OutputString (gST->ConOut, L")");
       }
 
+#if defined (DISPLAY_SYSTEM_MS)
+      gST->ConOut->OutputString (gST->ConOut, L" [System uptime: ");
+      MillisColumn = gST->ConOut->Mode->CursorColumn;
+      DisplaySystemMs();
+#endif
+
       gST->ConOut->OutputString (gST->ConOut, L"\r\n\r\n");
 
       FirstIndexRow = gST->ConOut->Mode->CursorRow;
 
       for (Index = 0; Index < MIN (Count, OC_INPUT_MAX); ++Index) {
-        EntryCursor = GetPickerEntryCursor(BootContext, TimeOutSeconds, ChosenEntry, Index);
+        EntryCursor = GetPickerEntryCursor(BootContext, TimeOutSeconds, ChosenEntry, Index, SetDefault);
 
         if (ChosenEntry >= 0 && (UINTN) ChosenEntry == Index) {
           OldEntryCursor = EntryCursor;
@@ -287,12 +323,20 @@ OcShowSimpleBootMenu (
       //
       // Pronounce entry name only after N ms of idleness.
       //
+      if (KeyIndex != OC_INPUT_MODIFIERS_ONLY) {
+        KeyEndTime = OcWaitForAppleKeyIndexGetEndTime(PlayChosen ? OC_VOICE_OVER_IDLE_TIMEOUT_MS : TimeOutSeconds * 1000);
+      }
+
       KeyIndex = OcWaitForAppleKeyIndex (
         BootContext->PickerContext,
         KeyMap,
-        PlayChosen ? OC_VOICE_OVER_IDLE_TIMEOUT_MS : TimeOutSeconds * 1000,
+        KeyEndTime,
         &SetDefault
         );
+
+      if (KeyIndex == OC_INPUT_MODIFIERS_ONLY) {
+        break;
+      }
 
       if (PlayChosen && KeyIndex == OC_INPUT_TIMEOUT) {
         OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileSelected, FALSE);
@@ -755,7 +799,7 @@ OcRunBootPicker (
       // Ensure that we flush all pressed keys after the application.
       // This resolves the problem of application-pressed keys being used to control the menu.
       //
-      OcKeyMapFlush (KeyMap, 0, TRUE);
+      OcKeyMapFlush (KeyMap, 0, TRUE, FALSE, FALSE);
     }
 
     OcFreeBootContext (BootContext);

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -724,6 +724,7 @@ mUefiAudioSchema[] = {
 STATIC
 OC_SCHEMA
 mUefiInputSchema[] = {
+  OC_SCHEMA_STRING_IN  ("DownkeysHandler",    OC_GLOBAL_CONFIG, Uefi.Input.DownkeysHandler),
   OC_SCHEMA_BOOLEAN_IN ("KeyFiltering",       OC_GLOBAL_CONFIG, Uefi.Input.KeyFiltering),
   OC_SCHEMA_INTEGER_IN ("KeyForgetThreshold", OC_GLOBAL_CONFIG, Uefi.Input.KeyForgetThreshold),
   OC_SCHEMA_BOOLEAN_IN ("KeySupport",         OC_GLOBAL_CONFIG, Uefi.Input.KeySupport),

--- a/Library/OcInputLib/Keycode/AIK.c
+++ b/Library/OcInputLib/Keycode/AIK.c
@@ -256,14 +256,19 @@ OcAppleGenericInputKeycodeInit (
   gAikSelf.KeyForgotThreshold = KeyForgotThreshold;
   gAikSelf.KeyFiltering       = KeyFiltering;
   Status = AIKInstall (&gAikSelf);
+  //
+  // Allow to see whether this is installed, even on success
+  //
+  DEBUG ((DEBUG_INFO, "AIKInstall - %r\n", Status));
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "AIKInstall failed - %r\n", Status));
-
     //
     // No AppleKeyMapAggregator present, install on its availability.
     //
     Status = AIKProtocolArriveInstall (&gAikSelf);
     if (EFI_ERROR (Status)) {
+      //
+      // TODO: Should there be DEBUG_ERROR here (critical error?)
+      //
       DEBUG ((DEBUG_INFO, "AIK is NOT waiting for protocols - %r\n", Status));
     }
   }

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -816,20 +816,21 @@ OcMiscBoot (
   IN  EFI_HANDLE                LoadHandle
   )
 {
-  EFI_STATUS             Status;
-  OC_PICKER_CONTEXT      *Context;
-  OC_PICKER_CMD          PickerCommand;
-  OC_PICKER_MODE         PickerMode;
-  OC_DMG_LOADING_SUPPORT DmgLoading;
-  UINTN                  ContextSize;
-  UINT32                 Index;
-  UINT32                 EntryIndex;
-  OC_INTERFACE_PROTOCOL  *Interface;
-  UINTN                  BlessOverrideSize;
-  CHAR16                 **BlessOverride;
-  CONST CHAR8            *AsciiPicker;
-  CONST CHAR8            *AsciiPickerVariant;
-  CONST CHAR8            *AsciiDmg;
+  EFI_STATUS                          Status;
+  APPLE_KEY_MAP_AGGREGATOR_PROTOCOL   *KeyMap;
+  OC_PICKER_CONTEXT                   *Context;
+  OC_PICKER_CMD                       PickerCommand;
+  OC_PICKER_MODE                      PickerMode;
+  OC_DMG_LOADING_SUPPORT              DmgLoading;
+  UINTN                               ContextSize;
+  UINT32                              Index;
+  UINT32                              EntryIndex;
+  OC_INTERFACE_PROTOCOL               *Interface;
+  UINTN                               BlessOverrideSize;
+  CHAR16                              **BlessOverride;
+  CONST CHAR8                         *AsciiPicker;
+  CONST CHAR8                         *AsciiPickerVariant;
+  CONST CHAR8                         *AsciiDmg;
 
   AsciiPicker = OC_BLOB_GET (&Config->Misc.Boot.PickerMode);
 
@@ -1025,7 +1026,9 @@ OcMiscBoot (
 
   DEBUG ((DEBUG_INFO, "OC: Ready for takeoff in %u us\n", (UINT32) Context->TakeoffDelay));
 
-  OcLoadPickerHotKeys (Context);
+  KeyMap = OcLoadPickerHotKeys (Context);
+
+  OcInitDownkeys (&Config->Uefi.Input, KeyMap);
 
   Context->ShowNvramReset  = Config->Misc.Security.AllowNvramReset;
   Context->AllowSetDefault = Config->Misc.Security.AllowSetDefault;

--- a/Library/OcMainLib/OpenCoreUefiInOut.c
+++ b/Library/OcMainLib/OpenCoreUefiInOut.c
@@ -142,6 +142,7 @@ OcLoadUefiInputSupport (
   }
 
   if (Config->Uefi.Input.KeySupport) {
+    DEBUG ((DEBUG_INFO, "OC: Installing KeySupport...\n"));
     KeySupportStr = OC_BLOB_GET (&Config->Uefi.Input.KeySupportMode);
     KeyMode = OcInputKeyModeMax;
     if (AsciiStrCmp (KeySupportStr, "Auto") == 0) {

--- a/Library/OcTimerLib/OcTimerLib.c
+++ b/Library/OcTimerLib/OcTimerLib.c
@@ -232,6 +232,21 @@ GetTimeInNanoSecond (
 }
 
 /**
+  Return cached PerformanceCounterFrequency value.
+
+  @retval               The timer frequency in use.
+
+**/
+UINT64
+EFIAPI
+GetTscFrequency (
+  VOID
+  )
+{
+  return mTscFrequency;
+}
+
+/**
   The constructor function caches PerformanceCounterFrequency.
 
   @retval EFI_SUCCESS   The constructor always returns RETURN_SUCCESS.

--- a/Platform/OpenCanopy/Input/InputSimTextIn.c
+++ b/Platform/OpenCanopy/Input/InputSimTextIn.c
@@ -47,6 +47,8 @@ GuiKeyRead (
 {
 
   ASSERT (Context != NULL);
+  ASSERT (KeyIndex != NULL);
+  ASSERT (Modifier != NULL);
 
   *Modifier = FALSE;
   *KeyIndex = Context->Context->GetKeyIndex (

--- a/Platform/OpenCanopy/Views/BootPicker.c
+++ b/Platform/OpenCanopy/Views/BootPicker.c
@@ -447,13 +447,18 @@ InternalBootPickerKeyEvent (
   }
 
   if (Key == OC_INPUT_MORE) {
-    GuiContext->HideAuxiliary = FALSE;
-    GuiContext->Refresh = TRUE;
-    DrawContext->GuiContext->PickerContext->PlayAudioFile (
-      DrawContext->GuiContext->PickerContext,
-      OcVoiceOverAudioFileShowAuxiliary,
-      FALSE
-      );
+    //
+    // Match Builtin picker logic here: only refresh if the keypress makes a change
+    //
+    if (GuiContext->HideAuxiliary == TRUE) {
+      GuiContext->HideAuxiliary = FALSE;
+      GuiContext->Refresh = TRUE;
+      DrawContext->GuiContext->PickerContext->PlayAudioFile (
+        DrawContext->GuiContext->PickerContext,
+        OcVoiceOverAudioFileShowAuxiliary,
+        FALSE
+        );
+    }
   } else if (Key == OC_INPUT_ABORTED) {
     GuiContext->Refresh = TRUE;
     DrawContext->GuiContext->PickerContext->PlayAudioFile (

--- a/Platform/OpenUsbKbDxe/KeyBoard.c
+++ b/Platform/OpenUsbKbDxe/KeyBoard.c
@@ -1063,7 +1063,7 @@ KeyboardHandler (
 
   //
   // If there is new key pressed, update the RepeatKey value, and set the
-  // timer to repeate delay timer
+  // timer to repeat delay timer
   //
   if (NewRepeatKey != 0) {
     //

--- a/Utilities/ocvalidate/ValidateUEFI.c
+++ b/Utilities/ocvalidate/ValidateUEFI.c
@@ -325,6 +325,7 @@ CheckUEFIInput (
   OC_UEFI_CONFIG  *UserUefi;
   BOOLEAN         IsPointerSupportEnabled;
   CONST CHAR8     *PointerSupportMode;
+  CONST CHAR8     *DownkeysHandler;
   CONST CHAR8     *KeySupportMode;
 
   ErrorCount      = 0;
@@ -334,6 +335,14 @@ CheckUEFIInput (
   PointerSupportMode      = OC_BLOB_GET (&UserUefi->Input.PointerSupportMode);
   if (IsPointerSupportEnabled && AsciiStrCmp (PointerSupportMode, "ASUS") != 0) {
     DEBUG ((DEBUG_WARN, "UEFI->Input->PointerSupport is enabled, but PointerSupportMode is not ASUS!\n"));
+    ++ErrorCount;
+  }
+
+  DownkeysHandler = OC_BLOB_GET (&UserUefi->Input.DownkeysHandler);
+  if (AsciiStrCmp (DownkeysHandler, "Auto") != 0
+    && AsciiStrCmp (DownkeysHandler, "Enabled") != 0
+    && AsciiStrCmp (DownkeysHandler, "Disabled") != 0) {
+    DEBUG ((DEBUG_WARN, "UEFI->Input->DownkeysHandler is illegal (Can only be Auto, Enabled, Disabled)!\n"));
     ++ErrorCount;
   }
 


### PR DESCRIPTION
So, I finished the rough proof of concept of ‘new down key’ detection.

Basic method:
1. ~Keep up/down state of all Apple hid keys with an original USB code of below 256 (which should be all of them?) in a 256 CHAR8 buffer (values 0 and 1 only)~ **EDIT:** Major improvements to state buffer approach after input from @vit9696 and @mhauser.
2. Call new method OcGetDownKeys which returns newly-down keys only, in main kb loop, instead of calling KeyMap->GetKeyStrokes directly.

To a first approximation, OcKeyMapFlush is no longer needed and is commented out to do nothing in this PoC (it is not obvious if/whether the specific additional flush code which was in there for some legacy machines, even *can* be applied anywhere truly sensible in the new logic).

It works.

The UI feel is honestly considerably nicer; if I could put it this way, you don’t really notice that much when switching to it (well, except for ESC not hanging the UI, which is a major plus anyway), but unfortunately you definitely do notice, for the worse, when switching back again.

With this method on:

On my Apple Mac (which I suspect may be quite typical?), and on OVMF + OpenUsbKbDxe.efi: keys respond on key down now; there is no hanging (e.g. waiting for control key to be released before actioning CTRL+Enter); ESC does not hang the boot menu; ~however, there is no kb repeat (e.g. for left right arrow), but noting that, for obvious reasons (i.e. nothing at all happened until you released a key), there never was on these setups~. **EDIT:** Key repeat handling (and optional non-repeating keys where required) is now an essential part of the updated PR.

In OVMF + KeySupport: keys still respond to key down as before; there is (still) kb repeat.

(Additional advantage in my mind, if you could accept this method, would be that it would now be possible to implement circular-arrow-while-ctrl-key-depressed in OpenCanopy, as in Apple bootpicker, since the anim is now continuing while keys, incl CTRL, are held down; and wasn’t before.)
