### PR TITLE
Trojan:Script/Wacatac.B!ml virus alert

### DIFF
--- a/Library/OcDeviceMiscLib/ReloadOptionRoms.c
+++ b/Library/OcDeviceMiscLib/ReloadOptionRoms.c
@@ -47,7 +47,7 @@ STATIC
 EFI_STATUS
 ReloadPciRom (
   IN VOID          *RomBar,
-  IN UINTN         RomSize,
+  IN UINT64        RomSize,
   IN CONST CHAR16  *FileName
   )
 {


### PR DESCRIPTION
Windows 10 warns of this trojan. Can you please be interested?
There is a problem with the OpenCore-0.6.8 version.
Trojan:Script/Wacatac.B!ml
VirusTotal results: https://www.virustotal.com/gui/file/9f2c4c9a34a7828cee38354e71587e5bd2ed32ce40c0ee0902c438a3f909bc36/detection

Thanks in advance!