### PR TITLE
Remove Redundant/Confusing Failsafe Definitions

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -2217,7 +2217,7 @@ Kernel and kext changes apply with the following effective order:
   \emph{Note}: It is risky to \texttt{Exclude} a kext that is a dependency of others.
 
   \emph{Note 2}: At this moment \texttt{Exclude} is only applied to \texttt{prelinkedkernel} and newer mechanisms.
-  
+
   \emph{Note 3}: In most cases strategy \texttt{Exclude} requires the new kext to be injected as a replacement.
 
 \end{enumerate}
@@ -3422,7 +3422,7 @@ the default boot entry choice will remain changed until the next manual reconfig
   It is also possible to use \texttt{efibootmgr} within Linux to remove the offending entry, if you have a working
   version of Linux on the machine. Linux must be started either not via OpenCore, or via OpenCore with \texttt{RequestBootVarRouting} disabled
   for this to work.
-  
+
 \item
   \texttt{LauncherPath}\\
   \textbf{Type}: \texttt{plist\ string}\\
@@ -3621,7 +3621,7 @@ the default boot entry choice will remain changed until the next manual reconfig
   held down. Earlier than this, the key press may not be registered. On some platforms,
   setting this option to a minimum of \texttt{5000-10000} microseconds is also required
   to access \texttt{action hotkeys} due to the nature of the keyboard driver.
-  
+
   If the boot chime is configured (see audio configuration options) then at the expense
   of slower startup, an even longer delay of half to one second (\texttt{500000-1000000})
   may be used to create behaviour similar to a real Mac, where the chime itself can be used
@@ -6769,7 +6769,7 @@ options for the driver may be specified in \texttt{UEFI/Drivers/Arguments}:
   output of \texttt{ls -l /dev/disk/by-partuuid}. \medskip
 
 	\item \texttt{autoopts[+]="\{options\}"} - Default: None specified. \medskip
-  
+
   Allows manually specifying kernel options to use in autodetect mode. The alternative format \texttt{autoopts:\{PARTUUID\}}
   is more suitable where there are multiple distros, but \texttt{autoopts} with no PARTUUID required may be more
   convenient for just one distro.
@@ -7141,21 +7141,18 @@ for additional options.
 \item
   \texttt{APFS}\\
   \textbf{Type}: \texttt{plist\ dict}\\
-  \textbf{Failsafe}: None\\
   \textbf{Description}: Provide APFS support as configured in the
   \hyperref[uefiapfsprops]{APFS Properties} section below.
 
 \item
   \texttt{AppleInput}\\
   \textbf{Type}: \texttt{plist\ dict}\\
-  \textbf{Failsafe}: None\\
   \textbf{Description}: Configure the re-implementation of the Apple Event protocol
   described in the \hyperref[uefiappleinputprops]{AppleInput Properties} section below.
 
 \item
   \texttt{Audio}\\
   \textbf{Type}: \texttt{plist\ dict}\\
-  \textbf{Failsafe}: None\\
   \textbf{Description}: Configure audio backend support described
   in the \hyperref[uefiaudioprops]{\texttt{Audio Properties}} section below.
 
@@ -7226,21 +7223,18 @@ for additional options.
 \item
   \texttt{Input}\\
   \textbf{Type}: \texttt{plist\ dict}\\
-  \textbf{Failsafe}: None\\
   \textbf{Description}: Apply individual settings designed for input (keyboard and mouse) in the
   \hyperref[uefiinputprops]{Input Properties} section below.
 
 \item
   \texttt{Output}\\
   \textbf{Type}: \texttt{plist\ dict}\\
-  \textbf{Failsafe}: None\\
   \textbf{Description}: Apply individual settings designed for output (text and graphics) in the
   \hyperref[uefioutputprops]{Output Properties} section below.
 
 \item
   \texttt{ProtocolOverrides}\\
   \textbf{Type}: \texttt{plist\ dict}\\
-  \textbf{Failsafe}: None\\
   \textbf{Description}: Force builtin versions of certain protocols described
   in the \hyperref[uefiprotoprops]{ProtocolOverrides Properties} section below.
 
@@ -7249,7 +7243,6 @@ for additional options.
 \item
   \texttt{Quirks}\\
   \textbf{Type}: \texttt{plist\ dict}\\
-  \textbf{Failsafe}: None\\
   \textbf{Description}: Apply individual firmware quirks described in the
   \hyperref[uefiquirkprops]{Quirks Properties} section below.
 
@@ -7635,7 +7628,7 @@ for additional options.
   \texttt{HDA: Connecting controller - \textit{\textbf{PciRoot(0x0)/Pci(0x1B,0x0)}}}
 
   Finally, \texttt{gfxutil -f HDEF} command can be used in macOS to obtain the device path.
-  
+
   Specifying an empty device path results in the first available codec and audio controller being used. The value
   of \texttt{AudioCodec} is ignored in this case. This can be a convenient initial option to try to get UEFI
   audio working. Manual settings as above will be required when this default value does not work.
@@ -7666,9 +7659,9 @@ for additional options.
   \texttt{HDA:  | Port widget @ 0x10 is an output (pin defaults 0x4BE030) (\textit{\textbf{bitmask 8}})}
 
   Further information on the available output channels may be found from a Linux codec dump using the command:
-  
+
   \texttt{cat /proc/asound/card\{n\}/codec\#\{m\}}
-  
+
   Using \texttt{AudioOutMask}, it is possible to play sound to more than one channel (e.g. main speaker plus bass speaker;
   headphones plus speakers) as long as all the chosen outputs support the sound file format in use; if any do not then no
   sound will play and a warning will be logged.
@@ -7711,7 +7704,7 @@ for additional options.
   All UEFI audio will use this gain setting when the system amplifier gain read from the \texttt{SystemAudioVolumeDB}
   NVRAM variable is higher than this. This is to avoid over-loud UEFI audio when the system volume is set very high,
   or the \texttt{SystemAudioVolumeDB} NVRAM value has been misconfigured.
-  
+
   \emph{Note 1}: Decibels (dB) specify gain (postive values; increase in volume) or attenuation (negative values; decrease
   in volume) compared to some reference level. When you hear the sound level of a jet plane expressed as 120 decibels, say,
   the reference level is the sound level just audible to an average human. However generally
@@ -7719,7 +7712,7 @@ for additional options.
   decibels to specify volume level. On most Intel HDA hardware the reference level of 0 dB is the
   \emph{loudest} volume of the hardware, and all lower volumes are therefore negative numbers. The quietest volume
   on typical sound hardware is around -55 dB to -60 dB.
-  
+
   \emph{Note 2}: Matching how macOS handles decibel values, this value is converted to a signed byte; therefore values
   outside $-128$ dB to $+127$ dB (which are well beyond physically plausible volume levels) are not allowed.
 


### PR DESCRIPTION
`Plist Dict` config items should not have failsafe values defined.

NB: Docs say contributors should not build the PDFs ... so they will need building by a team member if merged. 

