### PR TITLE
Work around partial overwriting of text by adding spaces at the end of the string

### DIFF
--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -295,7 +295,7 @@ def action_download(args):
         err = linecache.getline(tb.tb_frame.f_code.co_filename, tb.tb_lineno, tb.tb_frame.f_globals).strip()
       except:
         err = "Invalid chunklist"
-    print('\nImage verification failed. ({})'.format(err))
+    print('\rImage verification failed. ({})'.format(err))
     return 1
 
 def action_selfcheck(args):

--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -223,7 +223,7 @@ def save_image(url, sess, filename='', dir=''):
       size += len(chunk)
       print('\r{} MBs downloaded...'.format(size / (2**20)), end='')
       sys.stdout.flush()
-    print('\rDownload complete!')
+    print('\rDownload complete!          ')
 
   return os.path.join(dir, os.path.basename(filename))
 
@@ -240,10 +240,10 @@ def verify_image(dmgpath, cnkpath):
       if len(cnk) != cnksize:
         raise RuntimeError('Invalid chunk {} size: expected {}, read {}'.format(cnkcount, cnksize, len(cnk)))
       if hashlib.sha256(cnk).digest() != cnkhash:
-        raise RuntimeError('Invalid chunk {}: hash mismatch'.format(cnkcount)) 
+        raise RuntimeError('Invalid chunk {}: hash mismatch'.format(cnkcount))
     if dmgf.read(1) != b'':
       raise RuntimeError('Invalid image: larger than chunklist')
-    print('\rImage verification complete!')
+    print('\rImage verification complete!          ')
 
 def action_download(args):
   """
@@ -295,7 +295,7 @@ def action_download(args):
         err = linecache.getline(tb.tb_frame.f_code.co_filename, tb.tb_lineno, tb.tb_frame.f_globals).strip()
       except:
         err = "Invalid chunklist"
-    print('\rImage verification failed. ({})'.format(err))
+    print('\nImage verification failed. ({})'.format(err))
     return 1
 
 def action_selfcheck(args):

--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -223,7 +223,7 @@ def save_image(url, sess, filename='', dir=''):
       size += len(chunk)
       print('\r{} MBs downloaded...'.format(size / (2**20)), end='')
       sys.stdout.flush()
-    print('\rDownload complete!          ')
+    print('\rDownload complete!                    ')
 
   return os.path.join(dir, os.path.basename(filename))
 
@@ -243,7 +243,7 @@ def verify_image(dmgpath, cnkpath):
         raise RuntimeError('Invalid chunk {}: hash mismatch'.format(cnkcount))
     if dmgf.read(1) != b'':
       raise RuntimeError('Invalid image: larger than chunklist')
-    print('\rImage verification complete!          ')
+    print('\rImage verification complete!                    ')
 
 def action_download(args):
   """


### PR DESCRIPTION
This issue is observed when downloading macOS using macrecovery.py. Text is partially overwritten, and to work around this, spaces can be added to the end of the strings. 

![The issue](https://cdn.discordapp.com/attachments/186648463541272576/905105598633345064/unknown.png)
> Download complete!Bs downloaded...

Another approach would be to replace `\r` with `\n`, which should print the text in a new line. However, I am not completely sure how it would affect things in the variety of OSes this tool can be used in.