### PR TITLE
Docs: Add MaxKernel for SurPlus patch

### DIFF
--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -918,7 +918,7 @@
 				<key>Mask</key>
 				<data></data>
 				<key>MaxKernel</key>
-				<string></string>
+				<string>21.1.0</string>
 				<key>MinKernel</key>
 				<string>20.4.0</string>
 				<key>Replace</key>
@@ -948,7 +948,7 @@
 				<key>Mask</key>
 				<data></data>
 				<key>MaxKernel</key>
-				<string></string>
+				<string>21.1.0</string>
 				<key>MinKernel</key>
 				<string>20.4.0</string>
 				<key>Replace</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -918,7 +918,7 @@
 				<key>Mask</key>
 				<data></data>
 				<key>MaxKernel</key>
-				<string></string>
+				<string>21.1.0</string>
 				<key>MinKernel</key>
 				<string>20.4.0</string>
 				<key>Replace</key>
@@ -948,7 +948,7 @@
 				<key>Mask</key>
 				<data></data>
 				<key>MaxKernel</key>
-				<string></string>
+				<string>21.1.0</string>
 				<key>MinKernel</key>
 				<string>20.4.0</string>
 				<key>Replace</key>


### PR DESCRIPTION
As reported by user Syncretic, author of SurPlus and MonteRand patches, and by others on macrumors, SurPlus patches are not required for Monterey 12.1 (included).
Monterey 12.2 beta does not require them too.
> EDIT (20dec21): It appears that the released Monterey 12.1 does not require either the SurPlus or MonteRand patches. This may change in a later release, but for now, the race condition addressed by SurPlus is no longer an issue in 12.1. (Note that SurPlus is still required for Big Sur 11.3-11.6.2 and Monterey prior to 12.1; MonteRand seems to only be required for 12.1b1 and no other version/beta.)

This PR adds MaxKernel To SurPlus patches.

