### PR TITLE
OCAB: Implement macOS 10.4/10.5 relocation block support

### DIFF
--- a/Include/Acidanthera/Library/OcDeviceTreeLib.h
+++ b/Include/Acidanthera/Library/OcDeviceTreeLib.h
@@ -18,8 +18,8 @@
 //
 // Device tree property name prefixes for loaded kexts or mkext.
 //
-#define DT_BOOTER_KEXT_PREFIX    "Driver-"
-#define DT_BOOTER_MKEXT_PREFIX   "DriversPackage-"
+#define DT_BOOTER_KEXT_PREFIX   "Driver-"
+#define DT_BOOTER_MKEXT_PREFIX  "DriversPackage-"
 
 //
 // Struct at the beginning of every loaded kext (10.4 and 10.5).

--- a/Include/Acidanthera/Library/OcDeviceTreeLib.h
+++ b/Include/Acidanthera/Library/OcDeviceTreeLib.h
@@ -16,7 +16,25 @@
 #define OC_DEVICE_TREE_LIB_H
 
 //
-// Struct at the beginning of every loaded kext.
+// Device tree property name prefixes for loaded kexts or mkext.
+//
+#define DT_BOOTER_KEXT_PREFIX    "Driver-"
+#define DT_BOOTER_MKEXT_PREFIX   "DriversPackage-"
+
+//
+// Struct at the beginning of every loaded kext (10.4 and 10.5).
+// Pointers to every loaded kext (to this struct) are
+// properties Driver-<hex addr of DriverInfo> in DevTree /chosen/memory-map.
+//
+typedef struct DTBootxDriverInfo_ {
+  UINT32    PlistPhysAddr;
+  UINT32    PlistLength;
+  UINT32    ModuleAddress;
+  UINT32    ModuleLength;
+} DTBootxDriverInfo;
+
+//
+// Struct at the beginning of every loaded kext (10.6 and newer).
 // Pointers to every loaded kext (to this struct) are
 // properties Driver-<hex addr of DriverInfo> in DevTree /chosen/memory-map.
 //

--- a/Include/Apple/IndustryStandard/AppleBootArgs.h
+++ b/Include/Apple/IndustryStandard/AppleBootArgs.h
@@ -111,9 +111,9 @@ typedef struct {
   UINT8           efiMode;              /* 32 = 32-bit, 64 = 64-bit */
   UINT8           __reserved1[3];
   UINT32          __reserved2[1];
-  UINT32          performanceDataStart; /* physical address of log */
+  UINT32          performanceDataStart; /* physical address of log, 10.6 and up */
   UINT32          performanceDataSize;
-  UINT64          efiRuntimeServicesVirtualPageStart; /* virtual address of defragmented runtime pages */
+  UINT64          efiRuntimeServicesVirtualPageStart; /* virtual address of defragmented runtime pages, 10.6 and up */
   UINT32          __reserved3[2];
 } BootArgs1;
 

--- a/Library/OcAfterBootCompatLib/BootCompatInternal.h
+++ b/Library/OcAfterBootCompatLib/BootCompatInternal.h
@@ -64,9 +64,14 @@
 #define KERNEL_HIB_VADDR  ((UINTN) (0xFFFFFF8000100000ULL & MAX_UINTN))
 
 /**
-  Kernel __TEXT segment virtual address.
+  Kernel __TEXT segment virtual address (macOS 10.6 and higher).
 **/
 #define KERNEL_TEXT_VADDR  ((UINTN) (0xFFFFFF8000200000ULL & MAX_UINTN))
+
+/**
+  Kernel __TEXT segment virtual address (macOS 10.4 and 10.5).
+**/
+#define KERNEL_TEXT_VADDR_LEGACY  ((UINT32) (0x111000 & MAX_UINT32))
 
 /**
   Kernel physical base address.
@@ -74,9 +79,14 @@
 #define KERNEL_BASE_PADDR  ((UINT32) (KERNEL_HIB_VADDR & MAX_UINT32))
 
 /**
-  Kernel physical base address.
+  Kernel __TEXT physical base address (macOS 10.6 and higher).
 **/
 #define KERNEL_TEXT_PADDR  ((UINT32) (KERNEL_TEXT_VADDR & MAX_UINT32))
