### PR TITLE
TSC/FSB Fix for AMD CPUs

### DIFF
--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1415,31 +1415,30 @@ PatchProvideCurrentCpuInfo (
     return EFI_NOT_FOUND;
   }
 
-    //
-    // Perform TSC and FSB calculations. This is traditionally done in tsc.c in XNU.
-    //
-    // For AMD Processors
-    if ((CpuInfo->Family == 0xF) && ((CpuInfo->ExtFamily == 0x8) || (CpuInfo->ExtFamily == 0xA))) {
-      DEBUG ((DEBUG_INFO, "OCAK: Setting FSB and TSC for Family 0x%x and ExtFamily 0x%x\n", (UINT16)CpuInfo->Family, (UINT16)CpuInfo->ExtFamily));
-      busFreqValue    = CpuInfo->FSBFrequency;
-      busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
-      busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
+  //
+  // Perform TSC and FSB calculations. This is traditionally done in tsc.c in XNU.
+  //
+  // For AMD Processors
+  if ((CpuInfo->Family == 0xF) && ((CpuInfo->ExtFamily == 0x8) || (CpuInfo->ExtFamily == 0xA))) {
+    DEBUG ((DEBUG_INFO, "OCAK: Setting FSB and TSC for Family 0x%x and ExtFamily 0x%x\n", (UINT16)CpuInfo->Family, (UINT16)CpuInfo->ExtFamily));
+    busFreqValue    = CpuInfo->FSBFrequency;
+    busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
+    busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
 
-      tscFreqValue    = CpuInfo->CPUFrequency;
-      tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
-      tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL  << 32), tscFCvtt2nValue, NULL);
-    }
-    // For all other processors
-    else {
-      busFreqValue    = CpuInfo->FSBFrequency;
-      busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
-      busFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, busFCvtt2nValue, NULL);
+    tscFreqValue    = CpuInfo->CPUFrequency;
+    tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
+    tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL  << 32), tscFCvtt2nValue, NULL);
+  }
+  // For all other processors
+  else {
+    busFreqValue    = CpuInfo->FSBFrequency;
+    busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
+    busFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, busFCvtt2nValue, NULL);
 
-      tscFreqValue    = CpuInfo->CPUFrequency;
-      tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
-      tscFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, tscFCvtt2nValue, NULL);
-    }
-
+    tscFreqValue    = CpuInfo->CPUFrequency;
+    tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
+    tscFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, tscFCvtt2nValue, NULL);
+  }
 
   tscGranularityValue = DivU64x64Remainder (tscFreqValue, busFreqValue, NULL);
 

--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1418,13 +1418,27 @@ PatchProvideCurrentCpuInfo (
   //
   // Perform TSC and FSB calculations. This is traditionally done in tsc.c in XNU.
   //
-  busFreqValue    = CpuInfo->FSBFrequency;
-  busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
-  busFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, busFCvtt2nValue, NULL);
+  // For AMD Processors
+  if (CpuInfo->Family == 0xF && (CpuInfo->ExtFamily == 0x8 || CpuInfo->ExtFamily == 0xA)) {
+    DEBUG ((DEBUG_INFO, "OCAK: Setting FSB and TSC for Family 0x%x and ExtFamily 0x%x\n", (UINT16)CpuInfo->Family, (UINT16)CpuInfo->ExtFamily));
+    busFreqValue    = CpuInfo->FSBFrequency;
+    busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
+    busFCvtn2tValue = DivU64x64Remainder(((1000000000ULL) << 32), busFCvtt2nValue, NULL);
 
-  tscFreqValue    = CpuInfo->CPUFrequency;
-  tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
-  tscFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, tscFCvtt2nValue, NULL);
+    tscFreqValue    = CpuInfo->CPUFrequency;
+    tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
+    tscFCvtn2tValue = DivU64x64Remainder(((1000000000ULL)  << 32), tscFCvtt2nValue, NULL);
+    }
+    // For all other processors
+  else {
+    busFreqValue    = CpuInfo->FSBFrequency;
+    busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
+    busFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, busFCvtt2nValue, NULL);
+
+    tscFreqValue    = CpuInfo->CPUFrequency;
+    tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
+    tscFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, tscFCvtt2nValue, NULL);
+  }
 
   tscGranularityValue = DivU64x64Remainder (tscFreqValue, busFreqValue, NULL);
 

