### PR TITLE
Rename FullNvramAccess to RawNvramAccess

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@ OpenCore Changelog
 ==================
 #### v0.8.4
 - Added checks for `Driver` -> `LoadEarly` in ocvalidate
-- Added `FullNvramAccess` option for tools which require direct access to NVRAM
+- Added `RawNvramAccess` option for tools that require direct access to NVRAM
 
 #### v0.8.3
 - Added ext4 file system driver
@@ -264,7 +264,7 @@ OpenCore Changelog
 - Fixed ACPI table magic corruption during patching
 - Fixed unnatural OpenCanopy and FileVault 2 cursor movement
 - Fixed OpenCanopy interrupt handling causing missed events and lag
-- Improved OpenCanopy double-click detection 
+- Improved OpenCanopy double-click detection
 - Reduced OpenCanopy touch input lag and improved usability
 - Improved keypress responsiveness in OpenCanopy and builtin pickers
 - Improved non-repeating key detection in OpenCanopy and builtin pickers

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -4658,7 +4658,7 @@ rm vault.pub
   See \hyperref[oc-attr-use-flavour-icon]{\texttt{OC\_ATTR\_USE\_FLAVOUR\_ICON}} flag for documentation.
 
   \item
-  \texttt{FullNvramAccess}\\
+  \texttt{RawNvramAccess}\\
   \textbf{Type}: \texttt{plist\ boolean}\\
   \textbf{Failsafe}: \texttt{false}\\
   \textbf{Description}: Disable \texttt{OpenRuntime} NVRAM protection during usage of a tool.

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1172,12 +1172,12 @@
 				<false/>
 				<key>Flavour</key>
 				<string>OpenShell:UEFIShell:Shell</string>
-				<key>FullNvramAccess</key>
-				<false/>
 				<key>Name</key>
 				<string>UEFI Shell</string>
 				<key>Path</key>
 				<string>OpenShell.efi</string>
+				<key>RawNvramAccess</key>
+				<false/>
 				<key>RealPath</key>
 				<false/>
 				<key>TextMode</key>
@@ -1194,12 +1194,12 @@
 				<false/>
 				<key>Flavour</key>
 				<string>MemTest</string>
-				<key>FullNvramAccess</key>
-				<false/>
 				<key>Name</key>
 				<string>memtest86</string>
 				<key>Path</key>
 				<string>memtest86/BOOTX64.efi</string>
+				<key>RawNvramAccess</key>
+				<false/>
 				<key>RealPath</key>
 				<true/>
 				<key>TextMode</key>
@@ -1216,12 +1216,12 @@
 				<false/>
 				<key>Flavour</key>
 				<string>Auto</string>
-				<key>FullNvramAccess</key>
-				<false/>
 				<key>Name</key>
 				<string>Shutdown</string>
 				<key>Path</key>
 				<string>ResetSystem.efi</string>
+				<key>RawNvramAccess</key>
+				<false/>
 				<key>RealPath</key>
 				<false/>
 				<key>TextMode</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -1199,12 +1199,12 @@
 				<false/>
 				<key>Flavour</key>
 				<string>OpenShell:UEFIShell:Shell</string>
-				<key>FullNvramAccess</key>
-				<false/>
 				<key>Name</key>
 				<string>UEFI Shell</string>
 				<key>Path</key>
 				<string>OpenShell.efi</string>
+				<key>RawNvramAccess</key>
+				<false/>
 				<key>RealPath</key>
 				<false/>
 				<key>TextMode</key>
@@ -1221,12 +1221,12 @@
 				<false/>
 				<key>Flavour</key>
 				<string>MemTest</string>
-				<key>FullNvramAccess</key>
-				<false/>
 				<key>Name</key>
 				<string>memtest86</string>
 				<key>Path</key>
 				<string>memtest86/BOOTX64.efi</string>
+				<key>RawNvramAccess</key>
+				<false/>
 				<key>RealPath</key>
 				<true/>
 				<key>TextMode</key>
