### PR TITLE
OcAudio: Convert from int ids to string ids

### DIFF
--- a/Include/Acidanthera/Library/OcAudioLib.h
+++ b/Include/Acidanthera/Library/OcAudioLib.h
@@ -83,4 +83,12 @@ OcAudioDump (
   IN EFI_FILE_PROTOCOL  *Root
   );
 
+//
+// Base path and base type for a given APPLE_VOICE_OVER_AUDIO_FILE index.
+//
+typedef struct {
+  CONST CHAR8    *BasePath;
+  CONST CHAR8    *BaseType;
+} APPLE_VOICE_OVER_FILE_MAP;
+
 #endif // OC_AUDIO_LIB_H

--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -693,9 +693,10 @@ VOID
 typedef
 EFI_STATUS
 (EFIAPI *OC_PLAY_AUDIO_FILE)(
-  IN  OC_PICKER_CONTEXT  *Context,
-  IN  UINT32             File,
-  IN  BOOLEAN            Fallback
+  IN  OC_PICKER_CONTEXT                 *Context,
+  IN  CONST CHAR8                       *BasePath,
+  IN  CONST CHAR8                       *BaseType,
+  IN  BOOLEAN                           Fallback
   );
 
 /**
@@ -726,8 +727,9 @@ EFI_STATUS
 typedef
 VOID
 (EFIAPI *OC_TOGGLE_VOICE_OVER)(
-  IN  OC_PICKER_CONTEXT  *Context,
-  IN  UINT32             File  OPTIONAL
+  IN  OC_PICKER_CONTEXT                 *Context,
+  IN  CONST CHAR8                       *BasePath     OPTIONAL,
+  IN  CONST CHAR8                       *BaseType     OPTIONAL
   );
 
 /**
@@ -1629,7 +1631,8 @@ OcRunFirmwareApplication (
   Play audio file for context.
 
   @param[in]  Context   Picker context.
-  @param[in]  File      File to play.
+  @param[in]  BasePath  File base path.
+  @param[in]  BaseType  Audio base type.
   @param[in]  Fallback  Try to fallback to beeps on failure.
 
   @retval EFI_SUCCESS on success or when unnecessary.
@@ -1638,7 +1641,8 @@ EFI_STATUS
 EFIAPI
 OcPlayAudioFile (
   IN  OC_PICKER_CONTEXT  *Context,
-  IN  UINT32             File,
+  IN  CONST CHAR8        *BasePath,
+  IN  CONST CHAR8        *BaseType,
   IN  BOOLEAN            Fallback
   );
 
@@ -1680,13 +1684,15 @@ OcPlayAudioEntry (
   Toggle VoiceOver support.
 
   @param[in]  Context   Picker context.
-  @param[in]  File      File to play after enabling VoiceOver.
+  @param[in]  BasePath  File base path of file to play after enabling VoiceOver.
+  @param[in]  BaseType  Audio base type of file to play after enabling VoiceOver.
 **/
 VOID
 EFIAPI
 OcToggleVoiceOver (
   IN  OC_PICKER_CONTEXT  *Context,
-  IN  UINT32             File  OPTIONAL
+  IN  CONST CHAR8        *BasePath     OPTIONAL,
+  IN  CONST CHAR8        *BaseType     OPTIONAL
   );
 
 /**

--- a/Include/Acidanthera/Protocol/OcAudio.h
+++ b/Include/Acidanthera/Protocol/OcAudio.h
@@ -19,7 +19,7 @@
 #include <Protocol/AppleVoiceOver.h>
 #include <Protocol/DevicePath.h>
 
-#define OC_AUDIO_PROTOCOL_REVISION  0x050000
+#define OC_AUDIO_PROTOCOL_REVISION  0x060000
 
 //
 // OC_AUDIO_PROTOCOL_GUID
@@ -32,86 +32,46 @@
 typedef struct OC_AUDIO_PROTOCOL_ OC_AUDIO_PROTOCOL;
 
 /**
+  Voice over base types.
+**/
+#define OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE      "AXEFIAudio"
+#define OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE  "OCEFIAudio"
+
+/**
   Custom OpenCore audio files.
 **/
