### PR TITLE
"Spoof Proof" Setting UEFI 2.x Member

### DIFF
--- a/Platform/OpenVariableRuntimeDxe/VariableDxe.c
+++ b/Platform/OpenVariableRuntimeDxe/VariableDxe.c
@@ -648,8 +648,10 @@ VariableServiceInitialize (
   )
 {
   EFI_STATUS           Status;
-  EFI_EVENT            ReadyToBootEvent;
+  UINTN                OffsetQVI;
+  UINTN                HeaderQVI;
   EFI_EVENT            EndOfDxeEvent;
+  EFI_EVENT            ReadyToBootEvent;
   EFI_CREATE_EVENT_EX  OriginalCreateEventEx;
 
   SaveAcpiGlobalVariable (SystemTable);
@@ -684,8 +686,18 @@ VariableServiceInitialize (
   //
   // Avoid setting UEFI 2.x interface member on EFI 1.x.
   //
-  if (SystemTable->RuntimeServices->Hdr.Revision >= EFI_2_00_SYSTEM_TABLE_REVISION) {
-    SystemTable->RuntimeServices->QueryVariableInfo = VariableServiceQueryVariableInfo;
+  // First test all systable elements as some may have been spoofed and pass a limited element check
+  // Then check that QueryVariableInfo is specifically available before setting the interface member
+  //
+  if (  ((SystemTable->Hdr.Revision >> 16U) > 1)
+     && ((SystemTable->BootServices->Hdr.Revision >> 16U) > 1)
+     && ((SystemTable->RuntimeServices->Hdr.Revision >> 16U) > 1))
+  {
+    OffsetQVI = OFFSET_OF (EFI_RUNTIME_SERVICES, QueryVariableInfo);
+    HeaderQVI = OffsetQVI + sizeof (SystemTable->RuntimeServices->QueryVariableInfo);
+    if (SystemTable->RuntimeServices->Hdr.HeaderSize >= HeaderQVI) {
+      SystemTable->RuntimeServices->QueryVariableInfo = VariableServiceQueryVariableInfo;
+    }
   }
 
   //


### PR DESCRIPTION
UEFI 2.x spoofing, including `ForgeUEFI` in OpenCore, tend to only spoof one element of the system table. Hence, a test on single elements will pass, and UEFI 2.x assumed to be present, if the test happens to be on the spoofed element. 

This is more so the case where OpenCore may be loaded by other tools that may have spoofed the element being tested here. While loading via other tools may not be sanctioned, it is regardless best to always ensure that UEFI 2.x cannot be wrongly assumed under any circumstance.

The proposed change does the following:
- Ensures all system table elements are UEFI 2.x
- Ensures QueryVariableInfo is actually available

This ensures QueryVariableInfo is not set under any type of spoofed UEFI 2.x environment but should there be actual UEFI 2.x emulation at some point in the future, QueryVariableInfo will be set for such.

