### PR TITLE
Account for Format/Style in Sample Lint Failure Message

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,7 @@ jobs:
                 /<\/data>$/   {inside=0; print "</data>"; next}
                 inside        {gsub ("\t", "", $0); printf $0; next}
                               {print}' "${File}" > "${File}.tmp" && mv "${File}.tmp" "${File}"
-          if [ "$(git diff $File)" != '' ]; then echo "$File keys are not in alphabetical order"; exit 1 ; fi
+          if [ "$(git diff ${File})" != '' ]; then echo "Not in Xcode style or not in alphabetical order!!"; exit 1 ; fi
 
           File='Docs/SampleCustom.plist'
           plutil -lint "${File}" || exit 1
@@ -203,7 +203,7 @@ jobs:
                 /<\/data>$/   {inside=0; print "</data>"; next}
                 inside        {gsub ("\t", "", $0); printf $0; next}
                               {print}' "${File}" > "${File}.tmp" && mv "${File}.tmp" "${File}"
-          if [ "$(git diff $File)" != '' ]; then echo "$File keys are not in alphabetical order"; exit 1 ; fi
+          if [ "$(git diff ${File})" != '' ]; then echo "Not in Xcode style or not in alphabetical order!!"; exit 1 ; fi
 
   analyze-coverity:
     name: Analyze Coverity


### PR DESCRIPTION
Sample Lint Failure Message currently only mentions issues with alphabetical order but failure may be due to format/style issues. 

Message amended to reflect this.