--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1420,25 +1420,26 @@ PatchProvideCurrentCpuInfo (
     //
     // For AMD Processors
     if ((CpuInfo->Family == 0xF) && ((CpuInfo->ExtFamily == 0x8) || (CpuInfo->ExtFamily == 0xA))) {
-          DEBUG ((DEBUG_INFO, "OCAK: Setting FSB and TSC for Family 0x%x and ExtFamily 0x%x\n", (UINT16)CpuInfo->Family, (UINT16)CpuInfo->ExtFamily));
-          busFreqValue    = CpuInfo->FSBFrequency;
-          busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
-          busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
+      DEBUG ((DEBUG_INFO, "OCAK: Setting FSB and TSC for Family 0x%x and ExtFamily 0x%x\n", (UINT16)CpuInfo->Family, (UINT16)CpuInfo->ExtFamily));
+      busFreqValue    = CpuInfo->FSBFrequency;
+      busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
+      busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
 
-          tscFreqValue    = CpuInfo->CPUFrequency;
-          tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
-          tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL  << 32), tscFCvtt2nValue, NULL);
+      tscFreqValue    = CpuInfo->CPUFrequency;
+      tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
+      tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL  << 32), tscFCvtt2nValue, NULL);
     }
     // For all other processors
     else {
-          busFreqValue    = CpuInfo->FSBFrequency;
-          busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
-          busFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, busFCvtt2nValue, NULL);
+      busFreqValue    = CpuInfo->FSBFrequency;
+      busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
+      busFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, busFCvtt2nValue, NULL);
 
-          tscFreqValue    = CpuInfo->CPUFrequency;
-          tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
-          tscFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, tscFCvtt2nValue, NULL);
+      tscFreqValue    = CpuInfo->CPUFrequency;
+      tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
+      tscFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, tscFCvtt2nValue, NULL);
     }
+
 
   tscGranularityValue = DivU64x64Remainder (tscFreqValue, busFreqValue, NULL);
 

--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1415,30 +1415,30 @@ PatchProvideCurrentCpuInfo (
     return EFI_NOT_FOUND;
   }
 
-  //
-  // Perform TSC and FSB calculations. This is traditionally done in tsc.c in XNU.
-  //
-  // For AMD Processors
-  if (CpuInfo->Family == 0xF && (CpuInfo->ExtFamily == 0x8 || CpuInfo->ExtFamily == 0xA)) {
-    DEBUG ((DEBUG_INFO, "OCAK: Setting FSB and TSC for Family 0x%x and ExtFamily 0x%x\n", (UINT16)CpuInfo->Family, (UINT16)CpuInfo->ExtFamily));
-    busFreqValue    = CpuInfo->FSBFrequency;
-    busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
-    busFCvtn2tValue = DivU64x64Remainder(((1000000000ULL) << 32), busFCvtt2nValue, NULL);
+    //
+    // Perform TSC and FSB calculations. This is traditionally done in tsc.c in XNU.
+    //
+    // For AMD Processors
+    if ((CpuInfo->Family == 0xF) && ((CpuInfo->ExtFamily == 0x8) || (CpuInfo->ExtFamily == 0xA))) {
+          DEBUG ((DEBUG_INFO, "OCAK: Setting FSB and TSC for Family 0x%x and ExtFamily 0x%x\n", (UINT16)CpuInfo->Family, (UINT16)CpuInfo->ExtFamily));
+          busFreqValue    = CpuInfo->FSBFrequency;
+          busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
+          busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
 
-    tscFreqValue    = CpuInfo->CPUFrequency;
-    tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
-    tscFCvtn2tValue = DivU64x64Remainder(((1000000000ULL)  << 32), tscFCvtt2nValue, NULL);
+          tscFreqValue    = CpuInfo->CPUFrequency;
+          tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
+          tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL  << 32), tscFCvtt2nValue, NULL);
     }
-  // For all other processors
-  else {
-    busFreqValue    = CpuInfo->FSBFrequency;
-    busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
-    busFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, busFCvtt2nValue, NULL);
+    // For all other processors
+    else {
+          busFreqValue    = CpuInfo->FSBFrequency;
+          busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
+          busFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, busFCvtt2nValue, NULL);
 
-    tscFreqValue    = CpuInfo->CPUFrequency;
-    tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
-    tscFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, tscFCvtt2nValue, NULL);
-  }
+          tscFreqValue    = CpuInfo->CPUFrequency;
+          tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
+          tscFCvtn2tValue = DivU64x64Remainder (0xFFFFFFFFFFFFFFFFULL, tscFCvtt2nValue, NULL);
+    }
 
   tscGranularityValue = DivU64x64Remainder (tscFreqValue, busFreqValue, NULL);
 

--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1429,7 +1429,7 @@ PatchProvideCurrentCpuInfo (
     tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
     tscFCvtn2tValue = DivU64x64Remainder(((1000000000ULL)  << 32), tscFCvtt2nValue, NULL);
     }
-    // For all other processors
+  // For all other processors
   else {
     busFreqValue    = CpuInfo->FSBFrequency;
     busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);


### PR DESCRIPTION
Initial TSC frequency calculation for AMD processors differs somewhat from the frequency calculation for Intel processors. Without special treatment for AMD processors, macOS suffers from TSC de-sync particularly if the AMD processor has on-board GPU. This in turn leads to significant amounts of audio stutter across the entire audio subsystem. This PR has been tested on both AMD and Intel processors to ensure proper operation for both platforms.