### PR TITLE
OcMemoryLib: Avoid rebuilding attributes when MAT is empty

### DIFF
--- a/Library/OcMemoryLib/MemoryAttributes.c
+++ b/Library/OcMemoryLib/MemoryAttributes.c
@@ -438,7 +438,7 @@ OcRebuildAttributes (
   UINT32                             DescriptorVersion;
 
   MemoryAttributesTable = OcGetMemoryAttributes (&MemoryAttributesEntry);
-  if (MemoryAttributesTable == NULL) {
+  if (MemoryAttributesTable == NULL || MemoryAttributesTable->NumberOfEntries == 0) {
     return EFI_UNSUPPORTED;
   }
 


### PR DESCRIPTION
Some firmware implementations may provide an empty Memory Attributes
Table (NumberOfEntries is zero). Avoid calling OcUpdateDescriptors in
this case, as it will lead to division by zero.

This resolves boot failures due to #DE on XPS 15 9560 when Secure Boot
is enabled.