### PR TITLE
OcBootManagementLib: Auto-detect `macOS Installer` text label for use when `.disk_label` file cannot be displayed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 OpenCore Changelog
 ==================
+#### v0.7.9
+- Added auto-detect `macOS Installer` volume name for use when `.disk_label` file cannot be displayed
+
 #### v0.7.8
 - Updated ocvalidate to warn about insecure `DmgLoading` with secure `SecureBootModel` (already disallowed in runtime)
 - Fixed AudioDxe not disabling unused channels after recent updates

--- a/Library/OcBootManagementLib/BootEntryInfo.c
+++ b/Library/OcBootManagementLib/BootEntryInfo.c
@@ -691,32 +691,42 @@ InternalDescribeBootEntry (
   }
 
   if (BootEntry->Name == NULL) {
-    BootEntry->Name = OcGetVolumeLabel (FileSystem);
-    if (BootEntry->Name != NULL) {
-      if (StrCmp (BootEntry->Name, L"Recovery HD") == 0
-        || StrCmp (BootEntry->Name, L"Recovery") == 0) {
-        if (BootEntry->Type == OC_BOOT_UNKNOWN || BootEntry->Type == OC_BOOT_APPLE_OS) {
-          BootEntry->Type = OC_BOOT_APPLE_RECOVERY;
-        }
-        Status = InternalGetAppleVersion (FileSystem, BootDirectoryName, AppleVersion);
-        if (EFI_ERROR (Status)) {
-          TmpBootName = NULL;
+    //
+    // Special case - installer should be clearly identified to end users but does not normally
+    // contain text label, only pre-rendered graphical label which is not available in builtin
+    // picker, or in Canopy with disk labels disabled.
+    //
+    if (StrStr (BootDirectoryName, L"com.apple.installer") != NULL) {
+      BootEntry->Name = AllocateCopyPool (L_STR_SIZE (L"macOS Installer"), L"macOS Installer");
+    } else {
+      BootEntry->Name = OcGetVolumeLabel (FileSystem);
+      if (BootEntry->Name != NULL) {
+        if (StrCmp (BootEntry->Name, L"Recovery HD") == 0
+          || StrCmp (BootEntry->Name, L"Recovery") == 0) {
+          if (BootEntry->Type == OC_BOOT_UNKNOWN || BootEntry->Type == OC_BOOT_APPLE_OS) {
+            BootEntry->Type = OC_BOOT_APPLE_RECOVERY;
+          }
+          Status = InternalGetAppleVersion (FileSystem, BootDirectoryName, AppleVersion);
+          if (EFI_ERROR (Status)) {
+            TmpBootName = NULL;
+          } else {
+            TmpBootName = InternalGetAppleRecoveryName (AppleVersion);
+          }
+        } else if (StrCmp (BootEntry->Name, L"Preboot") == 0) {
+          //
+          // Common Big Sur beta bug failing to create .contentDetails files.
+          // Workaround it by choosing the default name following Apple BootPicker behaviour.
+          // Applies to anything on the main volume without any text labels (but specifically, to main OS).
+          //
+          TmpBootName = AllocateCopyPool (sizeof (L"Macintosh HD"), L"Macintosh HD");
         } else {
-          TmpBootName = InternalGetAppleRecoveryName (AppleVersion);
+          TmpBootName = NULL;
         }
-      } else if (StrCmp (BootEntry->Name, L"Preboot") == 0) {
-        //
-        // Common Big Sur beta bug failing to create .contentDetails files.
-        // Workaround it by choosing the default name following Apple BootPicker behaviour.
-        //
-        TmpBootName = AllocateCopyPool (sizeof (L"Macintosh HD"), L"Macintosh HD");
-      } else {
-        TmpBootName = NULL;
-      }
 
-      if (TmpBootName != NULL) {
-        FreePool (BootEntry->Name);
-        BootEntry->Name = TmpBootName;
+        if (TmpBootName != NULL) {
+          FreePool (BootEntry->Name);
+          BootEntry->Name = TmpBootName;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/acidanthera/bugtracker/issues/1939