### PR TITLE
OpenCanopy: Avoid invalid animation state when returning to menu after starting entry with animated label

### DIFF
--- a/Platform/OpenCanopy/Views/BootPicker.c
+++ b/Platform/OpenCanopy/Views/BootPicker.c
@@ -1990,6 +1990,9 @@ BootPickerViewInitialize (
   // Conditions for delta function:
   //
 
+  mBootPickerLabelAnimation.Link.BackLink    = &mBootPickerLabelAnimation.Link;
+  mBootPickerLabelAnimation.Link.ForwardLink = &mBootPickerLabelAnimation.Link;
+
   if (!GuiContext->DoneIntroAnimation) {
     InitBpAnimIntro (DrawContext);
     InsertHeadList (&DrawContext->Animations, &mBootPickerIntroAnimation.Link);


### PR DESCRIPTION
@mhaeuser - sent pm explaining reasoning behind this and possible alternative/additional options for related changes.