### PR TITLE
It should be OpenHfsPlus.efi

### DIFF
--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1305,7 +1305,7 @@
 		<true/>
 		<key>Drivers</key>
 		<array>
-			<string>HfsPlus.efi</string>
+			<string>OpenHfsPlus.efi</string>
 			<string>OpenRuntime.efi</string>
 			<string>#OpenCanopy.efi</string>
 			<string>#AudioDxe.efi</string>


### PR DESCRIPTION
It seems that HfsPlus.efi can no longer be used in version 0.7.2.