### PR TITLE
Add Facebook Hackintosh group

### DIFF
--- a/Docs/FORUMS.md
+++ b/Docs/FORUMS.md
@@ -16,3 +16,4 @@
 - [macOS86.it](https://www.macos86.it/showthread.php?4570-OpenCore-aka-OC-Nuovo-BootLoader) in Italian
 - [KVM-OpenCore](https://github.com/Leoyzen/KVM-Opencore) in English, KVM configuration
 - [Reddit](https://www.reddit.com/r/hackintosh) in English
+- [Facebook](https://www.facebook.com/groups/hackintosch) in English, bare-metal and KVM


### PR DESCRIPTION
This PR adds the Facebook Hackintosh group to the OpenCore discussion forums.

A couple of rules from this group: (to make clear no macOS distro's or anything like that are supported)
- No support for distros (Niresh, Hackintosh Zone, HackintoshShop and Tonymacx86)
- Posts about those macOS distros and their tools will be removed.
- No support for prebuild EFI's
- Posts in any other language than English will be removed, to make every post understandable for everyone.

These rules are in an announcement/pinned post  everyone can see it once they joined the group.

As of the time of writing this group has 86.4K members.

(And yes, there's a spelling fault in the link to this group. The actual name of this group is correct)