-typedef enum {
-  OcVoiceOverAudioFileBase = 0x1000,
-
-  OcVoiceOverAudioFileIndexBase         = 0x1000,
-  OcVoiceOverAudioFile1                 = 0x1001,
-  OcVoiceOverAudioFile2                 = 0x1002,
-  OcVoiceOverAudioFile3                 = 0x1003,
-  OcVoiceOverAudioFile4                 = 0x1004,
-  OcVoiceOverAudioFile5                 = 0x1005,
-  OcVoiceOverAudioFile6                 = 0x1006,
-  OcVoiceOverAudioFile7                 = 0x1007,
-  OcVoiceOverAudioFile8                 = 0x1008,
-  OcVoiceOverAudioFile9                 = 0x1009,
-  OcVoiceOverAudioFileIndexAlphabetical = 0x100A,
-  OcVoiceOverAudioFileLetterA           = 0x100A,
-  OcVoiceOverAudioFileLetterB           = 0x100B,
-  OcVoiceOverAudioFileLetterC           = 0x100C,
-  OcVoiceOverAudioFileLetterD           = 0x100D,
-  OcVoiceOverAudioFileLetterE           = 0x100E,
-  OcVoiceOverAudioFileLetterF           = 0x100F,
-  OcVoiceOverAudioFileLetterG           = 0x1010,
-  OcVoiceOverAudioFileLetterH           = 0x1011,
-  OcVoiceOverAudioFileLetterI           = 0x1012,
-  OcVoiceOverAudioFileLetterJ           = 0x1013,
-  OcVoiceOverAudioFileLetterK           = 0x1014,
-  OcVoiceOverAudioFileLetterL           = 0x1015,
-  OcVoiceOverAudioFileLetterM           = 0x1016,
-  OcVoiceOverAudioFileLetterN           = 0x1017,
-  OcVoiceOverAudioFileLetterO           = 0x1018,
-  OcVoiceOverAudioFileLetterP           = 0x1019,
-  OcVoiceOverAudioFileLetterQ           = 0x101A,
-  OcVoiceOverAudioFileLetterR           = 0x101B,
-  OcVoiceOverAudioFileLetterS           = 0x101C,
-  OcVoiceOverAudioFileLetterT           = 0x101D,
-  OcVoiceOverAudioFileLetterU           = 0x101E,
-  OcVoiceOverAudioFileLetterV           = 0x101F,
-  OcVoiceOverAudioFileLetterW           = 0x1020,
-  OcVoiceOverAudioFileLetterX           = 0x1021,
-  OcVoiceOverAudioFileLetterY           = 0x1022,
-  OcVoiceOverAudioFileLetterZ           = 0x1023,
-  OcVoiceOverAudioFileIndexMax          = 0x1023,
-
-  OcVoiceOverAudioFileAbortTimeout        = 0x1030,
-  OcVoiceOverAudioFileChooseOS            = 0x1031,
-  OcVoiceOverAudioFileDefault             = 0x1032,
-  OcVoiceOverAudioFileDiskImage           = 0x1033,
-  OcVoiceOverAudioFileEnterPassword       = 0x1034,
-  OcVoiceOverAudioFileExecutionFailure    = 0x1035,
-  OcVoiceOverAudioFileExecutionSuccessful = 0x1036,
-  OcVoiceOverAudioFileExternal            = 0x1037,
-  OcVoiceOverAudioFileExternalOS          = 0x1038,
-  OcVoiceOverAudioFileExternalTool        = 0x1039,
-  OcVoiceOverAudioFileLoading             = 0x103A,
-  OcVoiceOverAudioFilemacOS               = 0x103B,
-  OcVoiceOverAudioFilemacOS_Recovery      = 0x103C,
-  OcVoiceOverAudioFilemacOS_TimeMachine   = 0x103D,
-  OcVoiceOverAudioFilemacOS_UpdateFw      = 0x103E,
-  OcVoiceOverAudioFileOtherOS             = 0x103F,
-  OcVoiceOverAudioFilePasswordAccepted    = 0x1040,
-  OcVoiceOverAudioFilePasswordIncorrect   = 0x1041,
-  OcVoiceOverAudioFilePasswordRetryLimit  = 0x1042,
-  OcVoiceOverAudioFileReloading           = 0x1043,
-  OcVoiceOverAudioFileResetNVRAM          = 0x1044,
-  OcVoiceOverAudioFileRestart             = 0x1045,
-  OcVoiceOverAudioFileSelected            = 0x1046,
-  OcVoiceOverAudioFileShowAuxiliary       = 0x1047,
-  OcVoiceOverAudioFileShutDown            = 0x1048,
-  OcVoiceOverAudioFileSIPIsDisabled       = 0x1049,
-  OcVoiceOverAudioFileSIPIsEnabled        = 0x104A,
-  OcVoiceOverAudioFileTimeout             = 0x104B,
-  OcVoiceOverAudioFileUEFI_Shell          = 0x104C,
-  OcVoiceOverAudioFileWelcome             = 0x104D,
-  OcVoiceOverAudioFileWindows             = 0x104E,
-
-  OcVoiceOverAudioFileMax = 0x104F,
-} OC_VOICE_OVER_AUDIO_FILE;
-
-STATIC_ASSERT (OcVoiceOverAudioFileIndexMax - OcVoiceOverAudioFileIndexBase == 9 + 26, "Invalid index count");
+#define  OC_VOICE_OVER_AUDIO_FILE_ABORT_TIMEOUT         "AbortTimeout"
+#define  OC_VOICE_OVER_AUDIO_FILE_CHOOSE_OS             "ChooseOS"
+#define  OC_VOICE_OVER_AUDIO_FILE_DEFAULT               "Default"
+#define  OC_VOICE_OVER_AUDIO_FILE_DISK_IMAGE            "DiskImage"
+#define  OC_VOICE_OVER_AUDIO_FILE_ENTER_PASSWORD        "EnterPassword"
+#define  OC_VOICE_OVER_AUDIO_FILE_EXECUTION_FAILURE     "ExecutionFailure"
+#define  OC_VOICE_OVER_AUDIO_FILE_EXECUTION_SUCCESSFUL  "ExecutionSuccessful"
+#define  OC_VOICE_OVER_AUDIO_FILE_EXTERNAL              "External"
+#define  OC_VOICE_OVER_AUDIO_FILE_EXTERNAL_OS           "ExternalOS"
+#define  OC_VOICE_OVER_AUDIO_FILE_EXTERNAL_TOOL         "ExternalTool"
+#define  OC_VOICE_OVER_AUDIO_FILE_LOADING               "Loading"
+#define  OC_VOICE_OVER_AUDIO_FILE_MAC_OS                "macOS"
+#define  OC_VOICE_OVER_AUDIO_FILE_MAC_OS_RECOVERY       "macOS_Recovery"
+#define  OC_VOICE_OVER_AUDIO_FILE_MAC_OS_TIME_MACHINE   "macOS_TimeMachine"
+#define  OC_VOICE_OVER_AUDIO_FILE_MAC_OS_UPDATE_FW      "macOS_UpdateFw"
+#define  OC_VOICE_OVER_AUDIO_FILE_OTHER_OS              "OtherOS"
+#define  OC_VOICE_OVER_AUDIO_FILE_PASSWORD_ACCEPTED     "PasswordAccepted"
+#define  OC_VOICE_OVER_AUDIO_FILE_PASSWORD_INCORRECT    "PasswordIncorrect"
+#define  OC_VOICE_OVER_AUDIO_FILE_PASSWORD_RETRY_LIMIT  "PasswordRetryLimit"
+#define  OC_VOICE_OVER_AUDIO_FILE_RELOADING             "Reloading"
+#define  OC_VOICE_OVER_AUDIO_FILE_RESET_NVRAM           "ResetNVRAM"
+#define  OC_VOICE_OVER_AUDIO_FILE_RESTART               "Restart"
+#define  OC_VOICE_OVER_AUDIO_FILE_SELECTED              "Selected"
+#define  OC_VOICE_OVER_AUDIO_FILE_SHOW_AUXILIARY        "ShowAuxiliary"
+#define  OC_VOICE_OVER_AUDIO_FILE_SHUT_DOWN             "ShutDown"
+#define  OC_VOICE_OVER_AUDIO_FILE_SIP_IS_DISABLED       "SIPIsDisabled"
+#define  OC_VOICE_OVER_AUDIO_FILE_SIP_IS_ENABLED        "SIPIsEnabled"
+#define  OC_VOICE_OVER_AUDIO_FILE_TIMEOUT               "Timeout"
+#define  OC_VOICE_OVER_AUDIO_FILE_UEFI_SHELL            "UEFI_Shell"
+#define  OC_VOICE_OVER_AUDIO_FILE_VOICE_OVER_BOOT       "VoiceOver_Boot"
+#define  OC_VOICE_OVER_AUDIO_FILE_WELCOME               "Welcome"
+#define  OC_VOICE_OVER_AUDIO_FILE_WINDOWS               "Windows"
 
 /**
   Connect to Audio I/O.
@@ -154,7 +114,9 @@ EFI_STATUS
   Retrieve file contents callback.
 
   @param[in,out]  Context      Externally specified context.
-  @param[in]      File         File identifier, see APPLE_VOICE_OVER_AUDIO_FILE.
+  @param[in]      BasePath     File base path.
+  @param[in]      BaseType     Audio base type.
+  @param[in]      Localised    Is file localised?
   @param[in]      LanguageCode Language code for the file.
   @param[out]     Buffer       Pointer to buffer.
   @param[out]     BufferSize   Pointer to buffer size.
@@ -168,7 +130,9 @@ typedef
 EFI_STATUS
 (EFIAPI *OC_AUDIO_PROVIDER_ACQUIRE)(
   IN  VOID                            *Context,
-  IN  UINT32                          File,
+  IN  CONST CHAR8                     *BasePath,
+  IN  CONST CHAR8                     *BaseType,
+  IN  BOOLEAN                         Localised,
   IN  APPLE_VOICE_OVER_LANGUAGE_CODE  LanguageCode,
   OUT UINT8                           **Buffer,
   OUT UINT32                          *BufferSize,
@@ -233,7 +197,9 @@ EFI_STATUS
   Play file.
 
   @param[in,out] This         Audio protocol instance.
-  @param[in]     File         File to play.
+  @param[in]     BasePath     File base path.
+  @param[in]     BaseType     Audio base type.
+  @param[in]     Localised    Is file localised?
   @param[in]     Gain         The amplifier gain (or attenuation if negative) in dB to use, relative to 0 dB level.
   @param[in]     UseGain      If TRUE use provided volume level, otherwise use stored global volume level.
   @param[in]     Wait         Wait for completion of the previous track.
@@ -243,11 +209,13 @@ EFI_STATUS
 typedef
 EFI_STATUS
 (EFIAPI *OC_AUDIO_PLAY_FILE)(
-  IN OUT OC_AUDIO_PROTOCOL          *This,
-  IN     UINT32                     File,
-  IN     INT8                       Gain  OPTIONAL,
-  IN     BOOLEAN                    UseGain,
-  IN     BOOLEAN                    Wait
+  IN OUT OC_AUDIO_PROTOCOL              *This,
+  IN     CONST CHAR8                    *BasePath,
+  IN     CONST CHAR8                    *BaseType,
+  IN     BOOLEAN                        Localised,
+  IN     INT8                           Gain  OPTIONAL,
+  IN     BOOLEAN                        UseGain,
+  IN     BOOLEAN                        Wait
   );
 
 /**

--- a/Include/Apple/Protocol/AppleVoiceOver.h
+++ b/Include/Apple/Protocol/AppleVoiceOver.h
@@ -41,6 +41,7 @@ typedef struct APPLE_VOICE_OVER_AUDIO_PROTOCOL_ APPLE_VOICE_OVER_AUDIO_PROTOCOL;
   Files marked with * are only present on BridgeOS.
 **/
 typedef enum {
+  AppleVoiceOverAudioFileIndexLocalisedMin           = 0x01, ///< First valid localised file
   AppleVoiceOverAudioFileVoiceOverOn                 = 0x01, ///< VoiceOverOn
   AppleVoiceOverAudioFileVoiceOverOff                = 0x02, ///< VoiceOverOff
   AppleVoiceOverAudioFileUsername                    = 0x03, ///< Username
@@ -48,12 +49,28 @@ typedef enum {
   AppleVoiceOverAudioFileUsernameOrPasswordIncorrect = 0x05, ///< UsernameOrPasswordIncorrect
   AppleVoiceOverAudioFileAccountLockedTryLater       = 0x06, ///< AccountLockedTryLater (*)
   AppleVoiceOverAudioFileAccountLocked               = 0x07, ///< AccountLocked (*)
+  AppleVoiceOverAudioFileIndexLocalisedMax           = 0x08, ///< After last valid localised file
+  AppleVoiceOverAudioFileIndexNonLocalisedMin        = 0x3B, ///< First valid non-localised file
   AppleVoiceOverAudioFileVoiceOverBoot               = 0x3B, ///< VoiceOver_Boot (*)
   AppleVoiceOverAudioFileVoiceOverBoot2              = 0x3C, ///< VoiceOver_Boot (*)
   AppleVoiceOverAudioFileClick                       = 0x3D, ///< Click (*)
   AppleVoiceOverAudioFileBeep                        = 0x3E, ///< Beep
-  AppleVoiceOverAudioFileMax                         = 0x3F,
+  AppleVoiceOverAudioFileIndexNonLocalisedMax        = 0x3F, ///< After last valid non-localised file
 } APPLE_VOICE_OVER_AUDIO_FILE;
+
+/**
+  Corresponding file base names.
+**/
+#define APPLE_VOICE_OVER_AUDIO_FILE_VOICE_OVER_ON                   "VoiceOverOn"
+#define APPLE_VOICE_OVER_AUDIO_FILE_VOICE_OVER_OFF                  "VoiceOverOff"
+#define APPLE_VOICE_OVER_AUDIO_FILE_USERNAME                        "Username"
+#define APPLE_VOICE_OVER_AUDIO_FILE_PASSWORD                        "Password"
+#define APPLE_VOICE_OVER_AUDIO_FILE_USERNAME_OR_PASSWORD_INCORRECT  "UsernameOrPasswordIncorrect"
+#define APPLE_VOICE_OVER_AUDIO_FILE_ACCOUNT_LOCKED_TRY_LATER        "AccountLockedTryLater"
+#define APPLE_VOICE_OVER_AUDIO_FILE_ACCOUNT_LOCKED                  "AccountLocked"
+#define APPLE_VOICE_OVER_AUDIO_FILE_VOICE_OVER_BOOT                 "VoiceOver_Boot"
+#define APPLE_VOICE_OVER_AUDIO_FILE_CLICK                           "Click"
+#define APPLE_VOICE_OVER_AUDIO_FILE_BEEP                            "Beep"
 
 /**
   VoiceOver language codes.

--- a/Library/OcAudioLib/OcAudio.c
+++ b/Library/OcAudioLib/OcAudio.c
@@ -353,7 +353,9 @@ EFI_STATUS
 EFIAPI
 InternalOcAudioPlayFile (
   IN OUT OC_AUDIO_PROTOCOL  *This,
-  IN     UINT32             File,
+  IN     CONST CHAR8        *BasePath,
+  IN     CONST CHAR8        *BaseType,
+  IN     BOOLEAN            Localised,
   IN     INT8               Gain  OPTIONAL,
   IN     BOOLEAN            UseGain,
   IN     BOOLEAN            Wait
@@ -377,7 +379,9 @@ InternalOcAudioPlayFile (
 
   Status = Private->ProviderAcquire (
                       Private->ProviderContext,
-                      File,
+                      BasePath,
+                      BaseType,
+                      Localised,
                       Private->Language,
                       &RawBuffer,
                       &RawBufferSize,
@@ -387,14 +391,15 @@ InternalOcAudioPlayFile (
                       );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "OCAU: PlayFile has no file %d for lang %d - %r\n", File, Private->Language, Status));
+    DEBUG ((DEBUG_INFO, "OCAU: PlayFile has no file %a for type %a lang %u - %r\n", BasePath, BaseType, Private->Language, Status));
     return EFI_NOT_FOUND;
   }
 
   DEBUG ((
     DEBUG_INFO,
-    "OCAU: File %d for lang %d is %d %d %d (%u) - %r\n",
-    File,
+    "OCAU: File %a for type %a lang %u is %d %d %d (%u) - %r\n",
+    BasePath,
+    BaseType,
     Private->Language,
     Frequency,
     Bits,
@@ -404,7 +409,7 @@ InternalOcAudioPlayFile (
     ));
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "OCAU: PlayFile has invalid file %d for lang %d - %r\n", File, Private->Language, Status));
+    DEBUG ((DEBUG_INFO, "OCAU: PlayFile has invalid file %a for type %a lang %u - %r\n", BasePath, BaseType, Private->Language, Status));
     if (Private->ProviderRelease != NULL) {
       Private->ProviderRelease (Private->ProviderContext, RawBuffer);
     }

--- a/Library/OcAudioLib/OcAudioInternal.h
+++ b/Library/OcAudioLib/OcAudioInternal.h
@@ -94,7 +94,9 @@ EFI_STATUS
 EFIAPI
 InternalOcAudioPlayFile (
   IN OUT OC_AUDIO_PROTOCOL  *This,
-  IN     UINT32             File,
+  IN     CONST CHAR8        *BasePath,
+  IN     CONST CHAR8        *BaseType,
+  IN     BOOLEAN            Localised,
   IN     INT8               Gain  OPTIONAL,
   IN     BOOLEAN            UseGain,
   IN     BOOLEAN            Wait

--- a/Library/OcAudioLib/OcAudioVoiceOver.c
+++ b/Library/OcAudioLib/OcAudioVoiceOver.c
@@ -27,6 +27,65 @@
 
 #include "OcAudioInternal.h"
 
+//
+// Convert from Apple file id to file base name and type.
+//
+STATIC
+CONST
+APPLE_VOICE_OVER_FILE_MAP
+  mAppleVoiceOverLocalisedAudioFiles[AppleVoiceOverAudioFileIndexLocalisedMax - AppleVoiceOverAudioFileIndexLocalisedMin] = {
+  [AppleVoiceOverAudioFileVoiceOverOn - AppleVoiceOverAudioFileIndexLocalisedMin] =                 {
+    APPLE_VOICE_OVER_AUDIO_FILE_VOICE_OVER_ON,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  },
+  [AppleVoiceOverAudioFileVoiceOverOff - AppleVoiceOverAudioFileIndexLocalisedMin] =                {
+    APPLE_VOICE_OVER_AUDIO_FILE_VOICE_OVER_OFF,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  },
+  [AppleVoiceOverAudioFileUsername - AppleVoiceOverAudioFileIndexLocalisedMin] =                    {
+    APPLE_VOICE_OVER_AUDIO_FILE_USERNAME,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  },
+  [AppleVoiceOverAudioFilePassword - AppleVoiceOverAudioFileIndexLocalisedMin] =                    {
+    APPLE_VOICE_OVER_AUDIO_FILE_PASSWORD,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  },
+  [AppleVoiceOverAudioFileUsernameOrPasswordIncorrect - AppleVoiceOverAudioFileIndexLocalisedMin] = {
+    APPLE_VOICE_OVER_AUDIO_FILE_USERNAME_OR_PASSWORD_INCORRECT,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  },
+  [AppleVoiceOverAudioFileAccountLockedTryLater - AppleVoiceOverAudioFileIndexLocalisedMin] =       {
+    APPLE_VOICE_OVER_AUDIO_FILE_ACCOUNT_LOCKED_TRY_LATER,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  },
+  [AppleVoiceOverAudioFileAccountLocked - AppleVoiceOverAudioFileIndexLocalisedMin] =               {
+    APPLE_VOICE_OVER_AUDIO_FILE_ACCOUNT_LOCKED,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  }
+};
+
+STATIC
+CONST
+APPLE_VOICE_OVER_FILE_MAP
+  mAppleVoiceOverNonLocalisedAudioFiles[AppleVoiceOverAudioFileIndexNonLocalisedMax - AppleVoiceOverAudioFileIndexNonLocalisedMin] = {
+  [AppleVoiceOverAudioFileVoiceOverBoot - AppleVoiceOverAudioFileIndexNonLocalisedMin] =  {
+    OC_VOICE_OVER_AUDIO_FILE_VOICE_OVER_BOOT,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE
+  },
+  [AppleVoiceOverAudioFileVoiceOverBoot2 - AppleVoiceOverAudioFileIndexNonLocalisedMin] = {
+    APPLE_VOICE_OVER_AUDIO_FILE_VOICE_OVER_BOOT,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  },
+  [AppleVoiceOverAudioFileClick - AppleVoiceOverAudioFileIndexNonLocalisedMin] =          {
+    APPLE_VOICE_OVER_AUDIO_FILE_CLICK,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  },
+  [AppleVoiceOverAudioFileBeep - AppleVoiceOverAudioFileIndexNonLocalisedMin] =           {
+    APPLE_VOICE_OVER_AUDIO_FILE_BEEP,
+    OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE
+  }
+};
+
 STATIC CONST CHAR8  *mLanguagePairing[] = {
   NULL,
   "ar",
@@ -128,10 +187,31 @@ InternalOcAudioVoiceOverPlay (
   IN     UINT8                            File
   )
 {
-  OC_AUDIO_PROTOCOL_PRIVATE  *Private;
+  OC_AUDIO_PROTOCOL_PRIVATE        *Private;
+  CONST APPLE_VOICE_OVER_FILE_MAP  *Map;
+  BOOLEAN                          Localised;
+
+  Localised = FALSE;
+  Map       = NULL;
+
+  if (  (File >= AppleVoiceOverAudioFileIndexLocalisedMin)
+     && (File < AppleVoiceOverAudioFileIndexLocalisedMax))
+  {
+    Localised = TRUE;
+    Map       = &mAppleVoiceOverLocalisedAudioFiles[File - AppleVoiceOverAudioFileIndexLocalisedMin];
+  } else if (  (File >= AppleVoiceOverAudioFileIndexNonLocalisedMin)
+            && (File < AppleVoiceOverAudioFileIndexNonLocalisedMax))
+  {
+    Map = &mAppleVoiceOverNonLocalisedAudioFiles[File - AppleVoiceOverAudioFileIndexNonLocalisedMin];
+  }
+
+  if ((Map == NULL) || (Map->BasePath == NULL) || (Map->BaseType == NULL)) {
+    DEBUG ((DEBUG_INFO, "OCAU: Unsupported Apple voice over file index %u\n", File));
+    return EFI_UNSUPPORTED;
+  }
 
   Private = OC_AUDIO_PROTOCOL_PRIVATE_FROM_VOICE_OVER (This);
-  return Private->OcAudio.PlayFile (&Private->OcAudio, File, 0, FALSE, TRUE);
+  return Private->OcAudio.PlayFile (&Private->OcAudio, Map->BasePath, Map->BaseType, Localised, 0, FALSE, TRUE);
 }
 
 EFI_STATUS

--- a/Library/OcBootManagementLib/BuiltinPicker.c
+++ b/Library/OcBootManagementLib/BuiltinPicker.c
@@ -277,7 +277,7 @@ UpdateTabContext (
 
     if (IsEntering) {
       if (ChosenEntry >= 0) {
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileSelected, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_SELECTED, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
         OcPlayAudioEntry (BootContext->PickerContext, BootEntries[ChosenEntry]);
       } else {
         //
@@ -305,11 +305,11 @@ UpdateTabContext (
 
     if (IsEntering) {
       if (TabFocus == TAB_SHUTDOWN) {
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileSelected, FALSE);
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileShutDown, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_SELECTED, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_SHUT_DOWN, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
       } else {
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileSelected, FALSE);
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileRestart, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_SELECTED, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_RESTART, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
       }
     }
   }
@@ -588,11 +588,11 @@ OcShowSimpleBootMenu (
     }
 
     if (!PlayedOnce && BootContext->PickerContext->PickerAudioAssist) {
-      OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileChooseOS, FALSE);
+      OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_CHOOSE_OS, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
       for (Index = 0; Index < Count; ++Index) {
         OcPlayAudioEntry (BootContext->PickerContext, BootEntries[Index]);
         if ((TimeOutSeconds > 0) && (BootContext->DefaultEntry->EntryIndex - 1 == Index)) {
-          OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileDefault, FALSE);
+          OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_DEFAULT, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
         }
       }
 
@@ -691,7 +691,7 @@ OcShowSimpleBootMenu (
         if (PickerKeyInfo.OcKeyCode == OC_INPUT_TYPING_CONFIRM) {
           gST->ConOut->OutputString (gST->ConOut, OC_MENU_RESTART);
           gST->ConOut->OutputString (gST->ConOut, L"\r\n");
-          OcPlayAudioFile (BootContext->PickerContext, AppleVoiceOverAudioFileBeep, FALSE);
+          OcPlayAudioFile (BootContext->PickerContext, APPLE_VOICE_OVER_AUDIO_FILE_BEEP, OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE, FALSE);
           ResetWarm ();
           return EFI_SUCCESS;
         }
@@ -699,7 +699,7 @@ OcShowSimpleBootMenu (
         if (PickerKeyInfo.OcKeyCode == OC_INPUT_TYPING_CONFIRM) {
           gST->ConOut->OutputString (gST->ConOut, OC_MENU_SHUTDOWN);
           gST->ConOut->OutputString (gST->ConOut, L"\r\n");
-          OcPlayAudioFile (BootContext->PickerContext, AppleVoiceOverAudioFileBeep, FALSE);
+          OcPlayAudioFile (BootContext->PickerContext, APPLE_VOICE_OVER_AUDIO_FILE_BEEP, OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE, FALSE);
           ResetShutdown ();
           return EFI_SUCCESS;
         }
@@ -734,7 +734,7 @@ OcShowSimpleBootMenu (
  #endif
 
       if (PlayChosen && (PickerKeyInfo.OcKeyCode == OC_INPUT_TIMEOUT)) {
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileSelected, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_SELECTED, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
         OcPlayAudioEntry (BootContext->PickerContext, BootEntries[ChosenEntry]);
         PlayChosen = FALSE;
         continue;
@@ -742,7 +742,7 @@ OcShowSimpleBootMenu (
         *ChosenBootEntry = BootEntries[BootContext->DefaultEntry->EntryIndex - 1];
         gST->ConOut->OutputString (gST->ConOut, OC_MENU_TIMEOUT);
         gST->ConOut->OutputString (gST->ConOut, L"\r\n");
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileTimeout, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_TIMEOUT, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
         return EFI_SUCCESS;
       } else if (PickerKeyInfo.OcKeyCode == OC_INPUT_CONTINUE) {
         if (ChosenEntry >= 0) {
@@ -758,12 +758,12 @@ OcShowSimpleBootMenu (
       } else if (PickerKeyInfo.OcKeyCode == OC_INPUT_ABORTED) {
         gST->ConOut->OutputString (gST->ConOut, OC_MENU_RELOADING);
         gST->ConOut->OutputString (gST->ConOut, L"\r\n");
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileReloading, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_RELOADING, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
         return EFI_ABORTED;
       } else if ((PickerKeyInfo.OcKeyCode == OC_INPUT_MORE) && BootContext->PickerContext->HideAuxiliary) {
         gST->ConOut->OutputString (gST->ConOut, OC_MENU_SHOW_AUXILIARY);
         gST->ConOut->OutputString (gST->ConOut, L"\r\n");
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileShowAuxiliary, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_SHOW_AUXILIARY, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
         BootContext->PickerContext->HideAuxiliary = FALSE;
         return EFI_ABORTED;
       } else if (PickerKeyInfo.OcKeyCode == OC_INPUT_UP) {
@@ -813,7 +813,7 @@ OcShowSimpleBootMenu (
 
         break;
       } else if (PickerKeyInfo.OcKeyCode == OC_INPUT_VOICE_OVER) {
-        OcToggleVoiceOver (BootContext->PickerContext, 0);
+        OcToggleVoiceOver (BootContext->PickerContext, NULL, NULL);
         break;
       } else if ((PickerKeyInfo.OcKeyCode != OC_INPUT_NO_ACTION) && (PickerKeyInfo.OcKeyCode >= 0) && ((UINTN)PickerKeyInfo.OcKeyCode < Count)) {
         *ChosenBootEntry               = BootEntries[PickerKeyInfo.OcKeyCode];
@@ -825,7 +825,7 @@ OcShowSimpleBootMenu (
       }
 
       if ((ModifiersChanged || (PickerKeyInfo.OcKeyCode != OC_INPUT_NO_ACTION)) && (TimeOutSeconds > 0)) {
-        OcPlayAudioFile (BootContext->PickerContext, OcVoiceOverAudioFileAbortTimeout, FALSE);
+        OcPlayAudioFile (BootContext->PickerContext, OC_VOICE_OVER_AUDIO_FILE_ABORT_TIMEOUT, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
         TimeOutSeconds = 0;
         break;
       }
@@ -866,7 +866,7 @@ OcShowSimplePasswordRequest (
     Context->HotKeyContext->FlushTypingBuffer (Context);
 
     gST->ConOut->OutputString (gST->ConOut, OC_MENU_PASSWORD_REQUEST);
-    OcPlayAudioFile (Context, OcVoiceOverAudioFileEnterPassword, TRUE);
+    OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_ENTER_PASSWORD, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, TRUE);
 
     while (TRUE) {
       Context->HotKeyContext->WaitForKeyInfo (
@@ -877,7 +877,7 @@ OcShowSimplePasswordRequest (
                                 );
 
       if (PickerKeyInfo.OcKeyCode == OC_INPUT_VOICE_OVER) {
-        OcToggleVoiceOver (Context, OcVoiceOverAudioFileEnterPassword);
+        OcToggleVoiceOver (Context, OC_VOICE_OVER_AUDIO_FILE_ENTER_PASSWORD, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE);
         continue;
       }
 
@@ -911,7 +911,7 @@ OcShowSimplePasswordRequest (
                          );
         }
 
-        OcPlayAudioFile (Context, AppleVoiceOverAudioFileBeep, TRUE);
+        OcPlayAudioFile (Context, APPLE_VOICE_OVER_AUDIO_FILE_BEEP, OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE, TRUE);
         continue;
       }
 
@@ -921,7 +921,7 @@ OcShowSimplePasswordRequest (
       {
         gST->ConOut->OutputString (gST->ConOut, L"*");
         Password[PwIndex] = (UINT8)PickerKeyInfo.UnicodeChar;
-        OcPlayAudioFile (Context, AppleVoiceOverAudioFileBeep, TRUE);
+        OcPlayAudioFile (Context, APPLE_VOICE_OVER_AUDIO_FILE_BEEP, OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE, TRUE);
         ++PwIndex;
         continue;
       }
@@ -984,15 +984,15 @@ OcShowSimplePasswordRequest (
                    );
 
     if (Result) {
-      OcPlayAudioFile (Context, OcVoiceOverAudioFilePasswordAccepted, TRUE);
+      OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_PASSWORD_ACCEPTED, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, TRUE);
       return EFI_SUCCESS;
     }
 
-    OcPlayAudioFile (Context, OcVoiceOverAudioFilePasswordIncorrect, TRUE);
+    OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_PASSWORD_INCORRECT, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, TRUE);
   }
 
   gST->ConOut->OutputString (gST->ConOut, OC_MENU_PASSWORD_RETRY_LIMIT L"\r\n");
-  OcPlayAudioFile (Context, OcVoiceOverAudioFilePasswordRetryLimit, TRUE);
+  OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_PASSWORD_RETRY_LIMIT, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, TRUE);
   DEBUG ((DEBUG_WARN, "OCB: User failed to verify password %d times running\n", OC_PASSWORD_MAX_RETRIES));
 
   gBS->Stall (SECONDS_TO_MICROSECONDS (5));

--- a/Library/OcBootManagementLib/OcBootManagementLib.c
+++ b/Library/OcBootManagementLib/OcBootManagementLib.c
@@ -265,7 +265,7 @@ OcRunBootPicker (
         ));
 
       if (!SaidWelcome) {
-        OcPlayAudioFile (Context, OcVoiceOverAudioFileWelcome, FALSE);
+        OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_WELCOME, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
         SaidWelcome = TRUE;
       }
 
@@ -322,8 +322,8 @@ OcRunBootPicker (
 
         if (Chosen->SetDefault) {
           if (Context->PickerCommand == OcPickerShowPicker) {
-            OcPlayAudioFile (Context, OcVoiceOverAudioFileSelected, FALSE);
-            OcPlayAudioFile (Context, OcVoiceOverAudioFileDefault, FALSE);
+            OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_SELECTED, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
+            OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_DEFAULT, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
             OcPlayAudioEntry (Context, Chosen);
           }
 
@@ -343,7 +343,7 @@ OcRunBootPicker (
         //
         // Voice chosen information.
         //
-        OcPlayAudioFile (Context, OcVoiceOverAudioFileLoading, FALSE);
+        OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_LOADING, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
         Status = OcPlayAudioEntry (Context, Chosen);
         if (EFI_ERROR (Status)) {
           OcPlayAudioBeep (
@@ -365,14 +365,14 @@ OcRunBootPicker (
       // Do not wait on successful return code.
       //
       if (EFI_ERROR (Status)) {
-        OcPlayAudioFile (Context, OcVoiceOverAudioFileExecutionFailure, TRUE);
+        OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_EXECUTION_FAILURE, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, TRUE);
         gBS->Stall (SECONDS_TO_MICROSECONDS (3));
         //
         // Show picker on first failure.
         //
         Context->PickerCommand = OcPickerShowPicker;
       } else {
-        OcPlayAudioFile (Context, OcVoiceOverAudioFileExecutionSuccessful, FALSE);
+        OcPlayAudioFile (Context, OC_VOICE_OVER_AUDIO_FILE_EXECUTION_SUCCESSFUL, OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE, FALSE);
       }
 
       //

--- a/Platform/OpenCanopy/OcBootstrap.c
+++ b/Platform/OpenCanopy/OcBootstrap.c
@@ -165,7 +165,8 @@ OcShowMenuByOc (
   if (BootContext->PickerContext->PickerAudioAssist) {
     BootContext->PickerContext->PlayAudioFile (
                                   BootContext->PickerContext,
-                                  OcVoiceOverAudioFileChooseOS,
+                                  OC_VOICE_OVER_AUDIO_FILE_CHOOSE_OS,
+                                  OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                   FALSE
                                   );
     for (Index = 0; Index < BootContext->BootEntryCount; ++Index) {
@@ -176,7 +177,8 @@ OcShowMenuByOc (
       if ((BootContext->PickerContext->TimeoutSeconds > 0) && (BootContext->DefaultEntry->EntryIndex - 1 == Index)) {
         BootContext->PickerContext->PlayAudioFile (
                                       BootContext->PickerContext,
-                                      OcVoiceOverAudioFileDefault,
+                                      OC_VOICE_OVER_AUDIO_FILE_DEFAULT,
+                                      OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                       FALSE
                                       );
       }

--- a/Platform/OpenCanopy/OpenCanopy.c
+++ b/Platform/OpenCanopy/OpenCanopy.c
@@ -1162,7 +1162,8 @@ GuiDrawLoop (
           {
             DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                       DrawContext->GuiContext->PickerContext,
-                                                      OcVoiceOverAudioFileAbortTimeout,
+                                                      OC_VOICE_OVER_AUDIO_FILE_ABORT_TIMEOUT,
+                                                      OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                       FALSE
                                                       );
           }
@@ -1217,7 +1218,8 @@ GuiDrawLoop (
           {
             DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                       DrawContext->GuiContext->PickerContext,
-                                                      OcVoiceOverAudioFileAbortTimeout,
+                                                      OC_VOICE_OVER_AUDIO_FILE_ABORT_TIMEOUT,
+                                                      OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                       FALSE
                                                       );
           }
@@ -1264,7 +1266,8 @@ GuiDrawLoop (
           {
             DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                       DrawContext->GuiContext->PickerContext,
-                                                      OcVoiceOverAudioFileSelected,
+                                                      OC_VOICE_OVER_AUDIO_FILE_SELECTED,
+                                                      OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                       FALSE
                                                       );
             DrawContext->GuiContext->PickerContext->PlayAudioEntry (
@@ -1278,7 +1281,8 @@ GuiDrawLoop (
           {
             DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                       DrawContext->GuiContext->PickerContext,
-                                                      OcVoiceOverAudioFileEnterPassword,
+                                                      OC_VOICE_OVER_AUDIO_FILE_ENTER_PASSWORD,
+                                                      OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                       TRUE
                                                       );
             break;
@@ -1288,12 +1292,14 @@ GuiDrawLoop (
           {
             DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                       DrawContext->GuiContext->PickerContext,
-                                                      OcVoiceOverAudioFileSelected,
+                                                      OC_VOICE_OVER_AUDIO_FILE_SELECTED,
+                                                      OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                       FALSE
                                                       );
             DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                       DrawContext->GuiContext->PickerContext,
-                                                      OcVoiceOverAudioFileShutDown,
+                                                      OC_VOICE_OVER_AUDIO_FILE_SHUT_DOWN,
+                                                      OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                       TRUE
                                                       );
             break;
@@ -1303,12 +1309,14 @@ GuiDrawLoop (
           {
             DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                       DrawContext->GuiContext->PickerContext,
-                                                      OcVoiceOverAudioFileSelected,
+                                                      OC_VOICE_OVER_AUDIO_FILE_SELECTED,
+                                                      OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                       FALSE
                                                       );
             DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                       DrawContext->GuiContext->PickerContext,
-                                                      OcVoiceOverAudioFileRestart,
+                                                      OC_VOICE_OVER_AUDIO_FILE_RESTART,
+                                                      OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                       TRUE
                                                       );
             break;
@@ -1337,7 +1345,8 @@ GuiDrawLoop (
       if (DrawContext->GuiContext->PickerContext->PickerAudioAssist) {
         DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                   DrawContext->GuiContext->PickerContext,
-                                                  OcVoiceOverAudioFileTimeout,
+                                                  OC_VOICE_OVER_AUDIO_FILE_TIMEOUT,
+                                                  OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                   FALSE
                                                   );
       }

--- a/Platform/OpenCanopy/Views/BootPicker.c
+++ b/Platform/OpenCanopy/Views/BootPicker.c
@@ -465,7 +465,8 @@ InternalBootPickerKeyEvent (
       GuiContext->Refresh       = TRUE;
       DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                                 DrawContext->GuiContext->PickerContext,
-                                                OcVoiceOverAudioFileShowAuxiliary,
+                                                OC_VOICE_OVER_AUDIO_FILE_SHOW_AUXILIARY,
+                                                OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                                 FALSE
                                                 );
     }
@@ -473,7 +474,8 @@ InternalBootPickerKeyEvent (
     GuiContext->Refresh = TRUE;
     DrawContext->GuiContext->PickerContext->PlayAudioFile (
                                               DrawContext->GuiContext->PickerContext,
-                                              OcVoiceOverAudioFileReloading,
+                                              OC_VOICE_OVER_AUDIO_FILE_RELOADING,
+                                              OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                               FALSE
                                               );
   }
@@ -1099,7 +1101,8 @@ InternalBootPickerViewKeyEvent (
   if (KeyEvent->OcKeyCode == OC_INPUT_VOICE_OVER) {
     DrawContext->GuiContext->PickerContext->ToggleVoiceOver (
                                               DrawContext->GuiContext->PickerContext,
-                                              0
+                                              NULL,
+                                              NULL
                                               );
     return;
   }

--- a/Platform/OpenCanopy/Views/Common.c
+++ b/Platform/OpenCanopy/Views/Common.c
@@ -423,7 +423,8 @@ InternalCommonShutDownKeyEvent (
     if (Context->PickerContext->PickerAudioAssist) {
       Context->PickerContext->PlayAudioFile (
                                 Context->PickerContext,
-                                AppleVoiceOverAudioFileBeep,
+                                APPLE_VOICE_OVER_AUDIO_FILE_BEEP,
+                                OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE,
                                 TRUE
                                 );
     }
@@ -489,7 +490,8 @@ InternalCommonRestartKeyEvent (
     if (Context->PickerContext->PickerAudioAssist) {
       Context->PickerContext->PlayAudioFile (
                                 Context->PickerContext,
-                                AppleVoiceOverAudioFileBeep,
+                                APPLE_VOICE_OVER_AUDIO_FILE_BEEP,
+                                OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE,
                                 TRUE
                                 );
     }

--- a/Platform/OpenCanopy/Views/Password.c
+++ b/Platform/OpenCanopy/Views/Password.c
@@ -211,7 +211,8 @@ InternalConfirmPassword (
     if (Context->PickerContext->PickerAudioAssist) {
       Context->PickerContext->PlayAudioFile (
                                 Context->PickerContext,
-                                OcVoiceOverAudioFilePasswordAccepted,
+                                OC_VOICE_OVER_AUDIO_FILE_PASSWORD_ACCEPTED,
+                                OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                 TRUE
                                 );
     }
@@ -223,7 +224,8 @@ InternalConfirmPassword (
   if (Context->PickerContext->PickerAudioAssist) {
     Context->PickerContext->PlayAudioFile (
                               Context->PickerContext,
-                              OcVoiceOverAudioFilePasswordIncorrect,
+                              OC_VOICE_OVER_AUDIO_FILE_PASSWORD_INCORRECT,
+                              OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                               TRUE
                               );
   }
@@ -233,7 +235,8 @@ InternalConfirmPassword (
     if (Context->PickerContext->PickerAudioAssist) {
       Context->PickerContext->PlayAudioFile (
                                 Context->PickerContext,
-                                OcVoiceOverAudioFilePasswordRetryLimit,
+                                OC_VOICE_OVER_AUDIO_FILE_PASSWORD_RETRY_LIMIT,
+                                OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                 TRUE
                                 );
       DEBUG ((DEBUG_WARN, "OCB: User failed to verify password %d times running\n", OC_PASSWORD_MAX_RETRIES));
@@ -305,7 +308,8 @@ InternalPasswordBoxKeyEvent (
     if (Context->PickerContext->PickerAudioAssist) {
       Context->PickerContext->PlayAudioFile (
                                 Context->PickerContext,
-                                AppleVoiceOverAudioFileBeep,
+                                APPLE_VOICE_OVER_AUDIO_FILE_BEEP,
+                                OC_VOICE_OVER_AUDIO_BASE_TYPE_APPLE,
                                 TRUE
                                 );
     }
@@ -381,7 +385,8 @@ InternalPasswordViewKeyEvent (
   if (KeyEvent->OcKeyCode == OC_INPUT_VOICE_OVER) {
     DrawContext->GuiContext->PickerContext->ToggleVoiceOver (
                                               DrawContext->GuiContext->PickerContext,
-                                              OcVoiceOverAudioFileEnterPassword
+                                              OC_VOICE_OVER_AUDIO_FILE_ENTER_PASSWORD,
+                                              OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE
                                               );
     return;
   }
@@ -825,7 +830,8 @@ PasswordViewInitialize (
   if (GuiContext->PickerContext->PickerAudioAssist) {
     GuiContext->PickerContext->PlayAudioFile (
                                  GuiContext->PickerContext,
-                                 OcVoiceOverAudioFileEnterPassword,
+                                 OC_VOICE_OVER_AUDIO_FILE_ENTER_PASSWORD,
+                                 OC_VOICE_OVER_AUDIO_BASE_TYPE_OPEN_CORE,
                                  TRUE
                                  );
   }


### PR DESCRIPTION
I've had a chance to do a bit of work on https://github.com/acidanthera/bugtracker/issues/1777.

This is the first part, upgrading OC_AUDIO_PROTOCOL so that sound files are specified by string rather than int, to make it possible to implement system actions with support for audio assist in BootEntryProtocol next.