### PR TITLE
OcAppleKernelLib: Make quirk Patcher parameter optional

### DIFF
--- a/Include/Acidanthera/Library/OcAppleKernelLib.h
+++ b/Include/Acidanthera/Library/OcAppleKernelLib.h
@@ -616,7 +616,7 @@ typedef enum {
 /**
   Kernel quirk patch function.
 
-  @param[in,out]  Patcher        A pointer to the patcher context. Optional.
+  @param[in,out]  Patcher        A pointer to the patcher context. Only optional for kext patching.
   @param[in]      KernelVersion  Kernel version to be matched.
 
   @return  EFI_SUCCESS when the patch is successfully applied.
@@ -646,7 +646,7 @@ typedef struct {
   Applies the specified quirk.
 
   @param[in]     Name           KERNEL_QUIRK_NAME specifying the quirk name.
-  @param[in,out] Patcher        PATCHER_CONTEXT instance. Optional.
+  @param[in,out] Patcher        PATCHER_CONTEXT instance. Only optional for kext patching.
   @param[in]     KernelVersion  Current kernel version.
 
   @returns EFI_SUCCESS on success.

--- a/Include/Acidanthera/Library/OcAppleKernelLib.h
+++ b/Include/Acidanthera/Library/OcAppleKernelLib.h
@@ -616,7 +616,7 @@ typedef enum {
 /**
   Kernel quirk patch function.
 
-  @param[in,out]  Patcher        A pointer to the patcher context.
+  @param[in,out]  Patcher        A pointer to the patcher context. Optional.
   @param[in]      KernelVersion  Kernel version to be matched.
 
   @return  EFI_SUCCESS when the patch is successfully applied.
@@ -624,7 +624,7 @@ typedef enum {
 typedef
 EFI_STATUS
 (KERNEL_QUIRK_PATCH_FUNCTION) (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   );
 
@@ -646,7 +646,7 @@ typedef struct {
   Applies the specified quirk.
 
   @param[in]     Name           KERNEL_QUIRK_NAME specifying the quirk name.
-  @param[in,out] Patcher        PATCHER_CONTEXT instance.
+  @param[in,out] Patcher        PATCHER_CONTEXT instance. Optional.
   @param[in]     KernelVersion  Current kernel version.
 
   @returns EFI_SUCCESS on success.
@@ -654,7 +654,7 @@ typedef struct {
 EFI_STATUS
 KernelApplyQuirk (
   IN     KERNEL_QUIRK_NAME  Name,
-  IN OUT PATCHER_CONTEXT    *Patcher,
+  IN OUT PATCHER_CONTEXT    *Patcher OPTIONAL,
   IN     UINT32             KernelVersion
   );
 

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -51,7 +51,7 @@ CONST UINTN
 STATIC
 EFI_STATUS
 PatchAppleCpuPmCfgLock (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -65,7 +65,10 @@ PatchAppleCpuPmCfgLock (
     return EFI_SUCCESS;
   }
 
-  ASSERT (Patcher != NULL);
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   Count     = 0;
   Walker    = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext);
@@ -222,7 +225,7 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchAppleXcpmCfgLock (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -232,14 +235,17 @@ PatchAppleXcpmCfgLock (
 
   UINT32  Replacements;
 
-  ASSERT (Patcher != NULL);
-
   //
   // XCPM is not available before macOS 10.8.5.
   //
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_MOUNTAIN_LION, 5, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping XcpmCfgLock on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Last = (XCPM_MSR_RECORD *)((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
@@ -347,7 +353,7 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchAppleXcpmExtraMsrs (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -356,14 +362,17 @@ PatchAppleXcpmExtraMsrs (
   XCPM_MSR_RECORD  *Last;
   UINT32           Replacements;
 
-  ASSERT (Patcher != NULL);
-
   //
   // XCPM is not available before macOS 10.8.5.
   //
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_MOUNTAIN_LION, 5, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping XcpmExtraMsrs on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Last = (XCPM_MSR_RECORD *)((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
@@ -473,7 +482,7 @@ CONST UINT8
 STATIC
 EFI_STATUS
 PatchAppleXcpmForceBoost (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -481,14 +490,17 @@ PatchAppleXcpmForceBoost (
   UINT8  *Last;
   UINT8  *Current;
 
-  ASSERT (Patcher != NULL);
-
   //
   // XCPM is not available before macOS 10.8.5.
   //
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_MOUNTAIN_LION, 5, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping XcpmForceBoost on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Start   = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext);
@@ -633,7 +645,7 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchUsbXhciPortLimit1 (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -646,6 +658,11 @@ PatchUsbXhciPortLimit1 (
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_MOJAVE, 5, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping port patch IOUSBHostFamily on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mRemoveUsbLimitIoP1Patch);
@@ -661,17 +678,20 @@ PatchUsbXhciPortLimit1 (
 STATIC
 EFI_STATUS
 PatchUsbXhciPortLimit2 (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_HIGH_SIERRA_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping modern port patch AppleUSBXHCI on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   //
@@ -722,17 +742,20 @@ PatchUsbXhciPortLimit2 (
 STATIC
 EFI_STATUS
 PatchUsbXhciPortLimit3 (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_EL_CAPITAN_MIN, KERNEL_VERSION_HIGH_SIERRA_MAX)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping legacy port patch AppleUSBXHCIPCI on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   //
@@ -813,13 +836,16 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchThirdPartyDriveSupport (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIOAHCIBlockStoragePatchV1);
   if (EFI_ERROR (Status)) {
@@ -882,13 +908,16 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchForceInternalDiskIcons (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIOAHCIPortPatch);
   if (EFI_ERROR (Status)) {
@@ -929,17 +958,20 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchAppleIoMapperSupport (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOUNTAIN_LION_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping AppleIoMapper patch on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mAppleIoMapperPatch);
@@ -976,7 +1008,7 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchDummyPowerManagement (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -987,7 +1019,10 @@ PatchDummyPowerManagement (
     return EFI_SUCCESS;
   }
 
-  ASSERT (Patcher != NULL);
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   Status = PatcherApplyGenericPatch (Patcher, &mAppleDummyCpuPmPatch);
   if (EFI_ERROR (Status)) {
@@ -1056,17 +1091,20 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchIncreasePciBarSize (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_YOSEMITE_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping com.apple.iokit.IOPCIFamily IncreasePciBarSize on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIncreasePciBarSizePatch);
@@ -1130,7 +1168,7 @@ PatchSetPciSerialDevice (
 STATIC
 EFI_STATUS
 PatchCustomPciSerialPmio (
-  IN OUT PATCHER_CONTEXT  *Patcher
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL
   )
 {
   UINTN  Count;
@@ -1140,7 +1178,10 @@ PatchCustomPciSerialPmio (
   UINT8  *WalkerEnd;
   UINT8  *WalkerTmp;
 
-  ASSERT (Patcher != NULL);
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   Count     = 0;
   Walker    = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext);
@@ -1210,11 +1251,16 @@ PatchCustomPciSerialPmio (
 STATIC
 EFI_STATUS
 PatchCustomPciSerialDevice (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   Status = EFI_INVALID_PARAMETER;
   if (  ((mPmioRegisterBase != 0) && (mPmioRegisterStride != 0))
@@ -1265,13 +1311,16 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchCustomSmbiosGuid (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   Status = PatcherApplyGenericPatch (Patcher, &mCustomSmbiosGuidPatch);
   if (!EFI_ERROR (Status)) {
@@ -1312,7 +1361,7 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchPanicKextDump (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -1320,11 +1369,14 @@ PatchPanicKextDump (
   UINT8       *Record;
   UINT8       *Last;
 
-  ASSERT (Patcher != NULL);
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_HIGH_SIERRA_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping PanicKextDump on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Last = ((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
@@ -1470,13 +1522,16 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchLapicKernelPanic (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   //
   // This one is for <= 10.15 release kernels.
@@ -1585,17 +1640,20 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchPowerStateTimeout (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_CATALINA_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping power state patch on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mPowerStateTimeoutPanicInlinePatch);
@@ -1699,13 +1757,16 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchAppleRtcChecksum (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   Status = PatcherApplyGenericPatch (Patcher, Patcher->Is32Bit ? &mAppleRtcChecksumPatch32 : &mAppleRtcChecksumPatch64);
   if (EFI_ERROR (Status)) {
@@ -1720,7 +1781,7 @@ PatchAppleRtcChecksum (
 STATIC
 EFI_STATUS
 PatchSegmentJettison (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -1737,6 +1798,11 @@ PatchSegmentJettison (
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_BIG_SUR_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping SegmentJettison on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Last = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
@@ -1860,17 +1926,20 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchBTFeatureFlags (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOUNTAIN_LION_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping BTFeatureFlags on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mBTFeatureFlagsPatchV1);
@@ -1958,7 +2027,7 @@ CONST UINT8
 STATIC
 EFI_STATUS
 PatchLegacyCommpage (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -1975,7 +2044,10 @@ PatchLegacyCommpage (
   UINT32                   CommpageAddress;
   UINT32                   CommpageMustHave;
 
-  ASSERT (Patcher != NULL);
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
 
   Start = ((UINT8 *)MachoGetMachHeader (&Patcher->MachContext));
   Last  = Start + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2 - (Patcher->Is32Bit ? sizeof (COMMPAGE_DESCRIPTOR) : sizeof (COMMPAGE_DESCRIPTOR_64));
@@ -2135,13 +2207,11 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchAquantiaEthernet (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
-
-  ASSERT (Patcher != NULL);
 
   //
   // This patch is not required before macOS 10.15.4.
@@ -2149,6 +2219,11 @@ PatchAquantiaEthernet (
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_CATALINA, 4, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping patching AquantiaEthernet on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   //
@@ -2178,7 +2253,7 @@ PatchAquantiaEthernet (
 STATIC
 EFI_STATUS
 PatchForceSecureBootScheme (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
@@ -2188,11 +2263,14 @@ PatchForceSecureBootScheme (
   UINT8       *HybridAp;
   UINT32      Diff;
 
-  ASSERT (Patcher != NULL);
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_BIG_SUR_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping sb scheme on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   //
@@ -2302,17 +2380,20 @@ PATCHER_GENERIC_PATCH
 STATIC
 EFI_STATUS
 PatchSetApfsTrimTimeout (
-  IN OUT PATCHER_CONTEXT  *Patcher,
+  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL,
   IN     UINT32           KernelVersion
   )
 {
   EFI_STATUS  Status;
 
-  ASSERT (Patcher != NULL);
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOJAVE_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping apfs timeout on %u\n", KernelVersion));
     return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
   }
 
   //
@@ -2382,11 +2463,9 @@ KERNEL_QUIRK  gKernelQuirks[] = {
 EFI_STATUS
 KernelApplyQuirk (
   IN     KERNEL_QUIRK_NAME  Name,
-  IN OUT PATCHER_CONTEXT    *Patcher,
+  IN OUT PATCHER_CONTEXT    *Patcher OPTIONAL,
   IN     UINT32             KernelVersion
   )
 {
-  ASSERT (Patcher != NULL);
-
   return gKernelQuirks[Name].PatchFunction (Patcher, KernelVersion);
 }

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -60,11 +60,6 @@ PatchAppleCpuPmCfgLock (
   UINT8  *WalkerEnd;
   UINT8  *WalkerTmp;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   //
   // NOTE: As of macOS 13.0 AICPUPM kext is removed.
   // However, we may remove this check later, if an older version can be injected correctly
@@ -72,6 +67,11 @@ PatchAppleCpuPmCfgLock (
   //
   if (OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_VENTURA_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping AppleCpuPmCfgLock patch on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -656,17 +656,17 @@ PatchUsbXhciPortLimit1 (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   //
   // On 10.14.4 and newer IOUSBHostFamily also needs limit removal.
   // Thanks to ydeng discovering this.
   //
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_MOJAVE, 5, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping port patch IOUSBHostFamily on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -689,13 +689,13 @@ PatchUsbXhciPortLimit2 (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_HIGH_SIERRA_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping modern port patch AppleUSBXHCI on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -753,13 +753,13 @@ PatchUsbXhciPortLimit3 (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_EL_CAPITAN_MIN, KERNEL_VERSION_HIGH_SIERRA_MAX)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping legacy port patch AppleUSBXHCIPCI on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -848,8 +848,8 @@ PatchThirdPartyDriveSupport (
   EFI_STATUS  Status;
 
   if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
+    return EFI_SUCCESS;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIOAHCIBlockStoragePatchV1);
@@ -920,8 +920,8 @@ PatchForceInternalDiskIcons (
   EFI_STATUS  Status;
 
   if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
+    return EFI_SUCCESS;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIOAHCIPortPatch);
@@ -969,13 +969,13 @@ PatchAppleIoMapperSupport (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOUNTAIN_LION_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping AppleIoMapper patch on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -1019,13 +1019,13 @@ PatchDummyPowerManagement (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   if (OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_VENTURA_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping dummy AppleIntelCPUPowerManagement patch on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -1102,13 +1102,13 @@ PatchIncreasePciBarSize (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_YOSEMITE_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping com.apple.iokit.IOPCIFamily IncreasePciBarSize on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -1173,7 +1173,7 @@ PatchSetPciSerialDevice (
 STATIC
 EFI_STATUS
 PatchCustomPciSerialPmio (
-  IN OUT PATCHER_CONTEXT  *Patcher OPTIONAL
+  IN OUT PATCHER_CONTEXT  *Patcher
   )
 {
   UINTN  Count;
@@ -1183,10 +1183,10 @@ PatchCustomPciSerialPmio (
   UINT8  *WalkerEnd;
   UINT8  *WalkerTmp;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a\n", __func__));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   Count     = 0;
   Walker    = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext);
@@ -1323,8 +1323,8 @@ PatchCustomSmbiosGuid (
   EFI_STATUS  Status;
 
   if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
+    return EFI_SUCCESS;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mCustomSmbiosGuidPatch);
@@ -1769,8 +1769,8 @@ PatchAppleRtcChecksum (
   EFI_STATUS  Status;
 
   if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
+    return EFI_SUCCESS;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, Patcher->Is32Bit ? &mAppleRtcChecksumPatch32 : &mAppleRtcChecksumPatch64);
@@ -1937,13 +1937,13 @@ PatchBTFeatureFlags (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOUNTAIN_LION_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping BTFeatureFlags on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -2218,16 +2218,16 @@ PatchAquantiaEthernet (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   //
   // This patch is not required before macOS 10.15.4.
   //
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_CATALINA, 4, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping patching AquantiaEthernet on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -2268,13 +2268,13 @@ PatchForceSecureBootScheme (
   UINT8       *HybridAp;
   UINT32      Diff;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_BIG_SUR_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping sb scheme on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 
@@ -2391,13 +2391,13 @@ PatchSetApfsTrimTimeout (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
-
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOJAVE_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping apfs timeout on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
+
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_SUCCESS;
   }
 

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -72,7 +72,7 @@ PatchAppleCpuPmCfgLock (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Count     = 0;
@@ -667,7 +667,7 @@ PatchUsbXhciPortLimit1 (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mRemoveUsbLimitIoP1Patch);
@@ -696,7 +696,7 @@ PatchUsbXhciPortLimit2 (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   //
@@ -760,7 +760,7 @@ PatchUsbXhciPortLimit3 (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   //
@@ -849,7 +849,7 @@ PatchThirdPartyDriveSupport (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIOAHCIBlockStoragePatchV1);
@@ -921,7 +921,7 @@ PatchForceInternalDiskIcons (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIOAHCIPortPatch);
@@ -976,7 +976,7 @@ PatchAppleIoMapperSupport (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mAppleIoMapperPatch);
@@ -1026,7 +1026,7 @@ PatchDummyPowerManagement (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mAppleDummyCpuPmPatch);
@@ -1109,7 +1109,7 @@ PatchIncreasePciBarSize (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIncreasePciBarSizePatch);
@@ -1324,7 +1324,7 @@ PatchCustomSmbiosGuid (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mCustomSmbiosGuidPatch);
@@ -1770,7 +1770,7 @@ PatchAppleRtcChecksum (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, Patcher->Is32Bit ? &mAppleRtcChecksumPatch32 : &mAppleRtcChecksumPatch64);
@@ -1944,7 +1944,7 @@ PatchBTFeatureFlags (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mBTFeatureFlagsPatchV1);
@@ -2228,7 +2228,7 @@ PatchAquantiaEthernet (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   //
@@ -2275,7 +2275,7 @@ PatchForceSecureBootScheme (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   //
@@ -2398,7 +2398,7 @@ PatchSetApfsTrimTimeout (
 
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
-    return EFI_SUCCESS;
+    return EFI_NOT_FOUND;
   }
 
   //

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -248,10 +248,10 @@ PatchAppleXcpmCfgLock (
     return EFI_SUCCESS;
   }
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   Last = (XCPM_MSR_RECORD *)((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
                              + MachoGetFileSize (&Patcher->MachContext) - sizeof (XCPM_MSR_RECORD));
@@ -375,10 +375,10 @@ PatchAppleXcpmExtraMsrs (
     return EFI_SUCCESS;
   }
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   Last = (XCPM_MSR_RECORD *)((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
                              + MachoGetFileSize (&Patcher->MachContext) - sizeof (XCPM_MSR_RECORD));
@@ -503,10 +503,10 @@ PatchAppleXcpmForceBoost (
     return EFI_SUCCESS;
   }
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   Start   = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext);
   Last    = Start + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2;
@@ -1262,10 +1262,10 @@ PatchCustomPciSerialDevice (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   Status = EFI_INVALID_PARAMETER;
   if (  ((mPmioRegisterBase != 0) && (mPmioRegisterStride != 0))
@@ -1379,10 +1379,10 @@ PatchPanicKextDump (
     return EFI_SUCCESS;
   }
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   Last = ((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
           + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE);
@@ -1533,10 +1533,10 @@ PatchLapicKernelPanic (
 {
   EFI_STATUS  Status;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   //
   // This one is for <= 10.15 release kernels.
@@ -1656,10 +1656,10 @@ PatchPowerStateTimeout (
     return EFI_SUCCESS;
   }
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   Status = PatcherApplyGenericPatch (Patcher, &mPowerStateTimeoutPanicInlinePatch);
   if (!EFI_ERROR (Status)) {
@@ -1805,10 +1805,10 @@ PatchSegmentJettison (
     return EFI_SUCCESS;
   }
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   Last = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
          + MachoGetFileSize (&Patcher->MachContext) - sizeof (EFI_PAGE_SIZE) * 2;
@@ -2049,10 +2049,10 @@ PatchLegacyCommpage (
   UINT32                   CommpageAddress;
   UINT32                   CommpageMustHave;
 
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
-  }
+  //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
 
   Start = ((UINT8 *)MachoGetMachHeader (&Patcher->MachContext));
   Last  = Start + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2 - (Patcher->Is32Bit ? sizeof (COMMPAGE_DESCRIPTOR) : sizeof (COMMPAGE_DESCRIPTOR_64));

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -1184,7 +1184,7 @@ PatchCustomPciSerialPmio (
   UINT8  *WalkerTmp;
 
   if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a\n", __func__));
     return EFI_NOT_FOUND;
   }
 

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -60,6 +60,11 @@ PatchAppleCpuPmCfgLock (
   UINT8  *WalkerEnd;
   UINT8  *WalkerTmp;
 
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
+
   //
   // NOTE: As of macOS 13.0 AICPUPM kext is removed.
   // However, we may remove this check later, if an older version can be injected correctly
@@ -68,11 +73,6 @@ PatchAppleCpuPmCfgLock (
   if (OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_VENTURA_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping AppleCpuPmCfgLock patch on %u\n", KernelVersion));
     return EFI_SUCCESS;
-  }
-
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
   }
 
   Count     = 0;
@@ -241,17 +241,17 @@ PatchAppleXcpmCfgLock (
   UINT32  Replacements;
 
   //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
+
+  //
   // XCPM is not available before macOS 10.8.5.
   //
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_MOUNTAIN_LION, 5, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping XcpmCfgLock on %u\n", KernelVersion));
     return EFI_SUCCESS;
   }
-
-  //
-  // This is a kernel patch, so Patcher cannot be NULL.
-  //
-  ASSERT (Patcher != NULL);
 
   Last = (XCPM_MSR_RECORD *)((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
                              + MachoGetFileSize (&Patcher->MachContext) - sizeof (XCPM_MSR_RECORD));
@@ -368,17 +368,17 @@ PatchAppleXcpmExtraMsrs (
   UINT32           Replacements;
 
   //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
+
+  //
   // XCPM is not available before macOS 10.8.5.
   //
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_MOUNTAIN_LION, 5, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping XcpmExtraMsrs on %u\n", KernelVersion));
     return EFI_SUCCESS;
   }
-
-  //
-  // This is a kernel patch, so Patcher cannot be NULL.
-  //
-  ASSERT (Patcher != NULL);
 
   Last = (XCPM_MSR_RECORD *)((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
                              + MachoGetFileSize (&Patcher->MachContext) - sizeof (XCPM_MSR_RECORD));
@@ -496,17 +496,17 @@ PatchAppleXcpmForceBoost (
   UINT8  *Current;
 
   //
+  // This is a kernel patch, so Patcher cannot be NULL.
+  //
+  ASSERT (Patcher != NULL);
+
+  //
   // XCPM is not available before macOS 10.8.5.
   //
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_MOUNTAIN_LION, 5, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping XcpmForceBoost on %u\n", KernelVersion));
     return EFI_SUCCESS;
   }
-
-  //
-  // This is a kernel patch, so Patcher cannot be NULL.
-  //
-  ASSERT (Patcher != NULL);
 
   Start   = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext);
   Last    = Start + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2;
@@ -656,6 +656,11 @@ PatchUsbXhciPortLimit1 (
 {
   EFI_STATUS  Status;
 
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
+
   //
   // On 10.14.4 and newer IOUSBHostFamily also needs limit removal.
   // Thanks to ydeng discovering this.
@@ -663,11 +668,6 @@ PatchUsbXhciPortLimit1 (
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_MOJAVE, 5, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping port patch IOUSBHostFamily on %u\n", KernelVersion));
     return EFI_SUCCESS;
-  }
-
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mRemoveUsbLimitIoP1Patch);
@@ -689,14 +689,14 @@ PatchUsbXhciPortLimit2 (
 {
   EFI_STATUS  Status;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_HIGH_SIERRA_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping modern port patch AppleUSBXHCI on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;
+  }
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_HIGH_SIERRA_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping modern port patch AppleUSBXHCI on %u\n", KernelVersion));
+    return EFI_SUCCESS;
   }
 
   //
@@ -753,14 +753,14 @@ PatchUsbXhciPortLimit3 (
 {
   EFI_STATUS  Status;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_EL_CAPITAN_MIN, KERNEL_VERSION_HIGH_SIERRA_MAX)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping legacy port patch AppleUSBXHCIPCI on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;
+  }
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_EL_CAPITAN_MIN, KERNEL_VERSION_HIGH_SIERRA_MAX)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping legacy port patch AppleUSBXHCIPCI on %u\n", KernelVersion));
+    return EFI_SUCCESS;
   }
 
   //
@@ -969,14 +969,14 @@ PatchAppleIoMapperSupport (
 {
   EFI_STATUS  Status;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOUNTAIN_LION_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping AppleIoMapper patch on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;
+  }
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOUNTAIN_LION_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping AppleIoMapper patch on %u\n", KernelVersion));
+    return EFI_SUCCESS;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mAppleIoMapperPatch);
@@ -1019,14 +1019,14 @@ PatchDummyPowerManagement (
 {
   EFI_STATUS  Status;
 
-  if (OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_VENTURA_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping dummy AppleIntelCPUPowerManagement patch on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;
+  }
+
+  if (OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_VENTURA_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping dummy AppleIntelCPUPowerManagement patch on %u\n", KernelVersion));
+    return EFI_SUCCESS;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mAppleDummyCpuPmPatch);
@@ -1102,14 +1102,14 @@ PatchIncreasePciBarSize (
 {
   EFI_STATUS  Status;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_YOSEMITE_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping com.apple.iokit.IOPCIFamily IncreasePciBarSize on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;
+  }
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_YOSEMITE_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping com.apple.iokit.IOPCIFamily IncreasePciBarSize on %u\n", KernelVersion));
+    return EFI_SUCCESS;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIncreasePciBarSizePatch);
@@ -1374,15 +1374,15 @@ PatchPanicKextDump (
   UINT8       *Record;
   UINT8       *Last;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_HIGH_SIERRA_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping PanicKextDump on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   //
   // This is a kernel patch, so Patcher cannot be NULL.
   //
   ASSERT (Patcher != NULL);
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_HIGH_SIERRA_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping PanicKextDump on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
 
   Last = ((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
           + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE);
@@ -1651,15 +1651,15 @@ PatchPowerStateTimeout (
 {
   EFI_STATUS  Status;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_CATALINA_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping power state patch on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   //
   // This is a kernel patch, so Patcher cannot be NULL.
   //
   ASSERT (Patcher != NULL);
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_CATALINA_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping power state patch on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
 
   Status = PatcherApplyGenericPatch (Patcher, &mPowerStateTimeoutPanicInlinePatch);
   if (!EFI_ERROR (Status)) {
@@ -1800,15 +1800,15 @@ PatchSegmentJettison (
   UINT32      Diff;
   UINT32      Diff2;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_BIG_SUR_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping SegmentJettison on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   //
   // This is a kernel patch, so Patcher cannot be NULL.
   //
   ASSERT (Patcher != NULL);
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_BIG_SUR_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping SegmentJettison on %u\n", KernelVersion));
+    return EFI_SUCCESS;
+  }
 
   Last = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
          + MachoGetFileSize (&Patcher->MachContext) - sizeof (EFI_PAGE_SIZE) * 2;
@@ -1937,14 +1937,14 @@ PatchBTFeatureFlags (
 {
   EFI_STATUS  Status;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOUNTAIN_LION_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping BTFeatureFlags on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;
+  }
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOUNTAIN_LION_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping BTFeatureFlags on %u\n", KernelVersion));
+    return EFI_SUCCESS;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mBTFeatureFlagsPatchV1);
@@ -2218,17 +2218,17 @@ PatchAquantiaEthernet (
 {
   EFI_STATUS  Status;
 
+  if (Patcher == NULL) {
+    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
+    return EFI_NOT_FOUND;
+  }
+
   //
   // This patch is not required before macOS 10.15.4.
   //
   if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_CATALINA, 4, 0), 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping patching AquantiaEthernet on %u\n", KernelVersion));
     return EFI_SUCCESS;
-  }
-
-  if (Patcher == NULL) {
-    DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
-    return EFI_NOT_FOUND;
   }
 
   //
@@ -2268,14 +2268,14 @@ PatchForceSecureBootScheme (
   UINT8       *HybridAp;
   UINT32      Diff;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_BIG_SUR_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping sb scheme on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;
+  }
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_BIG_SUR_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping sb scheme on %u\n", KernelVersion));
+    return EFI_SUCCESS;
   }
 
   //
@@ -2391,14 +2391,14 @@ PatchSetApfsTrimTimeout (
 {
   EFI_STATUS  Status;
 
-  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOJAVE_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Skipping apfs timeout on %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: Patcher not found under for %a on %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;
+  }
+
+  if (!OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_MOJAVE_MIN, 0)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Skipping apfs timeout on %u\n", KernelVersion));
+    return EFI_SUCCESS;
   }
 
   //

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -2472,5 +2472,12 @@ KernelApplyQuirk (
   IN     UINT32             KernelVersion
   )
 {
+  //
+  // Patcher cannot be NULL for kernel patches, whose Identifier are NULL.
+  //
+  if (gKernelQuirks[Name].Identifier == NULL) {
+    ASSERT (Patcher != NULL);
+  }
+
   return gKernelQuirks[Name].PatchFunction (Patcher, KernelVersion);
 }

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -60,6 +60,11 @@ PatchAppleCpuPmCfgLock (
   UINT8  *WalkerEnd;
   UINT8  *WalkerTmp;
 
+  //
+  // NOTE: As of macOS 13.0 AICPUPM kext is removed.
+  // However, we may remove this check later, if an older version can be injected correctly
+  // such that it will patched.
+  //
   if (OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_VENTURA_MIN, 0)) {
     DEBUG ((DEBUG_INFO, "OCAK: Skipping AppleCpuPmCfgLock patch on %u\n", KernelVersion));
     return EFI_SUCCESS;


### PR DESCRIPTION
Patcher can be NULL when the kext is not found; this should not lead to assertion.