### PR TITLE
Docs: Add Override key for Serial to Sample.plist

### DIFF
--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1160,6 +1160,8 @@
 		<dict>
 			<key>Init</key>
 			<false/>
+			<key>Override</key>
+			<false/>
 		</dict>
 		<key>Tools</key>
 		<array>


### PR DESCRIPTION
Without Override key ocvalidate is failing.