### PR TITLE
Hide Picker when waking from macOS Hibernation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@ OpenCore Changelog
 #### v0.8.7
 - Removed unwanted clear screen when launching non-text boot entry
 - Changed `Misc` -> `Boot` -> `ShowPicker` typing to string:
-  - `Default` - Show Picker always (equivalent to 0.8.6's ShowPicker=True)
+  - `ShowAlways` - Show Picker always (equivalent to 0.8.6's ShowPicker=True)
   - `Hide` - Never Show Picker (equivalent to 0.8.6's ShowPicker=False)
   - `SkipOnHibernateWake` - Hide Picker if waking from macOS Hibernation
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,8 +3,8 @@ OpenCore Changelog
 #### v0.8.7
 - Removed unwanted clear screen when launching non-text boot entry
 - Changed `Misc` -> `Boot` -> `ShowPicker` typing to string:
-  - `Always` - Always show picker (equivalent to 0.8.6's ShowPicker=True)
-  - `Never` - Never show picker (equivalent to 0.8.6's ShowPicker=False)
+  - `Always` - Show picker (equivalent to 0.8.6's ShowPicker=True)
+  - `Never` - Hide picker (equivalent to 0.8.6's ShowPicker=False)
   - `SkipOnHibernateWake` - Hide picker if waking from macOS hibernation
 
 #### v0.8.6

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@ OpenCore Changelog
 #### v0.8.7
 - Removed unwanted clear screen when launching non-text boot entry
 - Changed `Misc` -> `Boot` -> `ShowPicker` typing to string:
-  - `Always` - Show picker always (equivalent to 0.8.6's ShowPicker=True)
+  - `Always` - Always show picker (equivalent to 0.8.6's ShowPicker=True)
   - `Never` - Never show picker (equivalent to 0.8.6's ShowPicker=False)
   - `SkipOnHibernateWake` - Hide picker if waking from macOS hibernation
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,9 +3,9 @@ OpenCore Changelog
 #### v0.8.7
 - Removed unwanted clear screen when launching non-text boot entry
 - Changed `Misc` -> `Boot` -> `ShowPicker` typing to string:
-  - `Always` - Show picker (equivalent to 0.8.6's ShowPicker=True)
-  - `Never` - Hide picker (equivalent to 0.8.6's ShowPicker=False)
-  - `SkipOnHibernateWake` - Hide picker if waking from macOS hibernation
+  - `Always` - Always show picker (equivalent to 0.8.6's ShowPicker=True)
+  - `Never` - Never show picker (equivalent to 0.8.6's ShowPicker=False)
+  - `SkipOnHibernateWake` - Don't show picker if waking from macOS hibernation
 
 #### v0.8.6
 - Updated NVRAM save script for compatibilty with earlier macOS (Snow Leopard+ tested)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@ OpenCore Changelog
 ==================
 #### v0.8.7
 - Removed unwanted clear screen when launching non-text boot entry
+- Changed `Misc` -> `Boot` -> `ShowPicker` typing to string:
+  - `Default` - Show Picker always (equivalent to 0.8.6's ShowPicker=True)
+  - `Hide` - Never Show Picker (equivalent to 0.8.6's ShowPicker=False)
+  - `SkipOnHibernateWake` - Hide Picker if waking from macOS Hibernation
 
 #### v0.8.6
 - Updated NVRAM save script for compatibilty with earlier macOS (Snow Leopard+ tested)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,9 +3,9 @@ OpenCore Changelog
 #### v0.8.7
 - Removed unwanted clear screen when launching non-text boot entry
 - Changed `Misc` -> `Boot` -> `ShowPicker` typing to string:
-  - `ShowAlways` - Show Picker always (equivalent to 0.8.6's ShowPicker=True)
-  - `Hide` - Never Show Picker (equivalent to 0.8.6's ShowPicker=False)
-  - `SkipOnHibernateWake` - Hide Picker if waking from macOS Hibernation
+  - `Always` - Show picker always (equivalent to 0.8.6's ShowPicker=True)
+  - `Never` - Never show picker (equivalent to 0.8.6's ShowPicker=False)
+  - `SkipOnHibernateWake` - Hide picker if waking from macOS hibernation
 
 #### v0.8.6
 - Updated NVRAM save script for compatibilty with earlier macOS (Snow Leopard+ tested)

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3604,9 +3604,26 @@ the default boot entry choice will remain changed until the next manual reconfig
 
 \item
   \texttt{ShowPicker}\\
-  \textbf{Type}: \texttt{plist\ boolean}\\
-  \textbf{Failsafe}: \texttt{false}\\
-  \textbf{Description}: Show a simple picker to allow boot entry selection.
+  \textbf{Type}: \texttt{plist\ string}\\
+  \textbf{Failsafe}: \texttt{Default}\\
+  \textbf{Description}: Show a simple picker to allow boot entry selection:
+  \begin{itemize}
+  \tightlist
+  \item \texttt{Default} --- Always show picker.
+  \item \texttt{Hide} --- Hide boot picker.
+  \item \texttt{SkipIfHibernate} --- Equivalent to \texttt{Default}, however hides picker if waking from macOS 
+  Hibernation. 
+  \end{itemize}
+  
+  Notes for \texttt{SkipIfHibernate}:
+  \begin{itemize}
+   \item Only supports macOS hibernation wake, Windows and Linux are currently out of scope
+   \item Should only be used on systems with reliable hibernation wake in macOS, otherwise users may not 
+   be able to visually see boot loops that may have occurred.
+  \item Highly recommended to pair this option with \texttt{PollAppleHotKeys}, allows to enter boot picker in 
+  case of issues with hibernate wake.
+  \item Visual Indication for hibernation wake is currently out of scope.
+  \end{itemize}
 
 \item
   \texttt{TakeoffDelay}\\

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3609,18 +3609,18 @@ the default boot entry choice will remain changed until the next manual reconfig
   \textbf{Description}: Show a simple picker to allow boot entry selection:
   \begin{itemize}
   \tightlist
-  \item \texttt{Always} --- Always show picker.
-  \item \texttt{Never} --- Hide boot picker.
-  \item \texttt{SkipIfHibernate} --- Equivalent to \texttt{Always}, however hides picker if waking from macOS 
-  hibernation. 
+  \item \texttt{Always} --- Show picker.
+  \item \texttt{Never} --- Hide picker.
+  \item \texttt{SkipIfHibernate} --- Equivalent to \texttt{Always}, however hides picker if waking from macOS
+  hibernation.
   \end{itemize}
-  
+
   Notes for \texttt{SkipIfHibernate}:
   \begin{itemize}
    \item Only supports macOS hibernation wake, Windows and Linux are currently out of scope.
-   \item Should only be used on systems with reliable hibernation wake in macOS, otherwise users may not 
+   \item Should only be used on systems with reliable hibernation wake in macOS, otherwise users may not
    be able to visually see boot loops that may occur.
-  \item Highly recommended to pair this option with \texttt{PollAppleHotKeys}, allows to enter boot picker in 
+  \item Highly recommended to pair this option with \texttt{PollAppleHotKeys}, allows to enter boot picker in
   case of issues with hibernate wake.
   \item Visual indication for hibernation wake is currently out of scope.
   \end{itemize}

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3609,9 +3609,9 @@ the default boot entry choice will remain changed until the next manual reconfig
   \textbf{Description}: Show a simple picker to allow boot entry selection:
   \begin{itemize}
   \tightlist
-  \item \texttt{Default} --- Always show picker.
+  \item \texttt{ShowAlways} --- Always show picker.
   \item \texttt{Hide} --- Hide boot picker.
-  \item \texttt{SkipIfHibernate} --- Equivalent to \texttt{Default}, however hides picker if waking from macOS 
+  \item \texttt{SkipIfHibernate} --- Equivalent to \texttt{ShowAlways}, however hides picker if waking from macOS 
   Hibernation. 
   \end{itemize}
   

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3609,18 +3609,17 @@ the default boot entry choice will remain changed until the next manual reconfig
   \textbf{Description}: Show a simple picker to allow boot entry selection:
   \begin{itemize}
   \tightlist
-  \item \texttt{Always} --- Show picker.
-  \item \texttt{Never} --- Hide picker.
-  \item \texttt{SkipIfHibernate} --- Equivalent to \texttt{Always}, however hides picker if waking from macOS
-  hibernation.
+  \item \texttt{Always} --- Always show picker.
+  \item \texttt{Never} --- Never show picker.
+  \item \texttt{SkipOnHibernateWake} --- Like \texttt{Always}, however doesn't show picker if waking from macOS hibernation.
   \end{itemize}
 
-  Notes for \texttt{SkipIfHibernate}:
+  Notes for \texttt{SkipOnHibernateWake}:
   \begin{itemize}
    \item Only supports macOS hibernation wake, Windows and Linux are currently out of scope.
    \item Should only be used on systems with reliable hibernation wake in macOS, otherwise users may not
    be able to visually see boot loops that may occur.
-  \item Highly recommended to pair this option with \texttt{PollAppleHotKeys}, allows to enter boot picker in
+  \item Highly recommended to pair this option with \texttt{PollAppleHotKeys}, allows to enter picker in
   case of issues with hibernation wake.
   \item Visual indication for hibernation wake is currently out of scope.
   \end{itemize}

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3605,24 +3605,24 @@ the default boot entry choice will remain changed until the next manual reconfig
 \item
   \texttt{ShowPicker}\\
   \textbf{Type}: \texttt{plist\ string}\\
-  \textbf{Failsafe}: \texttt{Default}\\
+  \textbf{Failsafe}: \texttt{Always}\\
   \textbf{Description}: Show a simple picker to allow boot entry selection:
   \begin{itemize}
   \tightlist
-  \item \texttt{ShowAlways} --- Always show picker.
-  \item \texttt{Hide} --- Hide boot picker.
-  \item \texttt{SkipIfHibernate} --- Equivalent to \texttt{ShowAlways}, however hides picker if waking from macOS 
-  Hibernation. 
+  \item \texttt{Always} --- Always show picker.
+  \item \texttt{Never} --- Hide boot picker.
+  \item \texttt{SkipIfHibernate} --- Equivalent to \texttt{Always}, however hides picker if waking from macOS 
+  hibernation. 
   \end{itemize}
   
   Notes for \texttt{SkipIfHibernate}:
   \begin{itemize}
-   \item Only supports macOS hibernation wake, Windows and Linux are currently out of scope
+   \item Only supports macOS hibernation wake, Windows and Linux are currently out of scope.
    \item Should only be used on systems with reliable hibernation wake in macOS, otherwise users may not 
    be able to visually see boot loops that may have occurred.
   \item Highly recommended to pair this option with \texttt{PollAppleHotKeys}, allows to enter boot picker in 
   case of issues with hibernate wake.
-  \item Visual Indication for hibernation wake is currently out of scope.
+  \item Visual indication for hibernation wake is currently out of scope.
   \end{itemize}
 
 \item

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3619,7 +3619,7 @@ the default boot entry choice will remain changed until the next manual reconfig
   \begin{itemize}
    \item Only supports macOS hibernation wake, Windows and Linux are currently out of scope.
    \item Should only be used on systems with reliable hibernation wake in macOS, otherwise users may not 
-   be able to visually see boot loops that may have occurred.
+   be able to visually see boot loops that may occur.
   \item Highly recommended to pair this option with \texttt{PollAppleHotKeys}, allows to enter boot picker in 
   case of issues with hibernate wake.
   \item Visual indication for hibernation wake is currently out of scope.

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3621,7 +3621,7 @@ the default boot entry choice will remain changed until the next manual reconfig
    \item Should only be used on systems with reliable hibernation wake in macOS, otherwise users may not
    be able to visually see boot loops that may occur.
   \item Highly recommended to pair this option with \texttt{PollAppleHotKeys}, allows to enter boot picker in
-  case of issues with hibernate wake.
+  case of issues with hibernation wake.
   \item Visual indication for hibernation wake is currently out of scope.
   \end{itemize}
 

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1062,8 +1062,6 @@
 			<string>None</string>
 			<key>HideAuxiliary</key>
 			<true/>
-			<key>HidePickerHibernate</key>
-			<false/>
 			<key>LauncherOption</key>
 			<string>Disabled</string>
 			<key>LauncherPath</key>
@@ -1079,7 +1077,7 @@
 			<key>PollAppleHotKeys</key>
 			<false/>
 			<key>ShowPicker</key>
-			<true/>
+			<string>Default</string>
 			<key>TakeoffDelay</key>
 			<integer>0</integer>
 			<key>Timeout</key>

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1062,6 +1062,8 @@
 			<string>None</string>
 			<key>HideAuxiliary</key>
 			<true/>
+			<key>HidePickerHibernate</key>
+			<false/>
 			<key>LauncherOption</key>
 			<string>Disabled</string>
 			<key>LauncherPath</key>

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1077,7 +1077,7 @@
 			<key>PollAppleHotKeys</key>
 			<false/>
 			<key>ShowPicker</key>
-			<string>Default</string>
+			<string>Always</string>
 			<key>TakeoffDelay</key>
 			<integer>0</integer>
 			<key>Timeout</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -1062,8 +1062,6 @@
 			<string>None</string>
 			<key>HideAuxiliary</key>
 			<true/>
-			<key>HidePickerHibernate</key>
-			<false/>
 			<key>LauncherOption</key>
 			<string>Disabled</string>
 			<key>LauncherPath</key>
@@ -1079,7 +1077,7 @@
 			<key>PollAppleHotKeys</key>
 			<false/>
 			<key>ShowPicker</key>
-			<true/>
+			<string>Default</string>
 			<key>TakeoffDelay</key>
 			<integer>0</integer>
 			<key>Timeout</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -1062,6 +1062,8 @@
 			<string>None</string>
 			<key>HideAuxiliary</key>
 			<true/>
+			<key>HidePickerHibernate</key>
+			<false/>
 			<key>LauncherOption</key>
 			<string>Disabled</string>
 			<key>LauncherPath</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -1077,7 +1077,7 @@
 			<key>PollAppleHotKeys</key>
 			<false/>
 			<key>ShowPicker</key>
-			<string>Default</string>
+			<string>Always</string>
 			<key>TakeoffDelay</key>
 			<integer>0</integer>
 			<key>Timeout</key>

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -336,6 +336,7 @@ OC_DECLARE (OC_MISC_BLESS_ARRAY)
   _(OC_STRING                   , HibernateMode               ,     , OC_STRING_CONSTR ("None", _, __)    , OC_DESTR (OC_STRING)) \
   _(OC_STRING                   , LauncherOption              ,     , OC_STRING_CONSTR ("Disabled", _, __), OC_DESTR (OC_STRING) ) \
   _(OC_STRING                   , LauncherPath                ,     , OC_STRING_CONSTR ("Default", _, __) , OC_DESTR (OC_STRING) ) \
+  _(OC_STRING                   , ShowPicker                  ,     , OC_STRING_CONSTR ("Default", _, __) , OC_DESTR (OC_STRING) ) \
   _(UINT32                      , ConsoleAttributes           ,     , 0                                   , ())                   \
   _(UINT32                      , PickerAttributes            ,     , 0                                   , ())                   \
   _(OC_STRING                   , PickerVariant               ,     , OC_STRING_CONSTR ("Auto", _, __)    , OC_DESTR (OC_STRING)) \
@@ -343,9 +344,7 @@ OC_DECLARE (OC_MISC_BLESS_ARRAY)
   _(UINT32                      , Timeout                     ,     , 0                                   , ())                   \
   _(BOOLEAN                     , PickerAudioAssist           ,     , FALSE                               , ())                   \
   _(BOOLEAN                     , HideAuxiliary               ,     , FALSE                               , ())                   \
-  _(BOOLEAN                     , PollAppleHotKeys            ,     , FALSE                               , ())                   \
-  _(BOOLEAN                     , ShowPicker                  ,     , FALSE                               , ())                   \
-  _(BOOLEAN                     , HidePickerHibernate         ,     , FALSE                               , ())
+  _(BOOLEAN                     , PollAppleHotKeys            ,     , FALSE                               , ())
 OC_DECLARE (OC_MISC_BOOT)
 
 #define OC_MISC_DEBUG_FIELDS(_, __) \

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -336,7 +336,6 @@ OC_DECLARE (OC_MISC_BLESS_ARRAY)
   _(OC_STRING                   , HibernateMode               ,     , OC_STRING_CONSTR ("None", _, __)    , OC_DESTR (OC_STRING)) \
   _(OC_STRING                   , LauncherOption              ,     , OC_STRING_CONSTR ("Disabled", _, __), OC_DESTR (OC_STRING) ) \
   _(OC_STRING                   , LauncherPath                ,     , OC_STRING_CONSTR ("Default", _, __) , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , ShowPicker                  ,     , OC_STRING_CONSTR ("Default", _, __) , OC_DESTR (OC_STRING) ) \
   _(UINT32                      , ConsoleAttributes           ,     , 0                                   , ())                   \
   _(UINT32                      , PickerAttributes            ,     , 0                                   , ())                   \
   _(OC_STRING                   , PickerVariant               ,     , OC_STRING_CONSTR ("Auto", _, __)    , OC_DESTR (OC_STRING)) \
@@ -344,7 +343,8 @@ OC_DECLARE (OC_MISC_BLESS_ARRAY)
   _(UINT32                      , Timeout                     ,     , 0                                   , ())                   \
   _(BOOLEAN                     , PickerAudioAssist           ,     , FALSE                               , ())                   \
   _(BOOLEAN                     , HideAuxiliary               ,     , FALSE                               , ())                   \
-  _(BOOLEAN                     , PollAppleHotKeys            ,     , FALSE                               , ())
+  _(BOOLEAN                     , PollAppleHotKeys            ,     , FALSE                               , ())                   \
+  _(OC_STRING                   , ShowPicker                  ,     , OC_STRING_CONSTR ("Always", _, __)  , OC_DESTR (OC_STRING) )
 OC_DECLARE (OC_MISC_BOOT)
 
 #define OC_MISC_DEBUG_FIELDS(_, __) \

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -344,7 +344,8 @@ OC_DECLARE (OC_MISC_BLESS_ARRAY)
   _(BOOLEAN                     , PickerAudioAssist           ,     , FALSE                               , ())                   \
   _(BOOLEAN                     , HideAuxiliary               ,     , FALSE                               , ())                   \
   _(BOOLEAN                     , PollAppleHotKeys            ,     , FALSE                               , ())                   \
-  _(BOOLEAN                     , ShowPicker                  ,     , FALSE                               , ())
+  _(BOOLEAN                     , ShowPicker                  ,     , FALSE                               , ())                   \
+  _(BOOLEAN                     , HidePickerHibernate         ,     , FALSE                               , ())
 OC_DECLARE (OC_MISC_BOOT)
 
 #define OC_MISC_DEBUG_FIELDS(_, __) \

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -405,19 +405,19 @@ OC_SCHEMA
 STATIC
 OC_SCHEMA
   mMiscConfigurationBootSchema[] = {
-  OC_SCHEMA_INTEGER_IN ("ConsoleAttributes",   OC_GLOBAL_CONFIG, Misc.Boot.ConsoleAttributes),
-  OC_SCHEMA_STRING_IN ("HibernateMode",        OC_GLOBAL_CONFIG, Misc.Boot.HibernateMode),
-  OC_SCHEMA_BOOLEAN_IN ("HideAuxiliary",       OC_GLOBAL_CONFIG, Misc.Boot.HideAuxiliary),
-  OC_SCHEMA_STRING_IN ("LauncherOption",       OC_GLOBAL_CONFIG, Misc.Boot.LauncherOption),
-  OC_SCHEMA_STRING_IN ("LauncherPath",         OC_GLOBAL_CONFIG, Misc.Boot.LauncherPath),
-  OC_SCHEMA_INTEGER_IN ("PickerAttributes",    OC_GLOBAL_CONFIG, Misc.Boot.PickerAttributes),
-  OC_SCHEMA_BOOLEAN_IN ("PickerAudioAssist",   OC_GLOBAL_CONFIG, Misc.Boot.PickerAudioAssist),
-  OC_SCHEMA_STRING_IN ("PickerMode",           OC_GLOBAL_CONFIG, Misc.Boot.PickerMode),
-  OC_SCHEMA_STRING_IN ("PickerVariant",        OC_GLOBAL_CONFIG, Misc.Boot.PickerVariant),
-  OC_SCHEMA_BOOLEAN_IN ("PollAppleHotKeys",    OC_GLOBAL_CONFIG, Misc.Boot.PollAppleHotKeys),
-  OC_SCHEMA_STRING_IN ("ShowPicker",           OC_GLOBAL_CONFIG, Misc.Boot.ShowPicker),
-  OC_SCHEMA_INTEGER_IN ("TakeoffDelay",        OC_GLOBAL_CONFIG, Misc.Boot.TakeoffDelay),
-  OC_SCHEMA_INTEGER_IN ("Timeout",             OC_GLOBAL_CONFIG, Misc.Boot.Timeout),
+  OC_SCHEMA_INTEGER_IN ("ConsoleAttributes", OC_GLOBAL_CONFIG, Misc.Boot.ConsoleAttributes),
+  OC_SCHEMA_STRING_IN ("HibernateMode",      OC_GLOBAL_CONFIG, Misc.Boot.HibernateMode),
+  OC_SCHEMA_BOOLEAN_IN ("HideAuxiliary",     OC_GLOBAL_CONFIG, Misc.Boot.HideAuxiliary),
+  OC_SCHEMA_STRING_IN ("LauncherOption",     OC_GLOBAL_CONFIG, Misc.Boot.LauncherOption),
+  OC_SCHEMA_STRING_IN ("LauncherPath",       OC_GLOBAL_CONFIG, Misc.Boot.LauncherPath),
+  OC_SCHEMA_INTEGER_IN ("PickerAttributes",  OC_GLOBAL_CONFIG, Misc.Boot.PickerAttributes),
+  OC_SCHEMA_BOOLEAN_IN ("PickerAudioAssist", OC_GLOBAL_CONFIG, Misc.Boot.PickerAudioAssist),
+  OC_SCHEMA_STRING_IN ("PickerMode",         OC_GLOBAL_CONFIG, Misc.Boot.PickerMode),
+  OC_SCHEMA_STRING_IN ("PickerVariant",      OC_GLOBAL_CONFIG, Misc.Boot.PickerVariant),
+  OC_SCHEMA_BOOLEAN_IN ("PollAppleHotKeys",  OC_GLOBAL_CONFIG, Misc.Boot.PollAppleHotKeys),
+  OC_SCHEMA_STRING_IN ("ShowPicker",         OC_GLOBAL_CONFIG, Misc.Boot.ShowPicker),
+  OC_SCHEMA_INTEGER_IN ("TakeoffDelay",      OC_GLOBAL_CONFIG, Misc.Boot.TakeoffDelay),
+  OC_SCHEMA_INTEGER_IN ("Timeout",           OC_GLOBAL_CONFIG, Misc.Boot.Timeout),
 };
 
 STATIC

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -408,7 +408,6 @@ OC_SCHEMA
   OC_SCHEMA_INTEGER_IN ("ConsoleAttributes",   OC_GLOBAL_CONFIG, Misc.Boot.ConsoleAttributes),
   OC_SCHEMA_STRING_IN ("HibernateMode",        OC_GLOBAL_CONFIG, Misc.Boot.HibernateMode),
   OC_SCHEMA_BOOLEAN_IN ("HideAuxiliary",       OC_GLOBAL_CONFIG, Misc.Boot.HideAuxiliary),
-  OC_SCHEMA_BOOLEAN_IN ("HidePickerHibernate", OC_GLOBAL_CONFIG, Misc.Boot.HidePickerHibernate),
   OC_SCHEMA_STRING_IN ("LauncherOption",       OC_GLOBAL_CONFIG, Misc.Boot.LauncherOption),
   OC_SCHEMA_STRING_IN ("LauncherPath",         OC_GLOBAL_CONFIG, Misc.Boot.LauncherPath),
   OC_SCHEMA_INTEGER_IN ("PickerAttributes",    OC_GLOBAL_CONFIG, Misc.Boot.PickerAttributes),
@@ -416,7 +415,7 @@ OC_SCHEMA
   OC_SCHEMA_STRING_IN ("PickerMode",           OC_GLOBAL_CONFIG, Misc.Boot.PickerMode),
   OC_SCHEMA_STRING_IN ("PickerVariant",        OC_GLOBAL_CONFIG, Misc.Boot.PickerVariant),
   OC_SCHEMA_BOOLEAN_IN ("PollAppleHotKeys",    OC_GLOBAL_CONFIG, Misc.Boot.PollAppleHotKeys),
-  OC_SCHEMA_BOOLEAN_IN ("ShowPicker",          OC_GLOBAL_CONFIG, Misc.Boot.ShowPicker),
+  OC_SCHEMA_STRING_IN ("ShowPicker",           OC_GLOBAL_CONFIG, Misc.Boot.ShowPicker),
   OC_SCHEMA_INTEGER_IN ("TakeoffDelay",        OC_GLOBAL_CONFIG, Misc.Boot.TakeoffDelay),
   OC_SCHEMA_INTEGER_IN ("Timeout",             OC_GLOBAL_CONFIG, Misc.Boot.Timeout),
 };

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -405,19 +405,20 @@ OC_SCHEMA
 STATIC
 OC_SCHEMA
   mMiscConfigurationBootSchema[] = {
-  OC_SCHEMA_INTEGER_IN ("ConsoleAttributes", OC_GLOBAL_CONFIG, Misc.Boot.ConsoleAttributes),
-  OC_SCHEMA_STRING_IN ("HibernateMode",      OC_GLOBAL_CONFIG, Misc.Boot.HibernateMode),
-  OC_SCHEMA_BOOLEAN_IN ("HideAuxiliary",     OC_GLOBAL_CONFIG, Misc.Boot.HideAuxiliary),
-  OC_SCHEMA_STRING_IN ("LauncherOption",     OC_GLOBAL_CONFIG, Misc.Boot.LauncherOption),
-  OC_SCHEMA_STRING_IN ("LauncherPath",       OC_GLOBAL_CONFIG, Misc.Boot.LauncherPath),
-  OC_SCHEMA_INTEGER_IN ("PickerAttributes",  OC_GLOBAL_CONFIG, Misc.Boot.PickerAttributes),
-  OC_SCHEMA_BOOLEAN_IN ("PickerAudioAssist", OC_GLOBAL_CONFIG, Misc.Boot.PickerAudioAssist),
-  OC_SCHEMA_STRING_IN ("PickerMode",         OC_GLOBAL_CONFIG, Misc.Boot.PickerMode),
-  OC_SCHEMA_STRING_IN ("PickerVariant",      OC_GLOBAL_CONFIG, Misc.Boot.PickerVariant),
-  OC_SCHEMA_BOOLEAN_IN ("PollAppleHotKeys",  OC_GLOBAL_CONFIG, Misc.Boot.PollAppleHotKeys),
-  OC_SCHEMA_BOOLEAN_IN ("ShowPicker",        OC_GLOBAL_CONFIG, Misc.Boot.ShowPicker),
-  OC_SCHEMA_INTEGER_IN ("TakeoffDelay",      OC_GLOBAL_CONFIG, Misc.Boot.TakeoffDelay),
-  OC_SCHEMA_INTEGER_IN ("Timeout",           OC_GLOBAL_CONFIG, Misc.Boot.Timeout),
+  OC_SCHEMA_INTEGER_IN ("ConsoleAttributes",   OC_GLOBAL_CONFIG, Misc.Boot.ConsoleAttributes),
+  OC_SCHEMA_STRING_IN ("HibernateMode",        OC_GLOBAL_CONFIG, Misc.Boot.HibernateMode),
+  OC_SCHEMA_BOOLEAN_IN ("HideAuxiliary",       OC_GLOBAL_CONFIG, Misc.Boot.HideAuxiliary),
+  OC_SCHEMA_BOOLEAN_IN ("HidePickerHibernate", OC_GLOBAL_CONFIG, Misc.Boot.HidePickerHibernate),
+  OC_SCHEMA_STRING_IN ("LauncherOption",       OC_GLOBAL_CONFIG, Misc.Boot.LauncherOption),
+  OC_SCHEMA_STRING_IN ("LauncherPath",         OC_GLOBAL_CONFIG, Misc.Boot.LauncherPath),
+  OC_SCHEMA_INTEGER_IN ("PickerAttributes",    OC_GLOBAL_CONFIG, Misc.Boot.PickerAttributes),
+  OC_SCHEMA_BOOLEAN_IN ("PickerAudioAssist",   OC_GLOBAL_CONFIG, Misc.Boot.PickerAudioAssist),
+  OC_SCHEMA_STRING_IN ("PickerMode",           OC_GLOBAL_CONFIG, Misc.Boot.PickerMode),
+  OC_SCHEMA_STRING_IN ("PickerVariant",        OC_GLOBAL_CONFIG, Misc.Boot.PickerVariant),
+  OC_SCHEMA_BOOLEAN_IN ("PollAppleHotKeys",    OC_GLOBAL_CONFIG, Misc.Boot.PollAppleHotKeys),
+  OC_SCHEMA_BOOLEAN_IN ("ShowPicker",          OC_GLOBAL_CONFIG, Misc.Boot.ShowPicker),
+  OC_SCHEMA_INTEGER_IN ("TakeoffDelay",        OC_GLOBAL_CONFIG, Misc.Boot.TakeoffDelay),
+  OC_SCHEMA_INTEGER_IN ("Timeout",             OC_GLOBAL_CONFIG, Misc.Boot.Timeout),
 };
 
 STATIC

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -935,8 +935,8 @@ OcMiscBoot (
      && (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") != 0)
      && (AsciiStrCmp (ShowPicker, "Never") != 0))
   {
-    DEBUG ((DEBUG_WARN, "OC: Unknown ShowPicker: %a, using Default\n", ShowPicker));
-    ShowPicker = "Default";
+    DEBUG ((DEBUG_WARN, "OC: Unknown ShowPicker: %a, using Always\n", ShowPicker));
+    ShowPicker = "Always";
   }
 
   if (!EFI_ERROR (Status)) {

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -931,7 +931,7 @@ OcMiscBoot (
              );
 
   ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
-  if (  (AsciiStrCmp (ShowPicker, "Default") != 0)
+  if (  (AsciiStrCmp (ShowPicker, "ShowAlways") != 0)
      && (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") != 0)
      && (AsciiStrCmp (ShowPicker, "Hide") != 0))
   {
@@ -941,7 +941,7 @@ OcMiscBoot (
 
   if (!EFI_ERROR (Status)) {
     Context->PickerCommand = OcPickerBootAppleRecovery;
-  } else if (AsciiStrCmp (ShowPicker, "Default") == 0) {
+  } else if (AsciiStrCmp (ShowPicker, "ShowAlways") == 0) {
     Context->PickerCommand = OcPickerShowPicker;
   } else if (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") == 0) {
     if (OcIsAppleHibernateWake ()) {

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -930,6 +930,8 @@ OcMiscBoot (
              );
   if (!EFI_ERROR (Status)) {
     Context->PickerCommand = OcPickerBootAppleRecovery;
+  } else if (OcIsAppleHibernateWake () && Config->Misc.Boot.HidePickerHibernate) {
+    Context->PickerCommand = FALSE;
   } else if (Config->Misc.Boot.ShowPicker) {
     Context->PickerCommand = OcPickerShowPicker;
   } else {

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -932,8 +932,8 @@ OcMiscBoot (
 
   ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
   if (  (AsciiStrCmp (ShowPicker, "Default") != 0)
-    && (AsciiStrCmp (ShowPicker, "SkipHibernate") != 0)
-    && (AsciiStrCmp (ShowPicker, "None") != 0))
+     && (AsciiStrCmp (ShowPicker, "SkipHibernate") != 0)
+     && (AsciiStrCmp (ShowPicker, "None") != 0))
   {
     DEBUG ((DEBUG_WARN, "OC: Unknown ShowPicker: %a, using Default\n", ShowPicker));
     ShowPicker = "Default";

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -941,8 +941,10 @@ OcMiscBoot (
 
   if (!EFI_ERROR (Status)) {
     Context->PickerCommand = OcPickerBootAppleRecovery;
-  } else if ((AsciiStrCmp (ShowPicker, "Default") == 0) || (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") == 0)) {
-    if ((AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") == 0) && OcIsAppleHibernateWake ()) {
+  } else if (AsciiStrCmp (ShowPicker, "Default") == 0) {
+    Context->PickerCommand = OcPickerShowPicker;
+  } else if (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") == 0) {
+    if (OcIsAppleHibernateWake ()) {
       Context->PickerCommand = OcPickerDefault;
     } else {
       Context->PickerCommand = OcPickerShowPicker;

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -931,17 +931,18 @@ OcMiscBoot (
              );
 
   ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
-  if (AsciiStrCmp (ShowPicker, "Default") != 0
-    && AsciiStrCmp (ShowPicker, "SkipHibernate") != 0
-    && AsciiStrCmp (ShowPicker, "None") != 0) {
+  if (  (AsciiStrCmp (ShowPicker, "Default") != 0)
+    && (AsciiStrCmp (ShowPicker, "SkipHibernate") != 0)
+    && (AsciiStrCmp (ShowPicker, "None") != 0))
+  {
     DEBUG ((DEBUG_WARN, "OC: Unknown ShowPicker: %a, using Default\n", ShowPicker));
     ShowPicker = "Default";
   }
 
   if (!EFI_ERROR (Status)) {
     Context->PickerCommand = OcPickerBootAppleRecovery;
-  } else if (AsciiStrCmp (ShowPicker, "Default") == 0 || AsciiStrCmp (ShowPicker, "SkipHibernate") == 0) {
-    if (AsciiStrCmp (ShowPicker, "SkipHibernate") == 0 && OcIsAppleHibernateWake ()) {
+  } else if ((AsciiStrCmp (ShowPicker, "Default") == 0) || (AsciiStrCmp (ShowPicker, "SkipHibernate") == 0)) {
+    if ((AsciiStrCmp (ShowPicker, "SkipHibernate") == 0) && OcIsAppleHibernateWake ()) {
       Context->PickerCommand = OcPickerDefault;
     } else {
       Context->PickerCommand = OcPickerShowPicker;

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -776,6 +776,7 @@ OcMiscBoot (
   CONST CHAR8             *AsciiPicker;
   CONST CHAR8             *AsciiPickerVariant;
   CONST CHAR8             *AsciiDmg;
+  CONST CHAR8             *ShowPicker;
 
   AsciiPicker = OC_BLOB_GET (&Config->Misc.Boot.PickerMode);
 
@@ -928,12 +929,23 @@ OcMiscBoot (
   Status = OcHandleRecoveryRequest (
              &Context->RecoveryInitiator
              );
+
+  ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
+  if (AsciiStrCmp (ShowPicker, "Default") != 0
+    && AsciiStrCmp (ShowPicker, "SkipHibernate") != 0
+    && AsciiStrCmp (ShowPicker, "None") != 0) {
+    DEBUG ((DEBUG_WARN, "OC: Unknown ShowPicker: %a, using Default\n", ShowPicker));
+    ShowPicker = "Default";
+  }
+
   if (!EFI_ERROR (Status)) {
     Context->PickerCommand = OcPickerBootAppleRecovery;
-  } else if (OcIsAppleHibernateWake () && Config->Misc.Boot.HidePickerHibernate) {
-    Context->PickerCommand = OcPickerDefault;
-  } else if (Config->Misc.Boot.ShowPicker) {
-    Context->PickerCommand = OcPickerShowPicker;
+  } else if (AsciiStrCmp (ShowPicker, "Default") == 0 || AsciiStrCmp (ShowPicker, "SkipHibernate") == 0) {
+    if (AsciiStrCmp (ShowPicker, "SkipHibernate") == 0 || OcIsAppleHibernateWake ()) {
+      Context->PickerCommand = OcPickerDefault;
+    } else {
+      Context->PickerCommand = OcPickerShowPicker;
+    }
   } else {
     Context->PickerCommand = OcPickerDefault;
   }

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -941,7 +941,7 @@ OcMiscBoot (
   if (!EFI_ERROR (Status)) {
     Context->PickerCommand = OcPickerBootAppleRecovery;
   } else if (AsciiStrCmp (ShowPicker, "Default") == 0 || AsciiStrCmp (ShowPicker, "SkipHibernate") == 0) {
-    if (AsciiStrCmp (ShowPicker, "SkipHibernate") == 0 || OcIsAppleHibernateWake ()) {
+    if (AsciiStrCmp (ShowPicker, "SkipHibernate") == 0 && OcIsAppleHibernateWake ()) {
       Context->PickerCommand = OcPickerDefault;
     } else {
       Context->PickerCommand = OcPickerShowPicker;

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -931,7 +931,7 @@ OcMiscBoot (
   if (!EFI_ERROR (Status)) {
     Context->PickerCommand = OcPickerBootAppleRecovery;
   } else if (OcIsAppleHibernateWake () && Config->Misc.Boot.HidePickerHibernate) {
-    Context->PickerCommand = FALSE;
+    Context->PickerCommand = OcPickerDefault;
   } else if (Config->Misc.Boot.ShowPicker) {
     Context->PickerCommand = OcPickerShowPicker;
   } else {

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -932,8 +932,8 @@ OcMiscBoot (
 
   ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
   if (  (AsciiStrCmp (ShowPicker, "Default") != 0)
-     && (AsciiStrCmp (ShowPicker, "SkipHibernate") != 0)
-     && (AsciiStrCmp (ShowPicker, "None") != 0))
+     && (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") != 0)
+     && (AsciiStrCmp (ShowPicker, "Hide") != 0))
   {
     DEBUG ((DEBUG_WARN, "OC: Unknown ShowPicker: %a, using Default\n", ShowPicker));
     ShowPicker = "Default";
@@ -941,8 +941,8 @@ OcMiscBoot (
 
   if (!EFI_ERROR (Status)) {
     Context->PickerCommand = OcPickerBootAppleRecovery;
-  } else if ((AsciiStrCmp (ShowPicker, "Default") == 0) || (AsciiStrCmp (ShowPicker, "SkipHibernate") == 0)) {
-    if ((AsciiStrCmp (ShowPicker, "SkipHibernate") == 0) && OcIsAppleHibernateWake ()) {
+  } else if ((AsciiStrCmp (ShowPicker, "Default") == 0) || (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") == 0)) {
+    if ((AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") == 0) && OcIsAppleHibernateWake ()) {
       Context->PickerCommand = OcPickerDefault;
     } else {
       Context->PickerCommand = OcPickerShowPicker;

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -931,9 +931,9 @@ OcMiscBoot (
              );
 
   ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
-  if (  (AsciiStrCmp (ShowPicker, "ShowAlways") != 0)
+  if (  (AsciiStrCmp (ShowPicker, "Always") != 0)
      && (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") != 0)
-     && (AsciiStrCmp (ShowPicker, "Hide") != 0))
+     && (AsciiStrCmp (ShowPicker, "Never") != 0))
   {
     DEBUG ((DEBUG_WARN, "OC: Unknown ShowPicker: %a, using Default\n", ShowPicker));
     ShowPicker = "Default";
@@ -941,7 +941,7 @@ OcMiscBoot (
 
   if (!EFI_ERROR (Status)) {
     Context->PickerCommand = OcPickerBootAppleRecovery;
-  } else if (AsciiStrCmp (ShowPicker, "ShowAlways") == 0) {
+  } else if (AsciiStrCmp (ShowPicker, "Always") == 0) {
     Context->PickerCommand = OcPickerShowPicker;
   } else if (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") == 0) {
     if (OcIsAppleHibernateWake ()) {

--- a/Utilities/ocvalidate/ValidateMisc.c
+++ b/Utilities/ocvalidate/ValidateMisc.c
@@ -256,8 +256,8 @@ CheckMiscBoot (
 
   ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
   if (  (AsciiStrCmp (ShowPicker, "Default") != 0)
-     && (AsciiStrCmp (ShowPicker, "SkipHibernate") != 0)
-     && (AsciiStrCmp (ShowPicker, "None") != 0))
+     && (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") != 0)
+     && (AsciiStrCmp (ShowPicker, "Hide") != 0))
   {
     DEBUG ((DEBUG_WARN, "Misc->Boot->ShowPicker is borked (Can only be Default, SkipHibernate, or None)!\n"));
     ++ErrorCount;

--- a/Utilities/ocvalidate/ValidateMisc.c
+++ b/Utilities/ocvalidate/ValidateMisc.c
@@ -200,6 +200,7 @@ CheckMiscBoot (
   BOOLEAN               IsAudioSupportEnabled;
   CONST CHAR8           *LauncherOption;
   CONST CHAR8           *LauncherPath;
+  CONST CHAR8           *ShowPicker;
 
   ErrorCount = 0;
 
@@ -250,6 +251,15 @@ CheckMiscBoot (
   PickerVariant = OC_BLOB_GET (&Config->Misc.Boot.PickerVariant);
   if (PickerVariant[0] == '\0') {
     DEBUG ((DEBUG_WARN, "Misc->Boot->PickerVariant cannot be empty!\n"));
+    ++ErrorCount;
+  }
+
+  ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
+  if (  (AsciiStrCmp (ShowPicker, "Default") != 0)
+     && (AsciiStrCmp (ShowPicker, "SkipHibernate") != 0)
+     && (AsciiStrCmp (ShowPicker, "None") != 0))
+  {
+    DEBUG ((DEBUG_WARN, "Misc->Boot->ShowPicker is borked (Can only be Default, SkipHibernate, or None)!\n"));
     ++ErrorCount;
   }
 

--- a/Utilities/ocvalidate/ValidateMisc.c
+++ b/Utilities/ocvalidate/ValidateMisc.c
@@ -255,11 +255,11 @@ CheckMiscBoot (
   }
 
   ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
-  if (  (AsciiStrCmp (ShowPicker, "Default") != 0)
+  if (  (AsciiStrCmp (ShowPicker, "ShowAlways") != 0)
      && (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") != 0)
      && (AsciiStrCmp (ShowPicker, "Hide") != 0))
   {
-    DEBUG ((DEBUG_WARN, "Misc->Boot->ShowPicker is borked (Can only be Default, SkipHibernate, or None)!\n"));
+    DEBUG ((DEBUG_WARN, "Misc->Boot->ShowPicker is borked (Can only be ShowAlways, SkipOnHibernateWake, or None)!\n"));
     ++ErrorCount;
   }
 

--- a/Utilities/ocvalidate/ValidateMisc.c
+++ b/Utilities/ocvalidate/ValidateMisc.c
@@ -255,11 +255,11 @@ CheckMiscBoot (
   }
 
   ShowPicker = OC_BLOB_GET (&Config->Misc.Boot.ShowPicker);
-  if (  (AsciiStrCmp (ShowPicker, "ShowAlways") != 0)
+  if (  (AsciiStrCmp (ShowPicker, "Always") != 0)
      && (AsciiStrCmp (ShowPicker, "SkipOnHibernateWake") != 0)
-     && (AsciiStrCmp (ShowPicker, "Hide") != 0))
+     && (AsciiStrCmp (ShowPicker, "Never") != 0))
   {
-    DEBUG ((DEBUG_WARN, "Misc->Boot->ShowPicker is borked (Can only be ShowAlways, SkipOnHibernateWake, or None)!\n"));
+    DEBUG ((DEBUG_WARN, "Misc->Boot->ShowPicker is borked (Can only be Always, SkipOnHibernateWake, or Never)!\n"));
     ++ErrorCount;
   }
 


### PR DESCRIPTION
Allows for seamless wake from hibernation, and avoids situation where someone may accidentally change the boot option when waking. Tests were conducted on a genuine MacBookPro11,3

Notes:

* Changes ShowPicker logic to be a string, takes following inputs:
  * `Always` - Show Picker regardless (previously `ShowPicker=True`).
  * `Never` - Never Show Picker (previously `ShowPicker=False`).
  * `SkipOnHibernateWake` - Hide Picker if machine is waking from macOS Hibernation.
    * Picker will still be shown if invoked via PollAppleHotKeys' Option/Esc keys.
    * Explicit setting to avoid accidental boot loops from botched Hibernation Configurations (Primarily PCs) where user may not realize or doesn't have PollAppleHotKeys enabled.
* Currently only detects macOS Hibernation, Linux and Windows Hibernation detection is unsupported at this time.

Reference: 
* https://github.com/acidanthera/bugtracker/issues/1722