### PR TITLE
Update to EDKII 202211 stable tag

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -61,7 +61,7 @@ jobs:
 
   analyze-python-scripts:
     name: Python Scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_TYPE: ANALYZE
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   analyze-docs-linux:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'acidanthera' && github.ref_name == 'master'
     steps:
       - uses: actions/checkout@v3
@@ -100,7 +100,7 @@ jobs:
 
   analyze-coverity:
     name: Coverity
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_TYPE: COVERITY
       TOOLCHAINS: GCC5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
   build-linux-clangpdb-gcc5:
     name: Linux CLANGPDB/GCC5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -89,7 +89,7 @@ jobs:
 
   build-linux-clangdwarf:
     name: Linux CLANGDWARF
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       TOOLCHAINS: CLANGDWARF
     steps:

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   analyze-uncrustify:
     name: Check Codestyle
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 OpenCore Changelog
 ==================
+#### v0.8.8
+- Updated underlying EDK II package to edk2-stable202211
+
 #### v0.8.7
 - Removed unwanted clear screen when launching non-text boot entry
 - Fixed TSC/FSB for AMD CPUs in ProvideCurrentCpuInfo, thx @Shaneee

--- a/Library/OcCpuLib/FrequencyDetect.c
+++ b/Library/OcCpuLib/FrequencyDetect.c
@@ -618,7 +618,7 @@ InternalCalculateVMTFrequency (
   }
 
   if (UnderHypervisor != NULL) {
-    *UnderHypervisor = CpuidVerEcx.Bits.NotUsed != 0;
+    *UnderHypervisor = CpuidVerEcx.Bits.ParaVirtualized != 0;
   }
 
   //
@@ -626,7 +626,7 @@ InternalCalculateVMTFrequency (
   // See https://github.com/acidanthera/audk/pull/2.
   // Get Hypervisor/Virtualization information.
   //
-  if (CpuidVerEcx.Bits.NotUsed == 0) {
+  if (CpuidVerEcx.Bits.ParaVirtualized == 0) {
     return 0;
   }
 

--- a/OpenCorePkg.dsc
+++ b/OpenCorePkg.dsc
@@ -161,6 +161,7 @@
   UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
   UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
+  VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   ResetSystemLib|OpenCorePkg/Library/OcResetSystemLib/OcResetSystemLib.inf
 
   !include NetworkPkg/NetworkLibs.dsc.inc

--- a/OpenDuetPkg.dsc
+++ b/OpenDuetPkg.dsc
@@ -78,6 +78,7 @@
   VarCheckLib|MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
+  VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   #
   # Generic Modules
   #


### PR DESCRIPTION
This change correct OpenCorePkg build for updated underlying EDK II package with edk2-stable202211tag