### PR TITLE
CreateVault linux portability

### DIFF
--- a/Utilities/CreateVault/create_vault.sh
+++ b/Utilities/CreateVault/create_vault.sh
@@ -74,7 +74,7 @@ write_header vault.plist
   \( ! -iname "vault.*" \) \
   \( ! -iname "MemTest86.log" \) \
   \( ! -iname "MemTest86-Report-*.html" \) \
-  \( ! -iname "OpenCore.efi" \) | env LC_COLLATE=POSIX sort | while read -r fname; do
+  \( ! -iname "OpenCore.efi" \) | env LC_COLLATE=POSIX /usr/bin/sort | while read -r fname; do
   fname="${fname#"./"}"
   wname="${fname//\//\\\\}"
   sha=$(/usr/bin/openssl sha256 "${fname}" | /usr/bin/awk '{print $2}') || abort "Failed to hash ${fname}"

--- a/Utilities/CreateVault/create_vault.sh
+++ b/Utilities/CreateVault/create_vault.sh
@@ -49,6 +49,8 @@ echo "Hashing files in ${OCPath}..."
 /usr/bin/find . -not -path '*/\.*' -type f \
   \( ! -iname ".*" \) \
   \( ! -iname "vault.*" \) \
+  \( ! -iname "MemTest86.log" \) \
+  \( ! -iname "MemTest86-Report-*.html" \) \
   \( ! -iname "OpenCore.efi" \) | while read -r fname; do
   fname="${fname#"./"}"
   wname="${fname//\//\\\\}"

--- a/Utilities/CreateVault/create_vault.sh
+++ b/Utilities/CreateVault/create_vault.sh
@@ -17,18 +17,8 @@ if [ ! -d "${OCPath}" ]; then
   exit 1
 fi
 
-if [ ! -x /usr/bin/find ] || [ ! -x /bin/rm ] || [ ! -x /usr/bin/sed ] || [ ! -x /usr/bin/xxd ]; then
+if [ ! -x /usr/bin/env ] || [ ! -x /usr/bin/find ] || [ ! -x /bin/rm ] || [ ! -x /usr/bin/sed ] || [ ! -x /usr/bin/openssl ] || [ ! -x /usr/bin/awk ] || [ ! -x /usr/bin/sort ] || [ ! -x /usr/bin/xxd ]; then
   echo "Unix environment is broken!"
-  exit 1
-fi
-
-if [ ! -x /usr/libexec/PlistBuddy ]; then
-  echo "PlistBuddy is missing!"
-  exit 1
-fi
-
-if [ ! -x /usr/bin/shasum ]; then
-  echo "shasum is missing!"
   exit 1
 fi
 
@@ -38,35 +28,67 @@ abort() {
   exit 1
 }
 
+# plist output functions so we don't need PlistBuddy
+write_header() {
+  cat <<EOF > $1
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Files</key>
+	<dict>
+EOF
+}
+
+write_file_name_and_hash() {
+  echo -e "\t\t<key>${2}</key>" >> $1
+  echo -e "\t\t<data>" >> $1
+  echo -e -n "\t\t" >> $1
+  cat $3 >> $1
+  echo -e "\t\t</data>" >> $1
+}
+
+write_footer() {
+  cat <<EOF >> $1
+	</dict>
+	<key>Version</key>
+	<integer>1</integer>
+</dict>
+</plist>
+EOF
+}
+
 echo "Chose ${OCPath} for hashing..."
 
 cd "${OCPath}" || abort "Failed to reach ${OCPath}"
 /bin/rm -rf vault.plist vault.sig || abort "Failed to cleanup"
-/usr/libexec/PlistBuddy -c "Add Version integer 1" vault.plist || abort "Failed to set vault.plist version"
 
 echo "Hashing files in ${OCPath}..."
+
+write_header vault.plist
 
 /usr/bin/find . -not -path '*/\.*' -type f \
   \( ! -iname ".*" \) \
   \( ! -iname "vault.*" \) \
   \( ! -iname "MemTest86.log" \) \
   \( ! -iname "MemTest86-Report-*.html" \) \
-  \( ! -iname "OpenCore.efi" \) | while read -r fname; do
+  \( ! -iname "OpenCore.efi" \) | env LC_COLLATE=POSIX sort | while read -r fname; do
   fname="${fname#"./"}"
   wname="${fname//\//\\\\}"
-  shasum=$(/usr/bin/shasum -a 256 "${fname}") || abort "Failed to hash ${fname}"
-  sha=$(echo "$shasum" | /usr/bin/sed 's/^\([a-f0-9]\{64\}\).*/\1/') || abort "Illegit hashsum"
+  sha=$(/usr/bin/openssl sha256 "${fname}" | /usr/bin/awk '{print $2}') || abort "Failed to hash ${fname}"
   if [ "${#sha}" != 64 ] || [ "$(echo "$sha"| /usr/bin/sed 's/^[a-f0-9]*$//')" ]; then
     abort "Got invalid hash: ${sha}!"
   fi
 
   echo "${wname}: ${sha}"
 