+
+/**
+  Kernel __TEXT physical base address (macOS 10.4 and 10.5).
+**/
+#define KERNEL_TEXT_PADDR_LEGACY  (KERNEL_TEXT_VADDR_LEGACY)
 
 /**
   Slide offset per slide entry
@@ -355,6 +365,10 @@ typedef struct KERNEL_SUPPORT_STATE_ {
   /// This value should match ksize in XNU BootArgs.
   ///
   UINTN                   RelocationBlockUsed;
+  ///
+  /// Relocation block is being used on macOS 10.4 or 10.5.
+  ///
+  BOOLEAN                 RelocationBlockLegacy;
 } KERNEL_SUPPORT_STATE;
 
 /**
@@ -413,7 +427,7 @@ typedef struct SLIDE_SUPPORT_STATE_ {
 **/
 typedef struct BOOT_COMPAT_CONTEXT_ {
   ///
-  /// Apple Coot Compatibility settings.
+  /// Apple Boot Compatibility settings.
   ///
   OC_ABC_SETTINGS            Settings;
   ///

--- a/Library/OcAfterBootCompatLib/BootCompatInternal.h
+++ b/Library/OcAfterBootCompatLib/BootCompatInternal.h
@@ -71,7 +71,7 @@
 /**
   Kernel __TEXT segment virtual address (macOS 10.4 and 10.5).
 **/
-#define KERNEL_TEXT_VADDR_LEGACY  ((UINT32) (0x111000 & MAX_UINT32))
+#define KERNEL_TEXT_VADDR_LEGACY  0x111000
 
 /**
   Kernel physical base address.

--- a/Library/OcAfterBootCompatLib/KernelSupport.c
+++ b/Library/OcAfterBootCompatLib/KernelSupport.c
@@ -384,10 +384,10 @@ AppleMapPrepareForBooting (
     }
   }
 
-  if (BootCompat->KernelState.RelocationBlock != 0) {
+  if (BootCompat->KernelState.RelocationBlock != 0 && !BootCompat->KernelState.RelocationBlockLegacy) {
     //
-    // When using Relocation Block EfiBoot will not virtualize the addresses since they
-    // cannot be mapped 1:1 due to any region from the relocation block being outside
+    // When using Relocation Block, EfiBoot on macOS 10.6 and newer will not virtualize the addresses
+    // since they cannot be mapped 1:1 due to any region from the relocation block being outside
     // of static XNU vaddr to paddr mapping. This causes a clean early exit in their
     // SetVirtualAddressMap calling routine avoiding gRT->SetVirtualAddressMap.
     //
@@ -687,7 +687,10 @@ AppleMapPrepareMemState (
   IN     EFI_MEMORY_DESCRIPTOR  *MemoryMap
   )
 {
-  EFI_STATUS  Status;
+  EFI_STATUS             Status;
+  UINTN                  NumEntries;
+  UINTN                  Index;
+  EFI_MEMORY_DESCRIPTOR  *Desc;
 
   //
   // Protect RT areas from relocation by marking then MemMapIO.
@@ -701,6 +704,25 @@ AppleMapPrepareMemState (
       BootCompat->KernelState.SysTableRtArea,
       BootCompat->KernelState.SysTableRtAreaSize
       );
+  }
+
+  //
+  // macOS 10.4 and 10.5 always call SetVirtualAddressMap, even when using a relocation block.
+  // Perform adjustment of virtual addresses here to their final positions.
+  //
+  if (BootCompat->KernelState.RelocationBlockLegacy) {
+    Desc       = MemoryMap;
+    NumEntries = MemoryMapSize / DescriptorSize;
+
+    for (Index = 0; Index < NumEntries; ++Index) {
+      if (  Desc->VirtualStart >= BootCompat->KernelState.RelocationBlock + BootCompat->KernelState.RelocationBlockUsed
+         && Desc->VirtualStart < BootCompat->KernelState.RelocationBlock + ESTIMATED_KERNEL_SIZE)
+      {
+        Desc->VirtualStart -= BootCompat->KernelState.RelocationBlock - KERNEL_BASE_PADDR;
+      }
+
+      Desc = NEXT_MEMORY_DESCRIPTOR (Desc, DescriptorSize);
+    }
   }
 
   //

--- a/Library/OcAfterBootCompatLib/KernelSupport.c
+++ b/Library/OcAfterBootCompatLib/KernelSupport.c
@@ -384,7 +384,7 @@ AppleMapPrepareForBooting (
     }
   }
 
-  if (BootCompat->KernelState.RelocationBlock != 0 && !BootCompat->KernelState.RelocationBlockLegacy) {
+  if ((BootCompat->KernelState.RelocationBlock != 0) && !BootCompat->KernelState.RelocationBlockLegacy) {
     //
     // When using Relocation Block, EfiBoot on macOS 10.6 and newer will not virtualize the addresses
     // since they cannot be mapped 1:1 due to any region from the relocation block being outside
@@ -715,8 +715,8 @@ AppleMapPrepareMemState (
     NumEntries = MemoryMapSize / DescriptorSize;
 
     for (Index = 0; Index < NumEntries; ++Index) {
-      if (  Desc->VirtualStart >= BootCompat->KernelState.RelocationBlock + BootCompat->KernelState.RelocationBlockUsed
-         && Desc->VirtualStart < BootCompat->KernelState.RelocationBlock + ESTIMATED_KERNEL_SIZE)
+      if (  (Desc->VirtualStart >= BootCompat->KernelState.RelocationBlock + BootCompat->KernelState.RelocationBlockUsed)
+         && (Desc->VirtualStart < BootCompat->KernelState.RelocationBlock + ESTIMATED_KERNEL_SIZE))
       {
         Desc->VirtualStart -= BootCompat->KernelState.RelocationBlock - KERNEL_BASE_PADDR;
       }

--- a/Library/OcAfterBootCompatLib/RelocationBlock.c
+++ b/Library/OcAfterBootCompatLib/RelocationBlock.c
@@ -311,7 +311,7 @@ AppleRelocationRebase (
   // On macOS 10.6 and newer, we need to adjust it like the others.
   //
   if (!BootCompat->KernelState.RelocationBlockLegacy) {
-    *BA->SystemTableP  -= RelocDiff;
+    *BA->SystemTableP -= RelocDiff;
   } else {
     *BA->MemoryMapSize -= (*BA->MemoryMapDescriptorSize * 4);
   }

--- a/Library/OcAfterBootCompatLib/RelocationBlock.c
+++ b/Library/OcAfterBootCompatLib/RelocationBlock.c
@@ -359,7 +359,7 @@ AppleRelocationRebase (
       }
 
       PrevDescAddress = Desc->PhysicalStart;
-      Desc = NEXT_MEMORY_DESCRIPTOR (Desc, DescriptorSize);
+      Desc            = NEXT_MEMORY_DESCRIPTOR (Desc, DescriptorSize);
     }
 
     *BA->MemoryMapSize -= (DescriptorSize * (NumEntries - Index));

--- a/Library/OcAfterBootCompatLib/RelocationBlock.c
+++ b/Library/OcAfterBootCompatLib/RelocationBlock.c
@@ -355,14 +355,13 @@ AppleRelocationRebase (
     //
     for (Index = 0; Index < NumEntries; ++Index) {
       if (Desc->PhysicalStart < PrevDescAddress) {
+        *BA->MemoryMapSize -= (DescriptorSize * (NumEntries - Index));
         break;
       }
 
       PrevDescAddress = Desc->PhysicalStart;
       Desc            = NEXT_MEMORY_DESCRIPTOR (Desc, DescriptorSize);
     }
-
-    *BA->MemoryMapSize -= (DescriptorSize * (NumEntries - Index));
   }
 
   *BA->MemoryMap         -= RelocDiff;

--- a/Library/OcAfterBootCompatLib/RelocationBlock.c
+++ b/Library/OcAfterBootCompatLib/RelocationBlock.c
@@ -311,7 +311,7 @@ AppleRelocationRebase (
   // On macOS 10.6 and newer, we need to adjust it like the others.
   //
   if (!BootCompat->KernelState.RelocationBlockLegacy) {
-    *BA->SystemTableP      -= RelocDiff;
+    *BA->SystemTableP  -= RelocDiff;
   } else {
     *BA->MemoryMapSize -= (*BA->MemoryMapDescriptorSize * 4);
   }

--- a/Library/OcAfterBootCompatLib/RelocationBlock.c
+++ b/Library/OcAfterBootCompatLib/RelocationBlock.c
@@ -263,11 +263,11 @@ AppleRelocationRebase (
   DTPropertyIterator        PropIter;
   DTBooterKextFileInfo      *BooterKextFileInfo;
   DTBootxDriverInfo         *BootxDriverInfo;
-  UINTN                     MemoryMapSize;
-  UINTN                     DescriptorSize;
+  UINT32                    MemoryMapSize;
+  UINT32                    DescriptorSize;
   EFI_MEMORY_DESCRIPTOR     *MemoryMap;
-  UINTN                     NumEntries;
-  UINTN                     Index;
+  UINT32                    NumEntries;
+  UINT32                    Index;
   EFI_MEMORY_DESCRIPTOR     *Desc;
   EFI_PHYSICAL_ADDRESS      DescLargestAddress;
   UINT32                    RelocDiff;

--- a/Library/OcAfterBootCompatLib/RelocationBlock.c
+++ b/Library/OcAfterBootCompatLib/RelocationBlock.c
@@ -306,12 +306,12 @@ AppleRelocationRebase (
           // 10.6 and newer use a different format from 10.4 and 10.5.
           //
           if (!BootCompat->KernelState.RelocationBlockLegacy) {
-            BooterKextFileInfo = (DTBooterKextFileInfo *)((UINTN)PropValue->Address);
+            BooterKextFileInfo                      = (DTBooterKextFileInfo *)((UINTN)PropValue->Address);
             BooterKextFileInfo->InfoDictPhysAddr   -= RelocDiff;
             BooterKextFileInfo->ExecutablePhysAddr -= RelocDiff;
             BooterKextFileInfo->BundlePathPhysAddr -= RelocDiff;
           } else {
-            BootxDriverInfo = (DTBootxDriverInfo *)((UINTN)PropValue->Address);
+            BootxDriverInfo                 = (DTBootxDriverInfo *)((UINTN)PropValue->Address);
             BootxDriverInfo->PlistPhysAddr -= RelocDiff;
             BootxDriverInfo->ModuleAddress -= RelocDiff;
           }

--- a/Library/OcAfterBootCompatLib/ServiceOverrides.c
+++ b/Library/OcAfterBootCompatLib/ServiceOverrides.c
@@ -674,6 +674,11 @@ OcGetMemoryMap (
         MemoryMap,
         *DescriptorSize
         );
+    } else if (BootCompat->Settings.AllowRelocationBlock) {
+      //
+      // A sorted memory map is required when using a relocation block.
+      //
+      OcSortMemoryMap (*MemoryMapSize, MemoryMap, *DescriptorSize);
     }
 
     //


### PR DESCRIPTION
Implements macOS 10.4 and 10.5 support for relocation blocks while using the AllowRelocationBlock booter quirk.

This is required due to XNU in 10.4 and 10.5 having a _TEXT base address of 0x111000, different from 0x200000 in 10.6 and later. SetVirtualAddressMap is also always invoked by EfiBoot even when using a relocation block.