### PR TITLE
Minor Tweaks to Docs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@ OpenCore Changelog
   - `Never` - Never show picker (equivalent to 0.8.6's ShowPicker=False)
   - `SkipOnHibernateWake` - Don't show picker if waking from macOS hibernation
 - Changed macrecovery to download files into `com.apple.recovery.boot` by default, thx @dreamwhite
-- Supported Apple builtin picker (using `BootKicker.efi` or `PickerMode` `Apple`) on MacPro5,1 graphics cards with no firmware Mac-EFI support (thx @cdf, @tsialex)
+- Supported Apple builtin picker (using `BootKicker.efi` or `PickerMode` `Apple`) when running GPUs without Mac-EFI support on units such as the MacPro5,1 (thx @cdf, @tsialex)
 - Enabled `PickerMode` `Apple` to successfully launch selected entry
 - Enabled `BootKicker.efi` to successfully launch selected entry (via reboot) (thx @cdf)
 
@@ -303,7 +303,7 @@ OpenCore Changelog
 - Fixed ACPI table magic corruption during patching
 - Fixed unnatural OpenCanopy and FileVault 2 cursor movement
 - Fixed OpenCanopy interrupt handling causing missed events and lag
-- Improved OpenCanopy double-click detection 
+- Improved OpenCanopy double-click detection
 - Reduced OpenCanopy touch input lag and improved usability
 - Improved keypress responsiveness in OpenCanopy and builtin pickers
 - Improved non-repeating key detection in OpenCanopy and builtin pickers

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -8607,8 +8607,8 @@ for additional options.
   \textbf{Failsafe}: \texttt{false}\\
   \textbf{Description}: Implement partial UEFI 2.x support on EFI 1.x firmware.
 
-  This setting allows running some software written for UEFI 2.x firmware like NVIDIA GOP
-  Option ROMs on hardware with older EFI 1.x firmware like \texttt{MacPro5,1}.
+  This setting allows running some software written for UEFI 2.x firmware, such as NVIDIA GOP
+  Option ROMs, on hardware with older EFI 1.x firmware (e.g. \texttt{MacPro5,1}).
 
 \item
   \texttt{IgnoreInvalidFlexRatio}\\
@@ -9263,10 +9263,10 @@ than 1 meter to avoid output corruption. To additionally enable XNU kernel seria
 \item
   \textbf{Can I use this on Apple hardware or virtual machines?}
 
-  Sure, most relatively modern Mac models including \texttt{MacPro5,1} and virtual machines
-  are fully supported. Even though there are little to none specific details relevant to
-  Mac hardware, some ongoing instructions can be found on
-  \href{https://forums.macrumors.com/threads/opencore-on-the-mac-pro.2207814}{MacRumors.com}.
+  Yes. Virtual machines and most relatively modern Mac models, as far back as the \texttt{MacPro3,1},
+  are fully supported. While specific detail relevant to Mac hardware is often limited,
+  some ongoing instructions can be found on
+  \href{https://forums.macrumors.com/threads/2207814}{MacRumors.com}.
 
 \item
   \textbf{Why must Find\&Replace patches be equal in size?}


### PR DESCRIPTION
Some minor tweaks for clarity

Mainly:
- Changelog.md: Reworded to better convey intent given that there are no MP51 specific GPUs as was implied
- Configuration.tex: Reworded for clarity on VM and better outline support scope on Apple Hardware
  - Previously _suggested_ support only goes as far as MP51 but MP31 is effectively the  boundary