### PR TITLE
[macrecovery] Create `com.apple.recovery.boot`

### DIFF
--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -461,7 +461,7 @@ def main():
                         ' "selfcheck" checks whether MLB serial validation is possible, "verify" performs'
                         ' MLB serial verification, "guess" tries to find suitable mac model for MLB.')
     parser.add_argument('-o', '--outdir', type=str, default='com.apple.recovery.boot',
-                        help='customise output directory for downloading, defaults to current directory')
+                        help='customise output directory for downloading, defaults to com.apple.recovery.boot')
     parser.add_argument('-n', '--basename', type=str, default='',
                         help='customise base name for downloading, defaults to remote name')
     parser.add_argument('-b', '--board-id', type=str, default=RECENT_MAC,

--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -214,7 +214,7 @@ def save_image(url, sess, filename='', directory=''):
     if filename.find('/') >= 0 or filename == '':
         raise RuntimeError('Invalid save path ' + filename)
 
-    print(f'Saving {url} to {filename}...')
+    print(f'Saving {url} to {DOWNLOAD_DIR}/{filename}...')
 
     with open(os.path.join(directory, filename), 'wb') as fh:
         response = run_query(url, headers, raw=True)

--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -24,7 +24,7 @@ except ImportError:
     from urlparse import urlparse
 
 SELF_DIR = os.path.dirname(os.path.realpath(__file__))
-COM_APPLE_RECOVERY_BOOT = 'com.apple.recovery.boot'
+DOWNLOAD_DIR = 'com.apple.recovery.boot'
 
 RECENT_MAC = 'Mac-7BA5B2D9E42DDD94'
 MLB_ZERO = '00000000000000000'
@@ -205,9 +205,9 @@ def save_image(url, sess, filename='', directory=''):
         'Cookie': '='.join(['AssetToken', sess])
     }
 
-    if not os.path.exists(COM_APPLE_RECOVERY_BOOT):
-        os.mkdir(COM_APPLE_RECOVERY_BOOT)
-    directory = COM_APPLE_RECOVERY_BOOT
+    if not os.path.exists(DOWNLOAD_DIR):
+        os.mkdir(DOWNLOAD_DIR)
+    directory = DOWNLOAD_DIR
 
     if filename == '':
         filename = os.path.basename(purl.path)

--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -204,6 +204,10 @@ def save_image(url, sess, filename='', directory=''):
         'Cookie': '='.join(['AssetToken', sess])
     }
 
+    if not os.path.exists('com.apple.recovery.boot'):
+        os.mkdir('com.apple.recovery.boot')
+    directory = 'com.apple.recovery.boot'
+
     if filename == '':
         filename = os.path.basename(purl.path)
     if filename.find('/') >= 0 or filename == '':

--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -24,7 +24,6 @@ except ImportError:
     from urlparse import urlparse
 
 SELF_DIR = os.path.dirname(os.path.realpath(__file__))
-DOWNLOAD_DIR = 'com.apple.recovery.boot'
 
 RECENT_MAC = 'Mac-7BA5B2D9E42DDD94'
 MLB_ZERO = '00000000000000000'
