### PR TITLE
Build: Run Coverity on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install curl nasm
+          sudo apt-get install curl nasm uuid-dev libssl-dev iasl
 
       - name: CI Bootstrap
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_TYPE: COVERITY
+      TOOLCHAINS: GCC5
     if: github.repository_owner == 'acidanthera' && github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install curl
+          sudo apt-get install curl nasm
 
       - name: CI Bootstrap
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,12 +222,17 @@ jobs:
 
   analyze-coverity:
     name: Analyze Coverity
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
       JOB_TYPE: COVERITY
     if: github.repository_owner == 'acidanthera' && github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install curl
 
       - name: CI Bootstrap
         run: |
@@ -238,9 +243,8 @@ jobs:
       - name: Run Coverity
         working-directory: UDK
         run: |
-          src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/coverity/covstrap.sh) && eval "$src" || exit 1
+          src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/coverity/covstrap-linux.sh) && eval "$src" || exit 1
         env:
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
           COVERITY_SCAN_EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
           COVERITY_BUILD_COMMAND: ../build_oc.tool --skip-tests --skip-package RELEASE
-          MAKE: /Applications/Xcode_12.5.1.app/Contents/Developer/usr/bin/make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -243,4 +243,4 @@ jobs:
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
           COVERITY_SCAN_EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
           COVERITY_BUILD_COMMAND: ../build_oc.tool --skip-tests --skip-package RELEASE
-          MAKE: /usr/bin/make
+          MAKE: /Applications/Xcode_12.5.1.app/Contents/Developer/usr/bin/make


### PR DESCRIPTION
Coverity does not have to be running on macOS, where a bunch of incompatible problems arise. This PR switches the host OS for Coverity to Linux.