### PR TITLE
OcAfterBootCompatLib: Store BootCompat CpuInfo

### DIFF
--- a/Library/OcAfterBootCompatLib/OcAfterBootCompatLib.c
+++ b/Library/OcAfterBootCompatLib/OcAfterBootCompatLib.c
@@ -156,6 +156,8 @@ OcAbcInitialize (
     sizeof (BootCompat->Settings)
     );
 
+  BootCompat->CpuInfo = CpuInfo;
+
   InstallServiceOverrides (BootCompat);
 
   return EFI_SUCCESS;


### PR DESCRIPTION
Hi,

Assumed here you forgot to store CpuInfo into BootCompat->CpuInfo to be used [here](https://github.com/acidanthera/OpenCorePkg/blob/master/Library/OcAfterBootCompatLib/CustomSlide.c#L812).