### PR TITLE
Build: Made stack-protector guard use global addressing instead of tls.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,11 +69,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install nasm uuid-dev libssl-dev iasl
-          file="clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04"
+          file="clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04"
           suf=".tar.xz"
-          curl -LO "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/${file}${suf}" || exit 1
+          curl -LO "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/${file}${suf}" || exit 1
           sum=$(shasum -a 256 "${file}${suf}" | cut -f1 -d' ')
-          expsum="6b3cc55d3ef413be79785c4dc02828ab3bd6b887872b143e3091692fc6acefe7"
+          expsum="2c2fb857af97f41a5032e9ecadf7f78d3eff389a5cd3c9ec620d24f134ceb3c8"
           if [ "$sum" != "$expsum" ]; then echo "Invalid checksum $sum" ; exit 1 ; fi
           tar -xf "${file}${suf}" || exit 1
           echo "$(pwd)/${file}/bin" >> $GITHUB_PATH
@@ -102,8 +102,8 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install nasm uuid-dev iasl clang-12 llvm-12-dev doxygen texlive texlive-latex-extra
-          echo "/usr/lib/llvm-12/bin" >> $GITHUB_PATH
+          sudo apt-get install nasm uuid-dev iasl clang-13 llvm-13-dev doxygen texlive texlive-latex-extra
+          echo "/usr/lib/llvm-13/bin" >> $GITHUB_PATH
 
       - name: CI Bootstrap
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,10 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install nasm uuid-dev iasl clang-13 llvm-13-dev doxygen texlive texlive-latex-extra
+          sudo apt-get install nasm uuid-dev iasl doxygen texlive texlive-latex-extra
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 13
           echo "/usr/lib/llvm-13/bin" >> $GITHUB_PATH
 
       - name: CI Bootstrap

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,11 +69,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install nasm uuid-dev libssl-dev iasl
-          file="clang+llvm-9.0.1-x86_64-linux-gnu-ubuntu-16.04"
+          file="clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04"
           suf=".tar.xz"
-          curl -LO "https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/${file}${suf}" || exit 1
+          curl -LO "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/${file}${suf}" || exit 1
           sum=$(shasum -a 256 "${file}${suf}" | cut -f1 -d' ')
-          expsum="1af280e96fec62acf5f3bb525e36baafe09f95f940dc9806e22809a83dfff4f8"
+          expsum="6b3cc55d3ef413be79785c4dc02828ab3bd6b887872b143e3091692fc6acefe7"
           if [ "$sum" != "$expsum" ]; then echo "Invalid checksum $sum" ; exit 1 ; fi
           tar -xf "${file}${suf}" || exit 1
           echo "$(pwd)/${file}/bin" >> $GITHUB_PATH
@@ -102,8 +102,8 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install nasm uuid-dev iasl clang-8 llvm-8-dev doxygen texlive texlive-latex-extra
-          echo "/usr/lib/llvm-8/bin" >> $GITHUB_PATH
+          sudo apt-get install nasm uuid-dev iasl clang-12 llvm-12-dev doxygen texlive texlive-latex-extra
+          echo "/usr/lib/llvm-12/bin" >> $GITHUB_PATH
 
       - name: CI Bootstrap
         run: |

--- a/OpenCorePkg.dsc
+++ b/OpenCorePkg.dsc
@@ -325,12 +325,12 @@
   DEFINE OCPKG_BUILD_OPTIONS_GEN = -D DISABLE_NEW_DEPRECATED_INTERFACES $(OCPKG_BUILD_OPTIONS) -D OC_TARGET_$(TARGET)=1
   DEFINE OCPKG_ANAL_OPTIONS_GEN = "-DANALYZER_UNREACHABLE=__builtin_unreachable" "-DANALYZER_NORETURN=__attribute__((noreturn))"
 
-  GCC:DEBUG_*_*_CC_FLAGS        = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -Wuninitialized
-  GCC:NOOPT_*_*_CC_FLAGS        = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -Wuninitialized
-  GCC:RELEASE_*_*_CC_FLAGS      = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -Wuninitialized
-  CLANGPDB:DEBUG_*_*_CC_FLAGS   = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -ftrivial-auto-var-init=pattern
-  CLANGPDB:NOOPT_*_*_CC_FLAGS   = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -ftrivial-auto-var-init=pattern
-  CLANGPDB:RELEASE_*_*_CC_FLAGS = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -ftrivial-auto-var-init=pattern
+  GCC:DEBUG_*_*_CC_FLAGS        = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -mstack-protector-guard=global -Wuninitialized
+  GCC:NOOPT_*_*_CC_FLAGS        = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -mstack-protector-guard=global -Wuninitialized
+  GCC:RELEASE_*_*_CC_FLAGS      = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -mstack-protector-guard=global -Wuninitialized
+  CLANGPDB:DEBUG_*_*_CC_FLAGS   = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -mstack-protector-guard=global -ftrivial-auto-var-init=pattern
+  CLANGPDB:NOOPT_*_*_CC_FLAGS   = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -mstack-protector-guard=global -ftrivial-auto-var-init=pattern
+  CLANGPDB:RELEASE_*_*_CC_FLAGS = $(OCPKG_BUILD_OPTIONS_GEN) $(OCPKG_ANAL_OPTIONS_GEN) -fstack-protector-strong -mstack-protector-guard=global -ftrivial-auto-var-init=pattern
   MSFT:DEBUG_*_*_CC_FLAGS       = $(OCPKG_BUILD_OPTIONS_GEN) /wd4723 /GS /kernel
   MSFT:NOOPT_*_*_CC_FLAGS       = $(OCPKG_BUILD_OPTIONS_GEN) /wd4723 /GS /kernel
   MSFT:RELEASE_*_*_CC_FLAGS     = $(OCPKG_BUILD_OPTIONS_GEN) /wd4723 /GS /kernel

