### PR TITLE
Support macOS 13 DP3 Kernel Collection

### DIFF
--- a/Include/Acidanthera/Library/OcAppleKernelLib.h
+++ b/Include/Acidanthera/Library/OcAppleKernelLib.h
@@ -200,7 +200,9 @@ typedef struct {
   //
   MACH_SECTION_ANY                       *PrelinkedInfoSection;
   //
-  // Pointer to PRELINK_TEXT_SEGMENT.
+  // Pointer to PRELINK_TEXT_SEGMENT (for prelinkedkernel, NULL for KC).
+  // As of macOS 13 Developer Beta 3, this segment may have corrupted
+  // information.
   //
   MACH_SEGMENT_COMMAND_ANY               *PrelinkedTextSegment;
   //

--- a/Include/Acidanthera/Library/OcAppleKernelLib.h
+++ b/Include/Acidanthera/Library/OcAppleKernelLib.h
@@ -1004,16 +1004,18 @@ KcGetKextSize (
 /**
   Apply the delta from KC header to the file's offsets.
 
-  @param[in,out] Context  The context of the KEXT to rebase.
-  @param[in]     Delta    The offset from KC header the KEXT starts at.
+  @param[in]     PrelinkedContext  Prelinked context.
+  @param[in,out] Context           The context of the KEXT to rebase.
+  @param[in]     Delta             The offset from KC header the KEXT starts at.
 
   @retval EFI_SUCCESS  The file has beem rebased successfully.
   @retval other        An error has occured.
 **/
 EFI_STATUS
 KcKextApplyFileDelta (
-  IN OUT OC_MACHO_CONTEXT  *Context,
-  IN     UINT32            Delta
+  IN     PRELINKED_CONTEXT  *PrelinkedContext,
+  IN OUT OC_MACHO_CONTEXT   *Context,
+  IN     UINT32             Delta
   );
 
 /**

--- a/Include/Acidanthera/Library/OcMachoLib.h
+++ b/Include/Acidanthera/Library/OcMachoLib.h
@@ -32,10 +32,11 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 /// only.  Members are not guaranteed to be sane.
 ///
 typedef struct {
-  MACH_HEADER_ANY          *MachHeader;
+  VOID                     *FileData;
   UINT32                   FileSize;
 
-  UINT32                   ContainerOffset;
+  MACH_HEADER_ANY          *MachHeader;
+  UINT32                   InnerSize;
   MACH_SYMTAB_COMMAND      *Symtab;
   MACH_NLIST_ANY           *SymbolTable;
   CHAR8                    *StringTable;
@@ -50,11 +51,12 @@ typedef struct {
 /**
   Initializes a 32-bit Mach-O Context.
 
-  @param[out] Context          Mach-O Context to initialize.
-  @param[in]  FileData         Pointer to the file's expected Mach-O header.
-  @param[in]  FileSize         File size of FileData.
-  @param[in]  ContainerOffset  The amount of Bytes the Mach-O header is offset
-                               from the base (container, e.g. KC) of the file.
+  @param[out] Context       Mach-O Context to initialize.
+  @param[in]  FileData      Pointer to the file's expected Mach-O header.
+  @param[in]  FileSize      File size of FileData.
+  @param[in]  HeaderOffset  The amount of Bytes the Mach-O header is offset from
+                            the base (container, e.g. KC) of the file.
+  @param[in]  InnerSize     The size, in Bytes, of the inner Mach-O file.
 
   @return  Whether Context has been initialized successfully.
 
@@ -64,17 +66,19 @@ MachoInitializeContext32 (
   OUT OC_MACHO_CONTEXT  *Context,
   IN  VOID              *FileData,
   IN  UINT32            FileSize,
-  IN  UINT32            ContainerOffset
+  IN  UINT32            HeaderOffset,
+  IN  UINT32            InnerSize
   );
 
 /**
   Initializes a 64-bit Mach-O Context.
 
-  @param[out] Context          Mach-O Context to initialize.
-  @param[in]  FileData         Pointer to the file's expected Mach-O header.
-  @param[in]  FileSize         File size of FileData.
-  @param[in]  ContainerOffset  The amount of Bytes the Mach-O header is offset
-                               from the base (container, e.g. KC) of the file.
+  @param[out] Context       Mach-O Context to initialize.
+  @param[in]  FileData      Pointer to the file's expected Mach-O header.
+  @param[in]  FileSize      File size of FileData.
+  @param[in]  HeaderOffset  The amount of Bytes the Mach-O header is offset from
+                            the base (container, e.g. KC) of the file.
+  @param[in]  InnerSize     The size, in Bytes, of the inner Mach-O file.
 
   @return  Whether Context has been initialized successfully.
 
@@ -84,18 +88,20 @@ MachoInitializeContext64 (
   OUT OC_MACHO_CONTEXT  *Context,
   IN  VOID              *FileData,
   IN  UINT32            FileSize,
-  IN  UINT32            ContainerOffset
+  IN  UINT32            HeaderOffset,
+  IN  UINT32            InnerSize
   );
 
 /**
   Initializes a Mach-O Context.
 
-  @param[out] Context          Mach-O Context to initialize.
-  @param[in]  FileData         Pointer to the file's expected Mach-O header.
-  @param[in]  FileSize         File size of FileData.
-  @param[in]  ContainerOffset  The amount of Bytes the Mach-O header is offset
-                               from the base (container, e.g. KC) of the file.
-  @param[in]  Is32Bit          TRUE if Mach-O is 32-bit.
+  @param[out] Context       Mach-O Context to initialize.
+  @param[in]  FileData      Pointer to the file's expected Mach-O header.
+  @param[in]  FileSize      File size of FileData.
+  @param[in]  HeaderOffset  The amount of Bytes the Mach-O header is offset from
+                            the base (container, e.g. KC) of the file.
+  @param[in]  InnerSize     The size, in Bytes, of the inner Mach-O file.
+  @param[in]  Is32Bit       TRUE if Mach-O is 32-bit.
 
   @return  Whether Context has been initialized successfully.
 
@@ -105,7 +111,8 @@ MachoInitializeContext (
   OUT OC_MACHO_CONTEXT  *Context,
   IN  VOID              *FileData,
   IN  UINT32            FileSize,
-  IN  UINT32            ContainerOffset,
+  IN  UINT32            HeaderOffset,
+  IN  UINT32            InnerSize,
   IN  BOOLEAN           Is32Bit
   );
 
@@ -117,6 +124,17 @@ MachoInitializeContext (
 **/
 MACH_HEADER_ANY *
 MachoGetMachHeader (
+  IN OUT OC_MACHO_CONTEXT  *Context
+  );
+
+/**
+  Returns the size of the inner Mach-O file (otherwise, the file size).
+
+  @param[in,out] Context  Context of the Mach-O.
+
+**/
+UINT32
+MachoGetInnerSize (
   IN OUT OC_MACHO_CONTEXT  *Context
   );
 
@@ -139,6 +157,17 @@ MachoGetMachHeader32 (
 **/
 MACH_HEADER_64 *
 MachoGetMachHeader64 (
+  IN OUT OC_MACHO_CONTEXT  *Context
+  );
+
+/**
+  Returns the file data of the Mach-O.
+
+  @param[in,out] Context  Context of the Mach-O.
+
+**/
+VOID *
+MachoGetFileData (
   IN OUT OC_MACHO_CONTEXT  *Context
   );
 

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -77,7 +77,7 @@ PatchAppleCpuPmCfgLock (
 
   Count     = 0;
   Walker    = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext);
-  WalkerEnd = Walker + MachoGetFileSize (&Patcher->MachContext) - mWrmsrMaxDistance;
+  WalkerEnd = Walker + MachoGetInnerSize (&Patcher->MachContext) - mWrmsrMaxDistance;
 
   //
   // Thanks to Clover developers for the approach.
@@ -254,7 +254,7 @@ PatchAppleXcpmCfgLock (
   }
 
   Last = (XCPM_MSR_RECORD *)((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
-                             + MachoGetFileSize (&Patcher->MachContext) - sizeof (XCPM_MSR_RECORD));
+                             + MachoGetInnerSize (&Patcher->MachContext) - sizeof (XCPM_MSR_RECORD));
 
   Replacements = 0;
 
@@ -381,7 +381,7 @@ PatchAppleXcpmExtraMsrs (
   }
 
   Last = (XCPM_MSR_RECORD *)((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
-                             + MachoGetFileSize (&Patcher->MachContext) - sizeof (XCPM_MSR_RECORD));
+                             + MachoGetInnerSize (&Patcher->MachContext) - sizeof (XCPM_MSR_RECORD));
 
   Replacements = 0;
 
@@ -509,7 +509,7 @@ PatchAppleXcpmForceBoost (
   }
 
   Start   = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext);
-  Last    = Start + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2;
+  Last    = Start + MachoGetInnerSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2;
   Start  += EFI_PAGE_SIZE;
   Current = Start;
 
@@ -1190,7 +1190,7 @@ PatchCustomPciSerialPmio (
 
   Count     = 0;
   Walker    = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext);
-  WalkerEnd = Walker + MachoGetFileSize (&Patcher->MachContext) - mInOutMaxDistance;
+  WalkerEnd = Walker + MachoGetInnerSize (&Patcher->MachContext) - mInOutMaxDistance;
 
   while (Walker < WalkerEnd) {
     if (  (Walker[0] == mSerialDevicePmioFind[0])
@@ -1385,7 +1385,7 @@ PatchPanicKextDump (
   }
 
   Last = ((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
-          + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE);
+          + MachoGetInnerSize (&Patcher->MachContext) - EFI_PAGE_SIZE);
 
   //
   // This should work on 10.15 and all debug kernels.
@@ -1811,7 +1811,7 @@ PatchSegmentJettison (
   }
 
   Last = (UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
-         + MachoGetFileSize (&Patcher->MachContext) - sizeof (EFI_PAGE_SIZE) * 2;
+         + MachoGetInnerSize (&Patcher->MachContext) - sizeof (EFI_PAGE_SIZE) * 2;
 
   Status = PatcherGetSymbolAddress (Patcher, "__ZN6OSKext19removeKextBootstrapEv", (UINT8 **)&RemoveBs);
   if (EFI_ERROR (Status) || (RemoveBs > Last)) {
@@ -2055,7 +2055,7 @@ PatchLegacyCommpage (
   ASSERT (Patcher != NULL);
 
   Start = ((UINT8 *)MachoGetMachHeader (&Patcher->MachContext));
-  Last  = Start + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2 - (Patcher->Is32Bit ? sizeof (COMMPAGE_DESCRIPTOR) : sizeof (COMMPAGE_DESCRIPTOR_64));
+  Last  = Start + MachoGetInnerSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2 - (Patcher->Is32Bit ? sizeof (COMMPAGE_DESCRIPTOR) : sizeof (COMMPAGE_DESCRIPTOR_64));
 
   //
   // This is a table of pointers to commpage entries.
@@ -2294,7 +2294,7 @@ PatchForceSecureBootScheme (
   //
 
   Last = ((UINT8 *)MachoGetMachHeader (&Patcher->MachContext)
-          + MachoGetFileSize (&Patcher->MachContext) - 64);
+          + MachoGetInnerSize (&Patcher->MachContext) - 64);
 
   Status = PatcherGetSymbolAddress (Patcher, "_img4_chip_select_effective_ap", &SelectAp);
   if (EFI_ERROR (Status) || (SelectAp > Last)) {

--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -815,7 +815,7 @@ PatchKernelCpuId (
     );
 
   Start = ((UINT8 *)MachoGetMachHeader (&Patcher->MachContext));
-  Last  = Start + MachoGetFileSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2 - sizeof (mKernelCpuIdFindRelNew);
+  Last  = Start + MachoGetInnerSize (&Patcher->MachContext) - EFI_PAGE_SIZE * 2 - sizeof (mKernelCpuIdFindRelNew);
 
   //
   // Do legacy patching for 32-bit 10.7, and 10.6 and older.

--- a/Library/OcAppleKernelLib/KextPatcher.c
+++ b/Library/OcAppleKernelLib/KextPatcher.c
@@ -155,7 +155,7 @@ PatcherInitContextFromBuffer (
   // and request PRELINK_KERNEL_IDENTIFIER.
   //
 
-  if (!MachoInitializeContext (&Context->MachContext, Buffer, BufferSize, 0, Is32Bit)) {
+  if (!MachoInitializeContext (&Context->MachContext, Buffer, BufferSize, 0, BufferSize, Is32Bit)) {
     DEBUG ((
       DEBUG_INFO,
       "OCAK: %a-bit patcher init from buffer %p %u has unsupported mach-o\n",
@@ -273,7 +273,7 @@ PatcherGetSymbolAddress (
     Index++;
   }
 
-  *Address = (UINT8 *)MachoGetMachHeader (&Context->MachContext) + Offset;
+  *Address = (UINT8 *)MachoGetFileData (&Context->MachContext) + Offset;
   return EFI_SUCCESS;
 }
 
@@ -289,7 +289,7 @@ PatcherApplyGenericPatch (
   UINT32      ReplaceCount;
 
   Base = (UINT8 *)MachoGetMachHeader (&Context->MachContext);
-  Size = MachoGetFileSize (&Context->MachContext);
+  Size = MachoGetInnerSize (&Context->MachContext);
   if (Patch->Base != NULL) {
     Status = PatcherGetSymbolAddress (Context, Patch->Base, &Base);
     if (EFI_ERROR (Status)) {
@@ -520,7 +520,7 @@ PatcherBlockKext (
   }
 
   MachBase = (UINT8 *)MachoGetMachHeader (&Context->MachContext);
-  MachSize = MachoGetFileSize (&Context->MachContext);
+  MachSize = MachoGetInnerSize (&Context->MachContext);
 
   //
   // Determine offset of kmod within file.

--- a/Library/OcAppleKernelLib/MkextContext.c
+++ b/Library/OcAppleKernelLib/MkextContext.c
@@ -1166,7 +1166,7 @@ MkextReserveKextSize (
 
   if (Executable != NULL) {
     ASSERT (ExecutableSize > 0);
-    if (!MachoInitializeContext (&Context, Executable, ExecutableSize, 0, Is32Bit)) {
+    if (!MachoInitializeContext (&Context, Executable, ExecutableSize, 0, ExecutableSize, Is32Bit)) {
       return EFI_INVALID_PARAMETER;
     }
 

--- a/Library/OcAppleKernelLib/PrelinkedContext.c
+++ b/Library/OcAppleKernelLib/PrelinkedContext.c
@@ -292,23 +292,6 @@ PrelinkedContextInit (
     return Status;
   }
 
-  Context->PrelinkedTextSegment = MachoGetSegmentByName (
-                                    &Context->PrelinkedMachContext,
-                                    PRELINK_TEXT_SEGMENT
-                                    );
-  if (Context->PrelinkedTextSegment == NULL) {
-    return EFI_NOT_FOUND;
-  }
-
-  Context->PrelinkedTextSection = MachoGetSectionByName (
-                                    &Context->PrelinkedMachContext,
-                                    Context->PrelinkedTextSegment,
-                                    PRELINK_TEXT_SECTION
-                                    );
-  if (Context->PrelinkedTextSection == NULL) {
-    return EFI_NOT_FOUND;
-  }
-
   if (Context->IsKernelCollection) {
     //
     // Additionally process special entries for KC.
@@ -335,6 +318,23 @@ PrelinkedContextInit (
                                  KC_LINKEDIT_SEGMENT
                                  );
     if (Context->LinkEditSegment == NULL) {
+      return EFI_NOT_FOUND;
+    }
+  } else {
+    Context->PrelinkedTextSegment = MachoGetSegmentByName (
+                                      &Context->PrelinkedMachContext,
+                                      PRELINK_TEXT_SEGMENT
+                                      );
+    if (Context->PrelinkedTextSegment == NULL) {
+      return EFI_NOT_FOUND;
+    }
+
+    Context->PrelinkedTextSection = MachoGetSectionByName (
+                                      &Context->PrelinkedMachContext,
+                                      Context->PrelinkedTextSegment,
+                                      PRELINK_TEXT_SECTION
+                                      );
+    if (Context->PrelinkedTextSection == NULL) {
       return EFI_NOT_FOUND;
     }
   }

--- a/Library/OcAppleKernelLib/Vtables.c
+++ b/Library/OcAppleKernelLib/Vtables.c
@@ -497,16 +497,16 @@ InternalInitializeVtablePatchData (
   OUT    MACH_NLIST_ANY        **SolveSymbols
   )
 {
-  BOOLEAN                Result;
-  UINT32                 VtableOffset;
-  UINT32                 VtableMaxSize;
-  CONST MACH_HEADER_ANY  *MachHeader;
-  VOID                   *VtableData;
-  UINT32                 SymIndex;
-  UINT32                 EntryOffset;
-  UINT64                 FileOffset;
-  UINT32                 MaxSymbols;
-  MACH_NLIST_ANY         *Symbol;
+  BOOLEAN         Result;
+  UINT32          VtableOffset;
+  UINT32          VtableMaxSize;
+  void            *FileData;
+  VOID            *VtableData;
+  UINT32          SymIndex;
+  UINT32          EntryOffset;
+  UINT64          FileOffset;
+  UINT32          MaxSymbols;
+  MACH_NLIST_ANY  *Symbol;
 
   Result = MachoSymbolGetFileOffset (
              MachoContext,
@@ -518,10 +518,10 @@ InternalInitializeVtablePatchData (
     return FALSE;
   }
 
-  MachHeader = MachoGetMachHeader (MachoContext);
-  ASSERT (MachHeader != NULL);
+  FileData = MachoGetFileData (MachoContext);
+  ASSERT (FileData != NULL);
 
-  VtableData = (VOID *)((UINTN)MachHeader + VtableOffset);
+  VtableData = (VOID *)((UINTN)FileData + VtableOffset);
   if (MachoContext->Is32Bit ? !OC_TYPE_ALIGNED (UINT32, VtableData) : !OC_TYPE_ALIGNED (UINT64, VtableData)) {
     return FALSE;
   }
@@ -591,7 +591,6 @@ InternalPatchByVtables (
   UINT32                 MaxSize;
 
   OC_MACHO_CONTEXT        *MachoContext;
-  CONST MACH_HEADER_ANY   *MachHeader;
   UINT32                  Index;
   UINT32                  NumTables;
   UINT32                  NumEntries;
@@ -620,9 +619,6 @@ InternalPatchByVtables (
   MaxSize = Context->LinkBufferSize;
 
   MachoContext = &Kext->Context.MachContext;
-
-  MachHeader = MachoGetMachHeader (MachoContext);
-  ASSERT (MachHeader != NULL);
   //
   // Retrieve all SMCPs.
   //

--- a/Library/OcMachoLib/Relocations.c
+++ b/Library/OcMachoLib/Relocations.c
@@ -159,7 +159,7 @@ InternalLookupSectionRelocationByOffset (
     //
     RelocationCount = Context->Is32Bit ? Section->Section32.NumRelocations : Section->Section64.NumRelocations;
     if (RelocationCount > 0) {
-      Relocations = (MACH_RELOCATION_INFO *)(((UINTN)(Context->MachHeader))
+      Relocations = (MACH_RELOCATION_INFO *)(((UINTN)(Context->FileData))
                                              + (Context->Is32Bit ? Section->Section32.RelocationsOffset : Section->Section64.RelocationsOffset));
 
       for (Index = 0; Index < RelocationCount; Index++) {

--- a/Library/OcMachoLib/SymbolsX.h
+++ b/Library/OcMachoLib/SymbolsX.h
@@ -235,7 +235,7 @@ MACH_X (
   Base   = Segment->FileOffset;
   Size   = Segment->Size;
 
-  *FileOffset = MACH_X_TO_UINT32 (Base - Context->ContainerOffset + Offset);
+  *FileOffset = MACH_X_TO_UINT32 (Base + Offset);
 
   if (MaxSize != NULL) {
     *MaxSize = MACH_X_TO_UINT32 (Size - Offset);
@@ -662,7 +662,7 @@ MACH_X (
     }
   }
 
-  *FileOffset = MACH_X_TO_UINT32 (Base - Context->ContainerOffset + Offset);
+  *FileOffset = MACH_X_TO_UINT32 (Base + Offset);
 
   if (MaxSize != NULL) {
     *MaxSize = MACH_X_TO_UINT32 (Size - Offset);

--- a/Utilities/TestMacho/Macho.c
+++ b/Utilities/TestMacho/Macho.c
@@ -37,7 +37,7 @@ FeedMacho (
 {
   OC_MACHO_CONTEXT  Context;
 
-  if (!MachoInitializeContext64 (&Context, File, Size, 0)) {
+  if (!MachoInitializeContext64 (&Context, File, Size, 0, Size)) {
     return -1;
   }
 


### PR DESCRIPTION
As of macOS 13 Developer Beta 3, the Kernel Collection's inner kernel
references a segment that precedes itself. The current model is that
a Kernel Collection is a container format and the included files are
(mostly) separate. Hence, this was treated as an out-of-bounds issue.
Kernel Collections apparently are rather an unconventional composite
format, where the sub-files are still part of the whole. Redesign
OcMachoLib to treat the Kernel Collection as the reference file.
Patches still use only the inner file, while parsing considers the
whole file.