### PR TITLE
OcCpuLib: Cache InternalCalculateARTFrequencyIntel failure to avoid log loop

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ OpenCore Changelog
 - Fixed maximum click duration and double click speed for non-standard poll frequencies
 - Added support for pointer dwell-clicking
 - Prevented Apple firmware from adding additional security checks on top of emulated NVRAM driver
+- Fixed recursive loop on first log protocol line on some systems
 
 #### v0.8.5
 - Updated builtin firmware versions for SMBIOS and the rest

--- a/Library/OcCpuLib/FrequencyDetect.c
+++ b/Library/OcCpuLib/FrequencyDetect.c
@@ -447,8 +447,9 @@ InternalCalculateARTFrequencyIntel (
   // this frequency on module entry to initialise a TimerLib instance, and at
   // a later point in time to gather CPU information.
   //
-  STATIC UINT64  ARTFrequency        = 0;
-  STATIC UINT64  CPUFrequencyFromART = 0;
+  STATIC BOOLEAN  ObtainedARTFreq     = FALSE;
+  STATIC UINT64   ARTFrequency        = 0;
+  STATIC UINT64   CPUFrequencyFromART = 0;
 
   UINT32  MaxId;
   UINT32  CpuVendor;
@@ -463,11 +464,14 @@ InternalCalculateARTFrequencyIntel (
   UINT8                          Model;
 
   if (Recalculate) {
+    ObtainedARTFreq     = FALSE;
     ARTFrequency        = 0;
     CPUFrequencyFromART = 0;
   }
 
-  if (ARTFrequency == 0) {
+  if (!ObtainedARTFreq) {
+    ObtainedARTFreq = TRUE;
+
     //
     // Get vendor CPUID 0x00000000
     //
@@ -686,6 +690,11 @@ InternalCalculateVMTFrequency (
   return CpuidEax * 1000ULL;
 }
 
+//
+// This function and everything called by it must not log (after the first early call
+// to it, which can log and cache results), otherwise it will generate a loop when it
+// gets called during first log line.
+//
 UINT64
 OcGetTSCFrequency (
   VOID


### PR DESCRIPTION
I think this is correct and with no unwanted side effects.

Note previously, by definition, the call to InternalCalculateARTFrequencyIntel inside OcGetTSCFrequency was capable of returning a zero result (otherwise it would never drop through to the other options), however it never cached a zero result and always recalculated it (and therefore always logged while doing so).

The updated code follows exactly the pattern already used in InternalCalculateTSCFromApplePlatformInfo.