--- a/OpenDuetPkg.dsc
+++ b/OpenDuetPkg.dsc
@@ -249,6 +249,6 @@
   XCODE:DEBUG_*_*_CC_FLAGS   = -D OC_TARGET_RELEASE=1 -fno-unwind-tables -flto -Os -DMDEPKG_NDEBUG -fstack-protector-strong -ftrivial-auto-var-init=pattern
   XCODE:RELEASE_*_*_CC_FLAGS = -D OC_TARGET_RELEASE=1 -fno-unwind-tables -flto -Os -DMDEPKG_NDEBUG -fstack-protector-strong -ftrivial-auto-var-init=pattern
 
-  GCC:NOOPT_*_*_CC_FLAGS     = -D OC_TARGET_RELEASE=1 -Wno-unused-but-set-variable -fstack-protector-strong -Wuninitialized
-  GCC:DEBUG_*_*_CC_FLAGS     = -D OC_TARGET_RELEASE=1 -DMDEPKG_NDEBUG -Wno-unused-but-set-variable -fstack-protector-strong -Wuninitialized
-  GCC:RELEASE_*_*_CC_FLAGS   = -D OC_TARGET_RELEASE=1 -DMDEPKG_NDEBUG -Wno-unused-but-set-variable -fstack-protector-strong -Wuninitialized
+  GCC:NOOPT_*_*_CC_FLAGS     = -D OC_TARGET_RELEASE=1 -Wno-unused-but-set-variable -fstack-protector-strong -mstack-protector-guard=global -Wuninitialized
+  GCC:DEBUG_*_*_CC_FLAGS     = -D OC_TARGET_RELEASE=1 -DMDEPKG_NDEBUG -Wno-unused-but-set-variable -fstack-protector-strong -mstack-protector-guard=global -Wuninitialized
+  GCC:RELEASE_*_*_CC_FLAGS   = -D OC_TARGET_RELEASE=1 -DMDEPKG_NDEBUG -Wno-unused-but-set-variable -fstack-protector-strong -mstack-protector-guard=global -Wuninitialized

--- a/Patches/0006-Fix-for-NOOPT-CLANG38-compilation-with-clang-13.patch
+++ b/Patches/0006-Fix-for-NOOPT-CLANG38-compilation-with-clang-13.patch
@@ -1,0 +1,37 @@
+From 76be193a80051662fe6a83307285e5fdde71be6f Mon Sep 17 00:00:00 2001
+From: ocbuild <ocbuild@acidanthera.local>
+Date: Fri, 22 Oct 2021 16:20:16 +0300
+Subject: [PATCH] Fix for NOOPT CLANG38 compilation with clang-13.
+
+---
+ BaseTools/Source/C/GenFw/Elf32Convert.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/BaseTools/Source/C/GenFw/Elf32Convert.c b/BaseTools/Source/C/GenFw/Elf32Convert.c
+index d917a44..b785998 100644
+--- a/BaseTools/Source/C/GenFw/Elf32Convert.c
++++ b/BaseTools/Source/C/GenFw/Elf32Convert.c
+@@ -779,6 +779,7 @@ WriteSections32 (
+             *(UINT32 *)Targ = *(UINT32 *)Targ - SymShdr->sh_addr
+               + mCoffSectionsOffset[Sym->st_shndx];
+             break;
++          case R_386_PLT32:
+           case R_386_PC32:
+             //
+             // Relative relocation: Symbol - Ip + Addend
+@@ -900,6 +901,7 @@ WriteRelocations32 (
+           if (mEhdr->e_machine == EM_386) {
+             switch (ELF_R_TYPE(Rel->r_info)) {
+             case R_386_NONE:
++            case R_386_PLT32:
+             case R_386_PC32:
+               //
+               // No fixup entry required.
+@@ -1168,5 +1170,3 @@ CleanUp32 (
+     free (mCoffSectionsOffset);
+   }
+ }
+-
+-
+--
+2.20.1


### PR DESCRIPTION
Needs at least clang-12 for successful compilation.