### PR TITLE
User: Add pool allocation size configurable limits for UserBaseMemoryLib

### DIFF
--- a/User/Include/UserMemory.h
+++ b/User/Include/UserMemory.h
@@ -6,6 +6,11 @@
 #ifndef USER_MEMORY_H
 #define USER_MEMORY_H
 
+//
+// Limits single pool allocation size to 512MB by default.
+//
+extern UINTN  mPoolAllocationSizeLimit;
+
 extern UINTN  mPoolAllocations;
 extern UINTN  mPageAllocations;
 
@@ -13,5 +18,10 @@ extern UINT64  mPoolAllocationMask;
 extern UINTN   mPoolAllocationIndex;
 extern UINT64  mPageAllocationMask;
 extern UINTN   mPageAllocationIndex;
+
+VOID
+SetPoolAllocationSizeLimit (
+  UINTN  AllocationSize
+  );
 
 #endif // USER_MEMORY_H

--- a/User/README.md
+++ b/User/README.md
@@ -32,7 +32,7 @@ Additional variables are supported to adjust the compilation process.
 - `DEBUG=1` — build with debugging information.
 - `FUZZ=1` — build with fuzzing enabled.
 - `FUZZ_JOBS=2` — run with 2 fuzzing jobs (defaults to 4).
-- `FUZZ_MEM=1024` - run with 1024 MB fuzzing memory limit (defaults to 4096).
+- `FUZZ_MEM=1024` - run with 1024 MB fuzzing memory limit (defaults to 4096)*.
 - `SANITIZE=1` — build with LLVM sanitizers enabled.
 - `CC=cc` — build with `cc` compiler (e.g. `i686-w64-mingw32-gcc` for Windows).
 - `DIST=Target` — build for target `Target` (e.g. `Darwin`, `Linux`, `Windows`).
@@ -44,6 +44,22 @@ Additional variables are supported to adjust the compilation process.
 - `SYDR=1` — change `$(SUFFIX)` to store compilation results for Sydr DSE in a directory distinct from the default one.
 
 Example 1. To build 32-bit version of utility on macOS (use High Sierra 10.13 or below):
+
+NOTE: If your program uses `UserBaseMemoryLib` and calls custom allocation functions, be sure that besides `FUZZ_MEM` limit you correctly set limit `mPoolAllocationSizeLimit` which defaults to the 512 MB in cases if your code could allocate more than this limit at single AllocatePool.
+
+To set up your limit, use `SetPoolAllocationSizeLimit` routine like shown in the example below:
+
+```
+...
+#include <UserMemory.h>
+
+int main(int argc, char *argv[]) {
+  SetPoolAllocationSizeLimit (SINGLE_ALLOCATION_MEMORY_LIMIT);
+  /* your code goes here */
+  return 0;
+}
+```
+
 
 ```sh
 UDK_ARCH=Ia32 make

--- a/Utilities/TestDiskImage/DiskImage.c
+++ b/Utilities/TestDiskImage/DiskImage.c
@@ -12,6 +12,7 @@
 #include <Library/DebugLib.h>
 
 #include <UserFile.h>
+#include <UserMemory.h>
 
 #define  NUM_EXTENTS  20
 
@@ -34,6 +35,11 @@ ENTRY_POINT (
   APPLE_RAM_DISK_EXTENT_TABLE  ExtentTable;
   UINT32                       Index2;
   OC_APPLE_CHUNKLIST_CONTEXT   ChunklistContext;
+
+  //
+  // Limit pool allocation size to 3072 MB
+  //
+  SetPoolAllocationSizeLimit (BASE_1GB | BASE_2GB);
 
   if (argc < 2) {
     DEBUG ((DEBUG_ERROR, "Please provide a valid Disk Image path\n"));


### PR DESCRIPTION
This changes should help us more accurately control pool allocations during fuzzing, as for example the handling of OOM-states. We provides options to limit by size total allocated memory and to limit maximum size of single allocation operation.
It is still open for discussion the size of these limits and the interface for changing them ("Set" routines in User Memory header)