### PR TITLE
Build: Provide 512B file alignment to CLANGPDB to fix SignTool error

### DIFF
--- a/OpenCorePkg.dsc
+++ b/OpenCorePkg.dsc
@@ -335,4 +335,4 @@
   GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
   XCODE:*_*_*_DLINK_FLAGS = -seg1addr 0x1000 -segalign 0x1000
   XCODE:*_*_*_MTOC_FLAGS = -align 0x1000
-  CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096
+  CLANGPDB:*_*_*_DLINK_FLAGS = /ALIGN:4096 /FILEALIGN:512


### PR DESCRIPTION
When use SignTool sign efi build with CLANGPDB will get the following error.
```
SignTool Error: SignedCode::Sign returned error: 0x800700C1
        For more information, please see https://aka.ms/badexeformat
```

edk2 set bouth `ALIGN` and `FILEALIGN` to 32, OpenCore changed `ALIGN` to 4K for page protection but forgot change `FILEALIGN`

According to Microsoft's [PE format](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-windows-specific-fields-image-only) document description. 
```
The value should be a power of 2 between 512 and 64 K, inclusive. The default is 512. If the SectionAlignment is less than the architecture's page size, then FileAlignment must match SectionAlignment.
```
FileAlignment should be set between 512 and 64 K when SectionAlignment is 4K