### PR TITLE
ocpasswordgen: Hide password characters on input

### DIFF
--- a/Utilities/ocpasswordgen/ocpasswordgen.c
+++ b/Utilities/ocpasswordgen/ocpasswordgen.c
@@ -4,10 +4,47 @@
 **/
 
 #include <stdio.h>
+#ifdef _WIN32
+#include <conio.h>
+#else
+#include <termios.h>
+#include <unistd.h>
+#endif
 
 #include <Library/DebugLib.h>
 #include <Library/OcCryptoLib.h>
 #include <UserPseudoRandom.h>
+
+//
+// Signal Interrupt Control-C symbol
+//
+#define CHAR_END_OF_TEXT 3
+#define CHAR_DELETE      127
+
+#ifndef _WIN32
+/**
+ * getch unix-compatible implementation
+ *
+ * @return integer with ch codenumber
+ */
+int
+getch (
+  void
+  )
+{
+    int Char;
+    struct termios OldTtyAttrs, NewTtyAttrs;
+
+    tcgetattr(STDIN_FILENO, &OldTtyAttrs);
+    NewTtyAttrs = OldTtyAttrs;
+    NewTtyAttrs.c_lflag = NewTtyAttrs.c_lflag & ~(ICANON|ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &NewTtyAttrs);
+    Char = getchar();
+    tcsetattr(STDIN_FILENO, TCSANOW, &OldTtyAttrs);
+
+    return Char;
+}
+#endif
 
 int
 ENTRY_POINT (
@@ -21,12 +58,33 @@ ENTRY_POINT (
   UINT8   Index;
   UINT8   PasswordHash[SHA512_DIGEST_SIZE];
 
-  DEBUG ((DEBUG_ERROR, "Please enter your password: "));
+  DEBUG ((DEBUG_ERROR, "Please enter your password: \n"));
 
   for (PasswordLen = 0; PasswordLen < OC_PASSWORD_MAX_LEN; ++PasswordLen) {
-    Char = getchar ();
-    if ((Char == EOF) || (Char == '\n')) {
+    fflush(stdin);
+    Char = getch ();
+    // Handle interrupt signal for conio
+    if (Char == CHAR_END_OF_TEXT) {
+      exit(EXIT_SUCCESS);
+    }
+    if (Char == EOF || Char == CHAR_LINEFEED) {
       break;
+    }
+    if (Char == CHAR_CARRIAGE_RETURN) {
+      continue;
+    }
+    if (Char == CHAR_BACKSPACE || Char == CHAR_DELETE) {
+      if (PasswordLen > 0) {
+        DEBUG ((DEBUG_ERROR, "\b \b"));
+        PasswordLen--;
+      }
+      continue;
+    }
+
+    if (Char == ' ') {
+      DEBUG ((DEBUG_ERROR, " "));
+    } else {
+      DEBUG ((DEBUG_ERROR, "*"));
     }
 
     Password[PasswordLen] = (UINT8)Char;
@@ -49,7 +107,7 @@ ENTRY_POINT (
     DEBUG ((DEBUG_ERROR, "%02x", PasswordHash[Index]));
   }
 
-  printf (">\nPasswordSalt: <");
+  DEBUG ((DEBUG_ERROR, ">\nPasswordSalt: <"));
   for (Index = 0; Index < sizeof (Salt); ++Index) {
     DEBUG ((DEBUG_ERROR, "%02x", ((UINT8 *)Salt)[Index]));
   }

--- a/Utilities/ocpasswordgen/ocpasswordgen.c
+++ b/Utilities/ocpasswordgen/ocpasswordgen.c
@@ -5,10 +5,10 @@
 
 #include <stdio.h>
 #ifdef _WIN32
-#include <conio.h>
+  #include <conio.h>
 #else
-#include <termios.h>
-#include <unistd.h>
+  #include <termios.h>
+  #include <unistd.h>
 #endif
 
 #include <Library/DebugLib.h>
@@ -18,10 +18,11 @@
 //
 // Signal Interrupt Control-C symbol
 //
-#define CHAR_END_OF_TEXT 3
-#define CHAR_DELETE      127
+#define CHAR_END_OF_TEXT  3
+#define CHAR_DELETE       127
 
 #ifndef _WIN32
+
 /**
  * getch unix-compatible implementation
  *
@@ -32,18 +33,19 @@ getch (
   void
   )
 {
-    int Char;
-    struct termios OldTtyAttrs, NewTtyAttrs;
+  int             Char;
+  struct termios  OldTtyAttrs, NewTtyAttrs;
 
-    tcgetattr(STDIN_FILENO, &OldTtyAttrs);
-    NewTtyAttrs = OldTtyAttrs;
-    NewTtyAttrs.c_lflag = NewTtyAttrs.c_lflag & ~(ICANON|ECHO);
-    tcsetattr(STDIN_FILENO, TCSANOW, &NewTtyAttrs);
-    Char = getchar();
-    tcsetattr(STDIN_FILENO, TCSANOW, &OldTtyAttrs);
+  tcgetattr (STDIN_FILENO, &OldTtyAttrs);
+  NewTtyAttrs         = OldTtyAttrs;
+  NewTtyAttrs.c_lflag = NewTtyAttrs.c_lflag & ~(ICANON|ECHO);
+  tcsetattr (STDIN_FILENO, TCSANOW, &NewTtyAttrs);
+  Char = getchar ();
+  tcsetattr (STDIN_FILENO, TCSANOW, &OldTtyAttrs);
 
-    return Char;
+  return Char;
 }
+
 #endif
 
 int
@@ -58,33 +60,31 @@ ENTRY_POINT (
   UINT8   Index;
   UINT8   PasswordHash[SHA512_DIGEST_SIZE];
 
-  DEBUG ((DEBUG_ERROR, "Please enter your password: \n"));
+  printf ("Please enter your password: ");
 
   for (PasswordLen = 0; PasswordLen < OC_PASSWORD_MAX_LEN; ++PasswordLen) {
-    fflush(stdin);
+    fflush (stdin);
     Char = getch ();
+
     // Handle interrupt signal for conio
     if (Char == CHAR_END_OF_TEXT) {
-      exit(EXIT_SUCCESS);
+      exit (EXIT_FAILURE);
     }
-    if (Char == EOF || Char == CHAR_LINEFEED) {
+
+    if ((Char == EOF) || (Char == CHAR_LINEFEED)) {
       break;
     }
+
     if (Char == CHAR_CARRIAGE_RETURN) {
       continue;
     }
-    if (Char == CHAR_BACKSPACE || Char == CHAR_DELETE) {
-      if (PasswordLen > 0) {
-        DEBUG ((DEBUG_ERROR, "\b \b"));
-        PasswordLen--;
-      }
-      continue;
-    }
 
-    if (Char == ' ') {
-      DEBUG ((DEBUG_ERROR, " "));
-    } else {
-      DEBUG ((DEBUG_ERROR, "*"));
+    if ((Char == CHAR_BACKSPACE) || (Char == CHAR_DELETE)) {
+      if (PasswordLen > 0) {
+        --PasswordLen;
+      }
+
+      continue;
     }
 
     Password[PasswordLen] = (UINT8)Char;
@@ -102,17 +102,17 @@ ENTRY_POINT (
     PasswordHash
     );
 
-  DEBUG ((DEBUG_ERROR, "\nPasswordHash: <"));
+  printf ("\nPasswordHash: <");
   for (Index = 0; Index < sizeof (PasswordHash); ++Index) {
-    DEBUG ((DEBUG_ERROR, "%02x", PasswordHash[Index]));
+    printf ("%02x", PasswordHash[Index]);
   }
 
-  DEBUG ((DEBUG_ERROR, ">\nPasswordSalt: <"));
+  printf (">\nPasswordSalt: <");
   for (Index = 0; Index < sizeof (Salt); ++Index) {
-    DEBUG ((DEBUG_ERROR, "%02x", ((UINT8 *)Salt)[Index]));
+    printf ("%02x", ((UINT8 *)Salt)[Index]);
   }
 
-  DEBUG ((DEBUG_ERROR, ">\n"));
+  printf (">\n");
 
   SecureZeroMem (Password, sizeof (Password));
   SecureZeroMem (PasswordHash, sizeof (PasswordHash));

--- a/Utilities/ocpasswordgen/ocpasswordgen.c
+++ b/Utilities/ocpasswordgen/ocpasswordgen.c
@@ -71,12 +71,9 @@ ENTRY_POINT (
       exit (EXIT_FAILURE);
     }
 
-    if ((Char == EOF) || (Char == CHAR_LINEFEED)) {
+    if ((Char == EOF) || (Char == CHAR_LINEFEED) || (Char == CHAR_CARRIAGE_RETURN)) {
+      Password[PasswordLen] = '\0';
       break;
-    }
-
-    if (Char == CHAR_CARRIAGE_RETURN) {
-      continue;
     }
 
     if ((Char == CHAR_BACKSPACE) || (Char == CHAR_DELETE)) {


### PR DESCRIPTION
This changes should hides characters on password input. In this case I use getch from conio.h library on Windows and also implemented getch for unix using unistd and termios standard libraries.