### PR TITLE
macrecovery: Update for Ventura

### DIFF
--- a/Utilities/macrecovery/recovery_urls.txt
+++ b/Utilities/macrecovery/recovery_urls.txt
@@ -31,6 +31,9 @@ Catalina
 Big Sur
 ./macrecovery.py -b Mac-2BD1B31983FE1663 -m 00000000000000000
 
+Monterey
+./macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000
+
 Diagnostics
 ./macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000 -diag
 ./macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000GDVQ00 -diag

--- a/Utilities/macrecovery/recovery_urls.txt
+++ b/Utilities/macrecovery/recovery_urls.txt
@@ -44,5 +44,5 @@ Default version
 ./macrecovery.py -b Mac-E43C1C25D4880AD6 -m <real MLB> -os default  (newer)
 
 Latest version
-./macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000 -os latest
-./macrecovery.py -b Mac-E43C1C25D4880AD6 -m <real MLB> -os latest
+./macrecovery.py -b Mac-B4831CEBD52A0C4C -m 00000000000000000 -os latest
+./macrecovery.py -b Mac-B4831CEBD52A0C4C -m <real MLB> -os latest


### PR DESCRIPTION
- Added Monterey recovery command, set to Mac-E43C1C25D4880AD6 (MacBookPro12,1)
- Updated "Latest Version" command to Mac-B4831CEBD52A0C4C (MacBookPro14,1)


Not sure if you want the "Diagnostics" and "Default version" changed to Mac-B4831CEBD52A0C4C too.