### PR TITLE
Skylake 睡眠问题解决方法(不完美) Skylake issue (isn't perfect )

### DIFF
--- a/Library/DuetBdsLib/BdsPlatform.c
+++ b/Library/DuetBdsLib/BdsPlatform.c
@@ -503,120 +503,6 @@ UpdateMemoryMap (
 
 STATIC
 EFI_STATUS
-DisableUsbLegacySupport (
-  VOID
-  )
-/*++
-
-Routine Description:
-  Disable the USB legacy Support in all Ehci and Uhci.
-  This function assume all PciIo handles have been created in system.
-
-Arguments:
-  None
-
-Returns:
-  EFI_SUCCESS
-  EFI_NOT_FOUND
---*/
-{
-  EFI_STATUS                            Status;
-  EFI_HANDLE                            *HandleArray;
-  UINTN                                 HandleArrayCount;
-  UINTN                                 Index;
-  EFI_PCI_IO_PROTOCOL                   *PciIo;
-  UINT8                                 Class[3];
-  UINT16                                Command;
-  UINT32                                HcCapParams;
-  UINT32                                ExtendCap;
-  UINT32                                Value;
-  UINT32                                TimeOut;
-
-  //
-  // Find the usb host controller
-  //
-  Status = gBS->LocateHandleBuffer (
-                                    ByProtocol,
-                                    &gEfiPciIoProtocolGuid,
-                                    NULL,
-                                    &HandleArrayCount,
-                                    &HandleArray
-                                    );
-  if (!EFI_ERROR (Status)) {
-    for (Index = 0; Index < HandleArrayCount; Index++) {
-      Status = gBS->HandleProtocol (
-                                    HandleArray[Index],
-                                    &gEfiPciIoProtocolGuid,
-                                    (VOID **)&PciIo
-                                    );
-      if (!EFI_ERROR (Status)) {
-        //
-        // Find the USB host controller controller
-        //
-        Status = PciIo->Pci.Read (PciIo, EfiPciIoWidthUint8, 0x09, 3, &Class);
-        if (!EFI_ERROR (Status)) {
-          if ((PCI_CLASS_SERIAL == Class[2]) &&
-              (PCI_CLASS_SERIAL_USB == Class[1])) {
-            if (PCI_IF_UHCI == Class[0]) {
-              //
-              // Found the UHCI, then disable the legacy support
-              //
-              Command = 0;
-              Status = PciIo->Pci.Write (PciIo, EfiPciIoWidthUint16, 0xC0, 1, &Command);
-            } else if (PCI_IF_EHCI == Class[0]) {
-
-              //
-              // Found the EHCI, then disable the legacy support
-              //
-              Status = PciIo->Mem.Read (
-                                        PciIo,
-                                        EfiPciIoWidthUint32,
-                                        0,                   ///< EHC_BAR_INDEX
-                                        (UINT64) 0x08,       ///< EHC_HCCPARAMS_OFFSET
-                                        1,
-                                        &HcCapParams
-                                        );
-
-              ExtendCap = (HcCapParams >> 8) & 0xFF;
-              //
-              // Disable the SMI in USBLEGCTLSTS firstly
-              // Not doing this may result in a hardlock soon after
-              //
-              PciIo->Pci.Read (PciIo, EfiPciIoWidthUint32, ExtendCap + 0x4, 1, &Value);
-              Value &= 0xFFFF0000;
-              PciIo->Pci.Write (PciIo, EfiPciIoWidthUint32, ExtendCap + 0x4, 1, &Value);
-
-              //
-              // Get EHCI Ownership from legacy bios
-              //
-              PciIo->Pci.Read (PciIo, EfiPciIoWidthUint32, ExtendCap, 1, &Value);
-              Value |= (0x1 << 24);
-              PciIo->Pci.Write (PciIo, EfiPciIoWidthUint32, ExtendCap, 1, &Value);
-
-              TimeOut = 40;
-              while (TimeOut--) {
-                gBS->Stall (500);
-
-                PciIo->Pci.Read (PciIo, EfiPciIoWidthUint32, ExtendCap, 1, &Value);
-
-                if ((Value & 0x01010000) == 0x01000000) {
-                  break;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    gBS->FreePool (HandleArray);
-  } else {
-    return Status;
-  }
-  return EFI_SUCCESS;
-}
-
-STATIC
-EFI_STATUS
 ConnectRootBridge (
   VOID
   )
@@ -1053,14 +939,6 @@ Returns:
     //
     DetectAndPreparePlatformPciDevicePath (TRUE);
   }
-
-  //
-  // The ConIn devices connection will start the USB bus, should disable all
-  // Usb legacy support firstly.
-  // Caution: Must ensure the PCI bus driver has been started. Since the
-  // ConnectRootBridge() will create all the PciIo protocol, it's safe here now
-  //
-  DisableUsbLegacySupport ();
 
   //
   // Connect the all the default console with current console variable

--- a/OpenDuetPkg.dsc
+++ b/OpenDuetPkg.dsc
@@ -220,6 +220,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdDevicePathSupportDevicePathFromText|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdDevicePathSupportDevicePathToText|FALSE
   gEfiMdePkgTokenSpaceGuid.PcdUgaConsumeSupport|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdTurnOffUsbLegacySupport|TRUE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor|L"Acidanthera"


### PR DESCRIPTION
当Skylake 架构的CPU 在config勾选了AppleXcpuforceboost 睡眠唤醒显示器能正常显示画面，但CPU一直是满频的，希望官方能就这个问题改善一下，现在好像全网都没有Skylake 睡眠的解决方案，但这好像就解决了一半的唤醒的问题，不过CPU会满频和系统自己睡眠就唤醒不了，我把配置图放在了下面

When Skylake CPU tick the AppleXcpuforceboost in config , the screen can wake up after sleeping but the CPU is full frequency all the time.Wish official can solve this problem. I can see that on google baidu is no one can solve the Skylake wake up problem , this way can solve half of problem,but there's a problem that can't wake up from system automatic sleep ,and the CPU full frequency all the time . I put my build at the end.

![D25F4A4C-85A7-4463-91CF-80D1BC01D1E7](https://user-images.githubusercontent.com/56785635/112141773-b345e600-8c10-11eb-8c61-8bb893655a0d.jpeg)
