### PR TITLE
OcSmbiosLib: Fix index in OcSmbiosGetSmcVersion

### DIFF
--- a/Library/OcSmbiosLib/SmbiosPatch.c
+++ b/Library/OcSmbiosLib/SmbiosPatch.c
@@ -1878,7 +1878,7 @@ OcSmbiosGetSmcVersion (
     }
   }
 
-  Temp = SmcRevision[4];
+  Temp = SmcRevision[3];
 
   if (Temp < 0x10) {
     SmcVersion[Index] = (Temp + 0x30);


### PR DESCRIPTION
I don't know if it was intended behaviour, if so, sorry, ignore this pr.

it produces different result for revisions like {0x02, 0x12, 0x0f, 0x00, 0x01, 0x43}

master: 2.1271143

this pr: 2.1270143 