### PR TITLE
ApfsTrimTimeout: replace ambiguous "it"

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -2832,7 +2832,7 @@ blocking.
   such that \texttt{apfs.kext} will remain untouched.
 
   \emph{Note 2}: On macOS 12.0 and above, it is no longer possible to specify trim timeout.
-  However, it can be disabled by setting \texttt{0}.
+  However, trim can be disabled by setting \texttt{0}.
 
   \emph{Note 3}: Trim operations are \emph{only} affected at booting phase when the startup volume is mounted.
   Either specifying timeout, or completely disabling trim with \texttt{0}, will not affect normal macOS running.


### PR DESCRIPTION
The passage reads like 0 turns off trim timeout, but it actually turns off trim based on the context. dortania/bugtracker#192