@@ -196,7 +195,7 @@ def get_image_info(session, bid, mlb=MLB_ZERO, diag=False, os_type='default', ci
     return info
 
 
-def save_image(url, sess, filename='', directory=''):
+def save_image(url, sess, filename='', directory='com.apple.recovery.boot'):
     purl = urlparse(url)
     headers = {
         'Host': purl.hostname,
@@ -205,16 +204,15 @@ def save_image(url, sess, filename='', directory=''):
         'Cookie': '='.join(['AssetToken', sess])
     }
 
-    if not os.path.exists(DOWNLOAD_DIR):
-        os.mkdir(DOWNLOAD_DIR)
-    directory = DOWNLOAD_DIR
+    if not os.path.exists(directory):
+        os.mkdir(directory)
 
     if filename == '':
         filename = os.path.basename(purl.path)
     if filename.find('/') >= 0 or filename == '':
         raise RuntimeError('Invalid save path ' + filename)
 
-    print(f'Saving {url} to {DOWNLOAD_DIR}/{filename}...')
+    print(f'Saving {url} to {directory}/{filename}...')
 
     with open(os.path.join(directory, filename), 'wb') as fh:
         response = run_query(url, headers, raw=True)
@@ -285,9 +283,9 @@ def action_download(args):
         print(info)
     print(f'Downloading {info[INFO_PRODUCT]}...')
     dmgname = '' if args.basename == '' else args.basename + '.dmg'
-    dmgpath = save_image(info[INFO_IMAGE_LINK], info[INFO_IMAGE_SESS], dmgname, args.outdir)
+    dmgpath = save_image(info[INFO_IMAGE_LINK], info[INFO_IMAGE_SESS], dmgname)
     cnkname = '' if args.basename == '' else args.basename + '.chunklist'
-    cnkpath = save_image(info[INFO_SIGN_LINK], info[INFO_SIGN_SESS], cnkname, args.outdir)
+    cnkpath = save_image(info[INFO_SIGN_LINK], info[INFO_SIGN_SESS], cnkname)
     try:
         verify_image(dmgpath, cnkpath)
         return 0

--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -283,9 +283,9 @@ def action_download(args):
         print(info)
     print(f'Downloading {info[INFO_PRODUCT]}...')
     dmgname = '' if args.basename == '' else args.basename + '.dmg'
-    dmgpath = save_image(info[INFO_IMAGE_LINK], info[INFO_IMAGE_SESS], dmgname)
+    dmgpath = save_image(info[INFO_IMAGE_LINK], info[INFO_IMAGE_SESS], dmgname, args.outdir)
     cnkname = '' if args.basename == '' else args.basename + '.chunklist'
-    cnkpath = save_image(info[INFO_SIGN_LINK], info[INFO_SIGN_SESS], cnkname)
+    cnkpath = save_image(info[INFO_SIGN_LINK], info[INFO_SIGN_SESS], cnkname, args.outdir)
     try:
         verify_image(dmgpath, cnkpath)
         return 0
@@ -460,7 +460,7 @@ def main():
                         help='Action to perform: "download" - performs recovery downloading,'
                         ' "selfcheck" checks whether MLB serial validation is possible, "verify" performs'
                         ' MLB serial verification, "guess" tries to find suitable mac model for MLB.')
-    parser.add_argument('-o', '--outdir', type=str, default=os.getcwd(),
+    parser.add_argument('-o', '--outdir', type=str, default='com.apple.recovery.boot',
                         help='customise output directory for downloading, defaults to current directory')
     parser.add_argument('-n', '--basename', type=str, default='',
                         help='customise base name for downloading, defaults to remote name')

--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -195,7 +195,7 @@ def get_image_info(session, bid, mlb=MLB_ZERO, diag=False, os_type='default', ci
     return info
 
 
-def save_image(url, sess, filename='', directory='com.apple.recovery.boot'):
+def save_image(url, sess, filename='', directory=''):
     purl = urlparse(url)
     headers = {
         'Host': purl.hostname,

--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -24,6 +24,7 @@ except ImportError:
     from urlparse import urlparse
 
 SELF_DIR = os.path.dirname(os.path.realpath(__file__))
+COM_APPLE_RECOVERY_BOOT = 'com.apple.recovery.boot'
 
 RECENT_MAC = 'Mac-7BA5B2D9E42DDD94'
 MLB_ZERO = '00000000000000000'
@@ -204,9 +205,9 @@ def save_image(url, sess, filename='', directory=''):
         'Cookie': '='.join(['AssetToken', sess])
     }
 
-    if not os.path.exists('com.apple.recovery.boot'):
-        os.mkdir('com.apple.recovery.boot')
-    directory = 'com.apple.recovery.boot'
+    if not os.path.exists(COM_APPLE_RECOVERY_BOOT):
+        os.mkdir(COM_APPLE_RECOVERY_BOOT)
+    directory = COM_APPLE_RECOVERY_BOOT
 
     if filename == '':
         filename = os.path.basename(purl.path)


### PR DESCRIPTION
I know this sounds stupid but since the only possible way to use the Internet Recovery Install method is `macrecovery.py`, I thought it would be great that the script creates the folder `com.apple.recovery.boot` where the downloaded image and chunklist goes.

Proof of work:

![image](https://user-images.githubusercontent.com/17933708/201292413-6058ca15-2629-4776-a959-f6342d8f2c1d.png)

![image](https://user-images.githubusercontent.com/17933708/201292469-2169ac7e-ba72-4c34-937f-2da89ae22533.png)

![image](https://user-images.githubusercontent.com/17933708/201292490-942d3126-df0b-46b1-93d0-45e2854b5f14.png)
