### PR TITLE
Support AvoidRuntimeDefrag for macOS 13 DP1

### DIFF
--- a/Include/Acidanthera/Library/OcDevicePathLib.h
+++ b/Include/Acidanthera/Library/OcDevicePathLib.h
@@ -40,6 +40,18 @@ AppendFileNameDevicePath (
   );
 
 /**
+  Locate the terminating node inside the device path.
+
+  @param[in] DevicePath  The device path used in the search.
+
+  @return  Returned is the last Device Path Node.
+**/
+EFI_DEVICE_PATH_PROTOCOL *
+FindDevicePathEndNode (
+  IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath
+  );
+
+/**
   Locate the node inside the device path specified by Type an SubType values.
 
   @param[in] DevicePath  The device path used in the search.

--- a/Include/Apple/IndustryStandard/AppleEfiBootRtInfo.h
+++ b/Include/Apple/IndustryStandard/AppleEfiBootRtInfo.h
@@ -1,0 +1,86 @@
+/** @file
+  Copyright (C) 2022, Marvin Häuser. All rights reserved.
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+**/
+
+#ifndef APPLE_EFI_BOOT_RT_INFO_H
+#define APPLE_EFI_BOOT_RT_INFO_H
+
+///
+/// The state value for when EfiBootRt has not been launched.
+///
+#define APPLE_EFI_BOOT_RT_STATE_NONE  SIGNATURE_32 ('b', 'r', '\0', '\0')
+
+///
+/// The state value for when EfiBootRt has been launched.
+///
+#define APPLE_EFI_BOOT_RT_STATE_LAUNCHED  SIGNATURE_32 ('b', 'r', 'H', 'i')
+
+///
+/// Arguments to the actual kernel call gate.
+///
+typedef struct {
+  ///
+  /// The address of the kernel entry point.
+  ///
+  UINTN    EntryPoint;
+  ///
+  /// The kernel argument handle.
+  ///
+  UINTN    Args;
+} APPLE_EFI_BOOT_RT_KCG_ARGS;
+
+/*
+  The kernel call gate transfers control to the Apple XNU kernel.
+
+  @param[in]  SystemTable   A pointer to the EFI System Table.
+  @param[in]  KcgArguments  Arguments to the kernel call gate.
+
+  @retval EFI_ABORTED  The kernel could not be started.
+  @retval other        On success, this function does not return.
+*/
+typedef
+EFI_STATUS
+(EFIAPI *APPLE_EFI_BOOT_RT_KCG)(
+  IN EFI_SYSTEM_TABLE                  *SystemTable,
+  IN CONST APPLE_EFI_BOOT_RT_KCG_ARGS  *KcgArguments
+  );
+
+///
+/// Apple EfiBootRt communication structure.
+///
+typedef struct {
+  ///
+  /// The image buffer of EfiBootRt.
+  ///
+  VOID                     *ImageBase;
+  ///
+  /// The size, in pages, of ImageBase.
+  ///
+  UINT64                   ImageNumPages;
+  ///
+  /// The current state of EfiBootRt.
+  ///
+  CONST UINT32             *State;
+  ///
+  /// The kernel call gate function.
+  ///
+  APPLE_EFI_BOOT_RT_KCG    KernelCallGate;
+  ///
+  /// The EfiBootRt build info string.
+  ///
+  CONST CHAR8              *BuildInfo;
+  ///
+  /// The EfiBootRt version string.
+  ///
+  CONST CHAR8              *VersionStr;
+} APPLE_EFI_BOOT_RT_INFO;
+
+#endif // APPLE_EFI_BOOT_RT_INFO_H

