### PR TITLE
Remove validation note as already existing in ocvalidate Readme

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,6 @@ OpenCore Changelog
 ==================
 #### v0.8.1
 - Improved `ExtendBTFeatureFlags` quirk on newer macOS versions, thx @lvs1974
-- Source code: codestyle fixes, cleanup and conversions
 - Added notes about DMAR table and `ForceAquantiaEthernet`, thx @kokowski
 - Added System option in `LauncherOption` property, thx @stevezhengshiqi
 - Updated note about `CustomPciSerialDevice`, thx @joevt

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@ OpenCore Changelog
 ==================
 #### v0.8.1
 - Improved `ExtendBTFeatureFlags` quirk on newer macOS versions, thx @lvs1974
+- Source code: codestyle fixes, cleanup and conversions
+- Added notes about DMAR table and `ForceAquantiaEthernet`, thx @kokowski
+- Added System option in `LauncherOption` property, thx @stevezhengshiqi
+- Updated note about `CustomPciSerialDevice`, thx @joevt
 
 #### v0.8.0
 - Added support for early log preservation


### PR DESCRIPTION
Removed ocvalidate validation note as duplicate. I am not sure if source code note is ok or not.
Thanks @PMheart for your comments.