-  echo "${sha}" | /usr/bin/xxd -r -p > /tmp/vault_hash || abort "Hashing failure"
-  /usr/libexec/PlistBuddy -c "Import Files:'${wname}' /tmp/vault_hash" vault.plist || abort "Failed to append vault.plist!"
+  echo "${sha}" | /usr/bin/xxd -r -p | /usr/bin/openssl base64 > /tmp/vault_hash || abort "Hashing failure"
+  write_file_name_and_hash vault.plist ${wname} /tmp/vault_hash
 done
 
 /bin/rm -rf /tmp/vault_hash
+
+write_footer vault.plist
 
 echo "All done!"
 exit 0

--- a/Utilities/CreateVault/create_vault.sh
+++ b/Utilities/CreateVault/create_vault.sh
@@ -30,7 +30,7 @@ abort() {
 
 # plist output functions so we don't need PlistBuddy
 write_header() {
-  cat <<EOF > $1
+  cat <<EOF > "$1"
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -41,15 +41,17 @@ EOF
 }
 
 write_file_name_and_hash() {
-  echo -e "\t\t<key>${2}</key>" >> $1
-  echo -e "\t\t<data>" >> $1
-  echo -e -n "\t\t" >> $1
-  cat $3 >> $1
-  echo -e "\t\t</data>" >> $1
+  {
+    echo -e "\t\t<key>${2}</key>"
+    echo -e "\t\t<data>"
+    echo -e -n "\t\t"
+    cat "$3"
+    echo -e "\t\t</data>"
+  } >> "$1"
 }
 
 write_footer() {
-  cat <<EOF >> $1
+  cat <<EOF >> "$1"
 	</dict>
 	<key>Version</key>
 	<integer>1</integer>
@@ -83,7 +85,7 @@ write_header vault.plist
   echo "${wname}: ${sha}"
 
   echo "${sha}" | /usr/bin/xxd -r -p | /usr/bin/openssl base64 > /tmp/vault_hash || abort "Hashing failure"
-  write_file_name_and_hash vault.plist ${wname} /tmp/vault_hash
+  write_file_name_and_hash vault.plist "${wname}" /tmp/vault_hash
 done
 
 /bin/rm -rf /tmp/vault_hash

--- a/Utilities/CreateVault/sign.command
+++ b/Utilities/CreateVault/sign.command
@@ -10,7 +10,7 @@ cleanup() {
   rm -rf "${KeyPath}"
 }
 
-if [ ! -x /usr/bin/dirname ] || [ ! -x /bin/chmod ] || [ ! -x /bin/mkdir ] || [ ! -x /bin/rm ] || [ ! -x /usr/bin/strings ] || [ ! -x /usr/bin/grep ] || [ ! -x /usr/bin/cut ] || [ ! -x /bin/dd ] || [ ! -x /usr/bin/uuidgen ] ; then
+if [ ! -x /usr/bin/dirname ] || [ ! -x /bin/chmod ] || [ ! -x /bin/mkdir ] || [ ! -x /bin/rm ] || [ ! -x /usr/bin/strings ] || [ ! -x /usr/bin/grep ] || [ ! -x /usr/bin/awk ] || [ ! -x /bin/dd ] || [ ! -x /usr/bin/uuidgen ] ; then
   abort "Unix environment is broken!"
 fi
 
@@ -60,7 +60,7 @@ echo "Signing ${OCBin}..."
 ./RsaTool -sign "${OCPath}/vault.plist" "${OCPath}/vault.sig" "${PubKey}" || abort "Failed to patch ${PubKey}"
 
 echo "Bin-patching ${OCBin}..."
-off=$(($(/usr/bin/strings -a -t d "${OCBin}" | /usr/bin/grep "=BEGIN OC VAULT=" | /usr/bin/cut -f1 -d' ') + 16))
+off=$(($(/usr/bin/strings -a -t d "${OCBin}" | /usr/bin/grep "=BEGIN OC VAULT=" | /usr/bin/awk '{print $1}') + 16))
 if [ "${off}" -le 16 ]; then
   abort "${OCBin} is borked"
 fi


### PR DESCRIPTION
Some notes:

- the plist output functions produce the exact same plist outputs as PlistBuddy as far as I've been able to tell.
- I'm piping the find output through sort with LC_COLLATE=POSIX to have it behave the same on linux as it does on macos. (doesn't matter functionally since OpenCore doesn't care about the order, but it's just nice to have the exact same vault.plists produced on all platforms)
- have to use awk instead of cut in sign.command since binutils (on linux) "strings -t d" outputs numbers that are padded with spaces on the left, whereas that isn't the case on macos apparently.
- the memtest86 things aren't really related, but seem like no brainers to include anyway
- it is still the user's responsibility to compile RsaTool (from Utilities/RsaTool) for their platform and place it in the directory along these scripts, maybe there should be a README in the CreateVault directory with this information?