### PR TITLE
Support custom boot entries as default options

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ OpenCore Changelog
 - Fixed that cursor bounds could be different from OpenCanopy's
 - Improved builtin picker rendering performance
 - Added Memory Type decoding for SMBIOS in `Automatic` mode
+- Properly support setting custom entries as default boot options
 
 #### v0.6.7
 - Fixed ocvalidate return code to be non-zero when issues are found

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -2813,6 +2813,7 @@ The algorithm to determine boot options behaves as follows:
   % Scan policy restrictions are actually checked here as we want the function to be self-contained
   % for non-scan based startup.
   \item Perform fixups (e.g. NVMe subtype correction) and expansion (e.g. for Boot Camp) of the device path.
+  \item On failure, if it is an OpenCore custom entry device path, pre-construct the corresponding custom entry and succeed.
   \item Obtain the device handle by locating the device path of the resulting device path (ignore it on failure).
   \item Locate the device handle in the list of partition handles (ignore it if missing).
   % To determine device path type we can use LocateDevicePath RemainingDevicePath argument.
@@ -2838,7 +2839,7 @@ The algorithm to determine boot options behaves as follows:
   \item Lookup alternate entries by ``bless'' recovery option list retrieval and predefined paths.
   \item Register the resulting entries as alternate auxiliary options and determine their types if found.
   \end{itemize}
-\item Custom entries and tools are added as primary options without any checks with respect to \texttt{Auxiliary}.
+\item Custom entries and tools, except such pre-constructed previously, are added as primary options without any checks with respect to \texttt{Auxiliary}.
 \item System entries, such as \texttt{Reset NVRAM}, are added as primary auxiliary options.
 \end{enumerate}
 

--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -194,6 +194,10 @@ typedef struct OC_BOOT_ENTRY_ {
   //
   BOOLEAN                   IsGeneric;
   //
+  // Set when this entry refers to a custom boot entry.
+  //
+  BOOLEAN                   IsCustom;
+  //
   // Should make this option default boot option.
   //
   BOOLEAN                   SetDefault;

--- a/Include/Acidanthera/Library/OcStringLib.h
+++ b/Include/Acidanthera/Library/OcStringLib.h
@@ -557,4 +557,27 @@ HasValidGuidStringPrefix (
   IN CONST CHAR16  *String
   );
 
+/**
+  Compares two Null-terminated Unocide and ASCII strings, and returns the
+  difference between the first mismatched characters.
+
+  This function compares the Null-terminated Unicode string FirstString to the
+  Null-terminated ASCII string SecondString. If FirstString is identical to
+  SecondString, then 0 is returned. Otherwise, the value returned is the first
+  mismatched character in SecondString subtracted from the first mismatched
+  character in FirstString.
+
+  @param  FirstString   A pointer to a Null-terminated Unicode string.
+  @param  SecondString  A pointer to a Null-terminated ASCII string.
+
+  @retval ==0      FirstString is identical to SecondString.
+  @retval !=0      FirstString is not identical to SecondString.
+
+**/
+INTN
+MixedStrCmp (
+  IN CONST CHAR16  *FirstString,
+  IN CONST CHAR8   *SecondString
+  );
+
 #endif // OC_STRING_LIB_H

--- a/Library/OcBootManagementLib/BootManagementInternal.h
+++ b/Library/OcBootManagementLib/BootManagementInternal.h
@@ -26,6 +26,41 @@
 
 #define OC_CUSTOM_FS_HANDLE ((EFI_HANDLE)(UINTN) 0x2007C5F5U)
 
+///
+/// Identifies the DevicePath structure for OpenCore custom entries.
+///
+#define OC_CUSTOM_BOOT_DEVICE_PATH_GUID  \
+  { 0xd6f263f9, 0x0b19, 0x4670,          \
+    { 0xb0, 0xa4, 0x9d, 0x95, 0x9f, 0x58, 0xdf, 0x65 } }
+
+#pragma pack(1)
+
+///
+/// DevicePath to describe OpenCore custom entries.
+///
+typedef PACKED struct {
+  VENDOR_DEVICE_PATH   Hdr;
+  FILEPATH_DEVICE_PATH EntryName;
+} OC_CUSTOM_BOOT_DEVICE_PATH;
+
+//
+// Ideally, a variant of FILEPATH_DEVICE_PATH will be used with PathName as a
+// flexible array. Such cannot be used for declarations, so provide an
+// alternative.
+//
+typedef PACKED struct {
+  VENDOR_DEVICE_PATH       Header;
+  EFI_DEVICE_PATH_PROTOCOL EntryName;
+} OC_CUSTOM_BOOT_DEVICE_PATH_DECL;
+
+#pragma pack()
+
+///
+/// The size of a OC_CUSTOM_BOOT_DEVICE_PATH structure excluding the name.
+///
+#define SIZE_OF_OC_CUSTOM_BOOT_DEVICE_PATH  \
+  (sizeof (VENDOR_DEVICE_PATH) + SIZE_OF_FILEPATH_DEVICE_PATH)
+
 typedef struct {
   EFI_DEVICE_PATH_PROTOCOL       *DevicePath;
   OC_APPLE_DISK_IMAGE_CONTEXT    *DmgContext;
@@ -167,6 +202,16 @@ InternalFileSystemForHandle (
 EFI_STATUS
 InternalSystemActionResetNvram (
   VOID
+  );
+
+/**
+  Determines whether DevicePath is an OpenCore custom boot entry.
+
+  @returns  The OpenCore custom boot entry, or NULL.
+**/
+CONST OC_CUSTOM_BOOT_DEVICE_PATH *
+InternetGetOcCustomDevPath (
+  IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath
   );
 
 #endif // BOOT_MANAGEMENET_INTERNAL_H

--- a/Library/OcStringLib/OcUnicodeLib.c
+++ b/Library/OcStringLib/OcUnicodeLib.c
@@ -405,3 +405,17 @@ HasValidGuidStringPrefix (
 
   return TRUE;
 }
+
+INTN
+MixedStrCmp (
+  IN CONST CHAR16  *FirstString,
+  IN CONST CHAR8   *SecondString
+  )
+{
+  while (*FirstString != '\0' && *FirstString == *SecondString) {
+    ++FirstString;
+    ++SecondString;
+  }
+
+  return *FirstString - *SecondString;
+}


### PR DESCRIPTION
Supports custom boot entries added by `Entries` to be the default boot options. Resolves issues with duplicated entries, incorrect boot arguments, and such when it is attempted currently.