@@ -1243,12 +1243,12 @@
 				<false/>
 				<key>Flavour</key>
 				<string>Auto</string>
-				<key>FullNvramAccess</key>
-				<false/>
 				<key>Name</key>
 				<string>Shutdown</string>
 				<key>Path</key>
 				<string>ResetSystem.efi</string>
+				<key>RawNvramAccess</key>
+				<false/>
 				<key>RealPath</key>
 				<false/>
 				<key>TextMode</key>

--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -263,7 +263,7 @@ typedef struct OC_BOOT_ENTRY_ {
   //
   // Should disable OpenRuntime NVRAM protection around invocation of tool.
   //
-  BOOLEAN                     FullNvramAccess;
+  BOOLEAN                     RawNvramAccess;
   //
   // Partition UUID of entry device.
   // Set for non-system action boot entry protocol boot entries only.
@@ -581,7 +581,7 @@ typedef struct {
   //
   // Should disable OpenRuntime NVRAM protection around invocation of tool.
   //
-  BOOLEAN                  FullNvramAccess;
+  BOOLEAN                  RawNvramAccess;
   //
   // System action. Boot Entry Protocol only. Optional.
   //

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -395,7 +395,7 @@ OC_DECLARE (OC_MISC_SECURITY)
   _(OC_STRING                   , Flavour         ,     , OC_STRING_CONSTR ("Auto", _, __), OC_DESTR (OC_STRING) ) \
   _(BOOLEAN                     , Auxiliary       ,     , FALSE                       , ()                   ) \
   _(BOOLEAN                     , Enabled         ,     , FALSE                       , ()                   ) \
-  _(BOOLEAN                     , FullNvramAccess ,     , FALSE                       , ()                   ) \
+  _(BOOLEAN                     , RawNvramAccess  ,     , FALSE                       , ()                   ) \
   _(BOOLEAN                     , RealPath        ,     , FALSE                       , ()                   ) \
   _(BOOLEAN                     , TextMode        ,     , FALSE                       , ()                   ) \
   _(OC_STRING                   , Name            ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \

--- a/Library/OcBootManagementLib/BootEntryManagement.c
+++ b/Library/OcBootManagementLib/BootEntryManagement.c
@@ -770,7 +770,7 @@ InternalAddBootEntryFromCustomEntry (
 
   BootEntry->LaunchInText     = CustomEntry->TextMode;
   BootEntry->ExposeDevicePath = CustomEntry->RealPath;
-  BootEntry->FullNvramAccess  = CustomEntry->FullNvramAccess;
+  BootEntry->RawNvramAccess   = CustomEntry->RawNvramAccess;
 
   if (BootEntry->SystemAction != NULL) {
     ASSERT (CustomEntry->Arguments == NULL);

--- a/Library/OcBootManagementLib/OcBootManagementLib.c
+++ b/Library/OcBootManagementLib/OcBootManagementLib.c
@@ -353,7 +353,7 @@ OcRunBootPicker (
         }
       }
 
-      FwRuntime = Chosen->FullNvramAccess ? OcDisableNvramProtection () : NULL;
+      FwRuntime = Chosen->RawNvramAccess ? OcDisableNvramProtection () : NULL;
 
       Status = OcLoadBootEntry (
                  Context,

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -496,16 +496,16 @@ OC_SCHEMA
 STATIC
 OC_SCHEMA
   mMiscToolsSchemaEntry[] = {
-  OC_SCHEMA_STRING_IN ("Arguments",        OC_MISC_TOOLS_ENTRY, Arguments),
-  OC_SCHEMA_BOOLEAN_IN ("Auxiliary",       OC_MISC_TOOLS_ENTRY, Auxiliary),
-  OC_SCHEMA_STRING_IN ("Comment",          OC_MISC_TOOLS_ENTRY, Comment),
-  OC_SCHEMA_BOOLEAN_IN ("Enabled",         OC_MISC_TOOLS_ENTRY, Enabled),
-  OC_SCHEMA_STRING_IN ("Flavour",          OC_MISC_TOOLS_ENTRY, Flavour),
-  OC_SCHEMA_BOOLEAN_IN ("FullNvramAccess", OC_MISC_TOOLS_ENTRY, FullNvramAccess),
-  OC_SCHEMA_STRING_IN ("Name",             OC_MISC_TOOLS_ENTRY, Name),
-  OC_SCHEMA_STRING_IN ("Path",             OC_MISC_TOOLS_ENTRY, Path),
-  OC_SCHEMA_BOOLEAN_IN ("RealPath",        OC_MISC_TOOLS_ENTRY, RealPath),
-  OC_SCHEMA_BOOLEAN_IN ("TextMode",        OC_MISC_TOOLS_ENTRY, TextMode),
+  OC_SCHEMA_STRING_IN ("Arguments",       OC_MISC_TOOLS_ENTRY, Arguments),
+  OC_SCHEMA_BOOLEAN_IN ("Auxiliary",      OC_MISC_TOOLS_ENTRY, Auxiliary),
+  OC_SCHEMA_STRING_IN ("Comment",         OC_MISC_TOOLS_ENTRY, Comment),
+  OC_SCHEMA_BOOLEAN_IN ("Enabled",        OC_MISC_TOOLS_ENTRY, Enabled),
+  OC_SCHEMA_STRING_IN ("Flavour",         OC_MISC_TOOLS_ENTRY, Flavour),
+  OC_SCHEMA_STRING_IN ("Name",            OC_MISC_TOOLS_ENTRY, Name),
+  OC_SCHEMA_STRING_IN ("Path",            OC_MISC_TOOLS_ENTRY, Path),
+  OC_SCHEMA_BOOLEAN_IN ("RawNvramAccess", OC_MISC_TOOLS_ENTRY, RawNvramAccess),
+  OC_SCHEMA_BOOLEAN_IN ("RealPath",       OC_MISC_TOOLS_ENTRY, RealPath),
+  OC_SCHEMA_BOOLEAN_IN ("TextMode",       OC_MISC_TOOLS_ENTRY, TextMode),
 };
 
 STATIC

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -938,15 +938,15 @@ OcMiscBoot (
 
   for (Index = 0, EntryIndex = 0; Index < Config->Misc.Entries.Count; ++Index) {
     if (Config->Misc.Entries.Values[Index]->Enabled) {
-      Context->CustomEntries[EntryIndex].Name            = OC_BLOB_GET (&Config->Misc.Entries.Values[Index]->Name);
-      Context->CustomEntries[EntryIndex].Path            = OC_BLOB_GET (&Config->Misc.Entries.Values[Index]->Path);
-      Context->CustomEntries[EntryIndex].Arguments       = OC_BLOB_GET (&Config->Misc.Entries.Values[Index]->Arguments);
-      Context->CustomEntries[EntryIndex].Flavour         = OC_BLOB_GET (&Config->Misc.Entries.Values[Index]->Flavour);
-      Context->CustomEntries[EntryIndex].Auxiliary       = Config->Misc.Entries.Values[Index]->Auxiliary;
-      Context->CustomEntries[EntryIndex].Tool            = FALSE;
-      Context->CustomEntries[EntryIndex].TextMode        = Config->Misc.Entries.Values[Index]->TextMode;
-      Context->CustomEntries[EntryIndex].RealPath        = TRUE;  ///< Always true for entries
-      Context->CustomEntries[EntryIndex].FullNvramAccess = FALSE;
+      Context->CustomEntries[EntryIndex].Name           = OC_BLOB_GET (&Config->Misc.Entries.Values[Index]->Name);
+      Context->CustomEntries[EntryIndex].Path           = OC_BLOB_GET (&Config->Misc.Entries.Values[Index]->Path);
+      Context->CustomEntries[EntryIndex].Arguments      = OC_BLOB_GET (&Config->Misc.Entries.Values[Index]->Arguments);
+      Context->CustomEntries[EntryIndex].Flavour        = OC_BLOB_GET (&Config->Misc.Entries.Values[Index]->Flavour);
+      Context->CustomEntries[EntryIndex].Auxiliary      = Config->Misc.Entries.Values[Index]->Auxiliary;
+      Context->CustomEntries[EntryIndex].Tool           = FALSE;
+      Context->CustomEntries[EntryIndex].TextMode       = Config->Misc.Entries.Values[Index]->TextMode;
+      Context->CustomEntries[EntryIndex].RealPath       = TRUE;   ///< Always true for entries
+      Context->CustomEntries[EntryIndex].RawNvramAccess = FALSE;
       ++EntryIndex;
     }
   }
@@ -958,15 +958,15 @@ OcMiscBoot (
   //
   for (Index = 0; Index < Config->Misc.Tools.Count; ++Index) {
     if (Config->Misc.Tools.Values[Index]->Enabled) {
-      Context->CustomEntries[EntryIndex].Name            = OC_BLOB_GET (&Config->Misc.Tools.Values[Index]->Name);
-      Context->CustomEntries[EntryIndex].Path            = OC_BLOB_GET (&Config->Misc.Tools.Values[Index]->Path);
-      Context->CustomEntries[EntryIndex].Arguments       = OC_BLOB_GET (&Config->Misc.Tools.Values[Index]->Arguments);
-      Context->CustomEntries[EntryIndex].Flavour         = OC_BLOB_GET (&Config->Misc.Tools.Values[Index]->Flavour);
-      Context->CustomEntries[EntryIndex].Auxiliary       = Config->Misc.Tools.Values[Index]->Auxiliary;
-      Context->CustomEntries[EntryIndex].Tool            = TRUE;
-      Context->CustomEntries[EntryIndex].TextMode        = Config->Misc.Tools.Values[Index]->TextMode;
-      Context->CustomEntries[EntryIndex].RealPath        = Config->Misc.Tools.Values[Index]->RealPath;
-      Context->CustomEntries[EntryIndex].FullNvramAccess = Config->Misc.Tools.Values[Index]->FullNvramAccess;
+      Context->CustomEntries[EntryIndex].Name           = OC_BLOB_GET (&Config->Misc.Tools.Values[Index]->Name);
+      Context->CustomEntries[EntryIndex].Path           = OC_BLOB_GET (&Config->Misc.Tools.Values[Index]->Path);
+      Context->CustomEntries[EntryIndex].Arguments      = OC_BLOB_GET (&Config->Misc.Tools.Values[Index]->Arguments);
+      Context->CustomEntries[EntryIndex].Flavour        = OC_BLOB_GET (&Config->Misc.Tools.Values[Index]->Flavour);
+      Context->CustomEntries[EntryIndex].Auxiliary      = Config->Misc.Tools.Values[Index]->Auxiliary;
+      Context->CustomEntries[EntryIndex].Tool           = TRUE;
+      Context->CustomEntries[EntryIndex].TextMode       = Config->Misc.Tools.Values[Index]->TextMode;
+      Context->CustomEntries[EntryIndex].RealPath       = Config->Misc.Tools.Values[Index]->RealPath;
+      Context->CustomEntries[EntryIndex].RawNvramAccess = Config->Misc.Tools.Values[Index]->RawNvramAccess;
       ++EntryIndex;
     }
   }


### PR DESCRIPTION
See discussion here: https://github.com/acidanthera/OpenCorePkg/commit/b3f2033d200bb8bf114baad861bc7a1a51ed8259#comments

Proceeded with PR as it appeared the reluctance expressed was more of a reluctance to implement the change as opposed to a view that the proposed rename was of no value or, in fact, detrimental.

Excuse me if that interpretation is wrong! (EDIT: Now better understand reticence seeing how finicky Uncrustify is!) 

PS: Docs say contributors should not build the PDFs ... so they will need building by a team member if merged.