--- a/Library/OcAfterBootCompatLib/CustomSlide.c
+++ b/Library/OcAfterBootCompatLib/CustomSlide.c
@@ -813,8 +813,7 @@ AppleSlideGetVariable (
                    FilterMapContext,
                    (BootCompat->CpuInfo->CpuGeneration == OcCpuGenerationSandyBridge)
                                             || (BootCompat->CpuInfo->CpuGeneration == OcCpuGenerationIvyBridge)
-                   )
-              && !BootCompat->ServiceState.AppleCustomSlide)
+                   ))
     {
       //
       // When we cannot allow some KASLR values due to used address we generate

--- a/Library/OcAfterBootCompatLib/RelocationBlock.c
+++ b/Library/OcAfterBootCompatLib/RelocationBlock.c
@@ -301,12 +301,13 @@ AppleRelocationRebase (
   *BA->DeviceTreeP     -= RelocDiff;
 }
 
-UINTN
+VOID
 AppleRelocationCallGate (
-  IN OUT BOOT_COMPAT_CONTEXT  *BootCompat,
+  IN OUT UINTN                *Args,
+  IN     BOOT_COMPAT_CONTEXT  *BootCompat,
   IN     KERNEL_CALL_GATE     CallGate,
-  IN     UINTN                Args,
-  IN     UINTN                EntryPoint
+  IN     UINTN                *KcgArg1,
+  IN     UINTN                KcgArg2
   )
 {
   UINT8                 *Payload;
@@ -315,7 +316,7 @@ AppleRelocationCallGate (
   //
   // Shift kernel arguments back.
   //
-  Args -= (UINTN)(BootCompat->KernelState.RelocationBlock - KERNEL_BASE_PADDR);
+  *Args -= (UINTN)(BootCompat->KernelState.RelocationBlock - KERNEL_BASE_PADDR);
 
   //
   // Provide copying payload that will not be overwritten.
@@ -328,10 +329,10 @@ AppleRelocationCallGate (
   // Transition to payload.
   //
   ReloGate = (RELOCATION_CALL_GATE)(UINTN)Payload;
-  return ReloGate (
-           BootCompat->KernelState.RelocationBlockUsed / sizeof (UINT64),
-           EntryPoint,
-           BootCompat->KernelState.RelocationBlock,
-           Args
-           );
+  ReloGate (
+    BootCompat->KernelState.RelocationBlockUsed / sizeof (UINT64),
+    KcgArg2,
+    BootCompat->KernelState.RelocationBlock,
+    *KcgArg1
+    );
 }

--- a/Library/OcAfterBootCompatLib/ServiceOverrides.c
+++ b/Library/OcAfterBootCompatLib/ServiceOverrides.c
@@ -1079,7 +1079,7 @@ OcGetVariable (
   BootCompat = GetBootCompatContext ();
   IsApple    = BootCompat->ServiceState.AppleBootNestedCount > 0;
 
-  if (IsApple && BootCompat->Settings.ProvideCustomSlide) {
+  if (IsApple && (BootCompat->Settings.ProvideCustomSlide || BootCompat->Settings.AllowRelocationBlock)) {
     Status = AppleSlideGetVariable (
                BootCompat,
                BootCompat->ServicePtrs.GetVariable,

--- a/Library/OcDevicePathLib/OcDevicePathLib.c
+++ b/Library/OcDevicePathLib/OcDevicePathLib.c
@@ -71,6 +71,18 @@ AppendFileNameDevicePath (
 }
 
 EFI_DEVICE_PATH_PROTOCOL *
+FindDevicePathEndNode (
+  IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath
+  )
+{
+  while (!IsDevicePathEnd (DevicePath)) {
+    DevicePath = NextDevicePathNode (DevicePath);
+  }
+
+  return DevicePath;
+}
+
+EFI_DEVICE_PATH_PROTOCOL *
 FindDevicePathNodeWithType (
   IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
   IN UINT8                     Type,


### PR DESCRIPTION
macOS 13 Developer Beta 1 introduced a new driver, bootrt.efi, which
now carries the kernel call gate. It communicates with efiboot via an
info buffer passed via LoadOptions. Patch it on load with our hook to
run our kernel entry code.