### PR TITLE
OcMainLib: Patch order change

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -1254,6 +1254,13 @@ of \href{https://github.com/acidanthera/AptioFixPkg}{\text{AptioMemoryFix.efi}},
 which is no longer maintained. Refer to the \hyperref[troubleshootingtricks]{Tips and Tricks}
 section for instructions on migration.
 
+Booter changes apply with the following effective order:
+\begin{itemize}
+\tightlist
+\item \texttt{Quirks} are processed.
+\item \texttt{Patch} is processed.
+\end{itemize}
+
 If this is used for the first time on customised firmware, the following requirements
 should be met before starting:
 

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -847,10 +847,10 @@ ACPI changes apply globally (to every operating system) with the following effec
 
 \begin{itemize}
 \tightlist
-\item \texttt{Patch} is processed.
 \item \texttt{Delete} is processed.
-\item \texttt{Add} is processed.
 \item \texttt{Quirks} are processed.
+\item \texttt{Patch} is processed.
+\item \texttt{Add} is processed.
 \end{itemize}
 
 Applying the changes globally resolves the problems of incorrect operating system

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -1948,6 +1948,16 @@ Apple Kernel (\href{https://opensource.apple.com/source/xnu}{XNU}). The modifica
 currently provide driver (kext) injection, kernel and driver patching, and driver
 blocking.
 
+Kernel and kext changes apply with the following effective order:
+
+\begin{itemize}
+\tightlist
+\item \texttt{Block} is processed.
+\item \texttt{Emulate} and \texttt{Quirks} are processed.
+\item \texttt{Patch} is processed.
+\item \texttt{Add} and \texttt{Force} are processed.
+\end{itemize}
+
 \subsection{Properties}\label{kernelprops}
 
 \begin{enumerate}

--- a/Library/OcAfterBootCompatLib/ServiceOverrides.c
+++ b/Library/OcAfterBootCompatLib/ServiceOverrides.c
@@ -1262,16 +1262,6 @@ OcStartImage (
     }
   }
 
-  //
-  // Apply customised booter patches.
-  //
-  ApplyBooterPatches (
-    ImageHandle,
-    AppleLoadedImage != NULL,
-    BootCompat->Settings.BooterPatches,
-    BootCompat->Settings.BooterPatchesSize
-    );
-
   if (BootCompat->ServiceState.FwRuntime != NULL) {
     BootCompat->ServiceState.FwRuntime->GetCurrent (&Config);
 
@@ -1315,6 +1305,16 @@ OcStartImage (
                                           &Config
                                           );
   }
+
+  //
+  // Apply customised booter patches.
+  //
+  ApplyBooterPatches (
+    ImageHandle,
+    AppleLoadedImage != NULL,
+    BootCompat->Settings.BooterPatches,
+    BootCompat->Settings.BooterPatchesSize
+    );
 
   Status = BootCompat->ServicePtrs.StartImage (
                                      ImageHandle,

--- a/Library/OcMainLib/OpenCoreAcpi.c
+++ b/Library/OcMainLib/OpenCoreAcpi.c
@@ -211,15 +211,11 @@ OcLoadAcpiSupport (
     return;
   }
 
+  OcAcpiDeleteTables (Config, &Context);
+
   if (Config->Acpi.Quirks.RebaseRegions) {
     AcpiLoadRegions (&Context);
   }
-
-  OcAcpiPatchTables (Config, &Context);
-
-  OcAcpiDeleteTables (Config, &Context);
-
-  OcAcpiAddTables (Config, Storage, &Context);
 
   if (Config->Acpi.Quirks.FadtEnableReset) {
     AcpiFadtEnableReset (&Context);
@@ -245,6 +241,10 @@ OcLoadAcpiSupport (
   if (Config->Acpi.Quirks.SyncTableIds) {
     AcpiSyncTableIds (&Context);
   }
+
+  OcAcpiPatchTables (Config, &Context);
+
+  OcAcpiAddTables (Config, Storage, &Context);
 
   AcpiApplyContext (&Context);
 

--- a/Library/OcMainLib/OpenCoreKernel.c
+++ b/Library/OcMainLib/OpenCoreKernel.c
@@ -785,9 +785,9 @@ OcKernelProcessPrelinked (
   if (!EFI_ERROR (Status)) {
     OcKernelBlockKexts (Config, DarwinVersion, Is32Bit, CacheTypePrelinked, &Context);
 
-    OcKernelInjectKexts (Config, CacheTypePrelinked, &Context, DarwinVersion, Is32Bit, LinkedExpansion, ReservedExeSize);
-
     OcKernelApplyPatches (Config, mOcCpuInfo, DarwinVersion, Is32Bit, CacheTypePrelinked, &Context, NULL, 0);
+
+    OcKernelInjectKexts (Config, CacheTypePrelinked, &Context, DarwinVersion, Is32Bit, LinkedExpansion, ReservedExeSize);
 
     *KernelSize = Context.PrelinkedSize;
 
@@ -818,9 +818,9 @@ OcKernelProcessMkext (
 
   OcKernelBlockKexts (Config, DarwinVersion, Is32Bit, CacheTypeMkext, &Context);
 
-  OcKernelInjectKexts (Config, CacheTypeMkext, &Context, DarwinVersion, Is32Bit, 0, 0);
-
   OcKernelApplyPatches (Config, mOcCpuInfo, DarwinVersion, Is32Bit, CacheTypeMkext, &Context, NULL, 0);
+
+  OcKernelInjectKexts (Config, CacheTypeMkext, &Context, DarwinVersion, Is32Bit, 0, 0);
 
   MkextInjectPatchComplete (&Context);
 
@@ -857,9 +857,9 @@ OcKernelInitCacheless (
 
   OcKernelBlockKexts (Config, DarwinVersion, Is32Bit, CacheTypeCacheless, Context);
 
-  OcKernelInjectKexts (Config, CacheTypeCacheless, Context, DarwinVersion, Is32Bit, 0, 0);
-
   OcKernelApplyPatches (Config, mOcCpuInfo, DarwinVersion, Is32Bit, CacheTypeCacheless, Context, NULL, 0);
+
+  OcKernelInjectKexts (Config, CacheTypeCacheless, Context, DarwinVersion, Is32Bit, 0, 0);
 
   return CachelessContextOverlayExtensionsDir (Context, File);
 }


### PR DESCRIPTION
The current behaviors of how our modification to `Booter` and `Kernel` are undocumented. In addition, we should ensure that:
- Deletion is always performed first, as it makes no sense to patch something that will be removed
- Integrated quirks are always applied preceding user patches (to prevent users from messing up the whole patch structure)
- Injection is performed last

TODO:
- [ ] Rebuild pdf