### PR TITLE
Set MinDate and MinVersion default to -1

### DIFF
--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1259,9 +1259,9 @@
 			<key>JumpstartHotPlug</key>
 			<false/>
 			<key>MinDate</key>
-			<integer>0</integer>
+			<integer>-1</integer>
 			<key>MinVersion</key>
-			<integer>0</integer>
+			<integer>-1</integer>
 		</dict>
 		<key>AppleInput</key>
 		<dict>


### PR DESCRIPTION
I'm pretty active in the AMD OS X discord server as a helper, and we've been a little bit flooded with people trying to use Catalina or lower confused on why their drive won't show up after stage 1 installation when they use APFS. Since this fixes the issue, you can still boot Big Sur and up with these set to -1, and there are (to my knowledge) no downsides, I figured setting the default to -1 may be a good thing to do.