### PR TITLE
Introduce Docker setup for Dev Containers and CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "oc",
+  "dockerComposeFile": "../compose-dev.yaml",
+  "service": "dev-edk2-docs",
+  "workspaceFolder": "/com.docker.devenvironments.code",
+  "shutdownAction": "stopCompose"
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,70 +59,65 @@ jobs:
           tag: ${{ github.ref }}
           file_glob: true
 
-  build-linux-clangpdb-gcc5:
-    name: Linux CLANGPDB/GCC5
+  build-linux-clangpdb:
+    name: Linux CLANGPDB
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install nasm uuid-dev libssl-dev iasl
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 13
-          echo "/usr/lib/llvm-13/bin" >> $GITHUB_PATH
-
-      - name: CI Bootstrap
-        run: |
-          src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
-
-      - run: ./build_duet.tool
-      - run: ./build_oc.tool
+      - name: ./build_duet.tool
+        run: docker compose run -e TOOLCHAINS=CLANGPDB build-duet
+      - name: ./build_oc.tool
+        run: docker compose run -e TOOLCHAINS=CLANGPDB build-oc
 
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: Linux CLANGPDB-GCC5 Artifacts
+          name: Linux CLANGPDB Artifacts
+          path: Binaries/*.zip
+
+  build-linux-gcc5:
+    name: Linux GCC5
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: ./build_duet.tool
+        run: docker compose run -e TOOLCHAINS=GCC5 build-duet
+      - name: ./build_oc.tool
+        run: docker compose run -e TOOLCHAINS=GCC5 build-oc
+
+      - name: Upload to Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Linux GCC5 Artifacts
           path: Binaries/*.zip
 
   build-linux-clangdwarf:
     name: Linux CLANGDWARF
     runs-on: ubuntu-22.04
-    env:
-      TOOLCHAINS: CLANGDWARF
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install nasm uuid-dev iasl doxygen texlive texlive-latex-extra
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 13
-          echo "/usr/lib/llvm-13/bin" >> $GITHUB_PATH
-
-      - name: CI Bootstrap
-        run: |
-          src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
-
-      - run: ./build_duet.tool
-      - run: ./build_oc.tool
-
-      - name: Docs
-        run: |
-          abort() { tail -200 log.txt ; exit 1 ; }
-          doxygen Doxyfile &> log.txt || abort
-          cd Doxy/latex || abort
-          make pdf &> log.txt || abort
+      - name: ./build_duet.tool
+        run: docker compose run -e TOOLCHAINS=CLANGDWARF build-duet
+      - name: ./build_oc.tool
+        run: docker compose run -e TOOLCHAINS=CLANGDWARF build-oc
 
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v3
         with:
           name: Linux CLANGDWARF Artifacts
           path: Binaries/*.zip
+
+  build-linux-docs:
+    name: Linux Docs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docs
+        run: docker compose run build-docs
 
   build-windows:
     name: Windows VS2019

--- a/Dockerfiles/oc-dev-docs/Dockerfile
+++ b/Dockerfiles/oc-dev-docs/Dockerfile
@@ -1,0 +1,7 @@
+ARG OC_DEV_DOCS_BASE=ubuntu:22.04
+FROM $OC_DEV_DOCS_BASE
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y make doxygen texlive texlive-latex-extra && \
+    rm -rf /var/lib/apt/lists/*

--- a/Dockerfiles/oc-dev-edk2/Dockerfile
+++ b/Dockerfiles/oc-dev-edk2/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y lsb-release wget software-properties-common gnupg build-essential nasm uuid-dev libssl-dev iasl curl git zip && \
+    { [ "$(dpkg --print-architecture)" == "amd64" ] || { apt-get install -y gcc-x86-64-linux-gnu && export GCC5_BIN=x86_64-linux-gnu- ; } ; } && echo "export GCC5_BIN=$GCC5_BIN" > ~/.edk2_rc.sh && echo ". ~/.edk2_rc.sh" > /etc/profile.d/edk2-gcc5.sh && \
+    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13 && rm -f llvm.sh && \
+    apt-get purge --auto-remove -y wget software-properties-common gnupg && \
+    rm -rf /var/lib/apt/lists/*
+ENV PATH="$PATH:/usr/lib/llvm-13/bin"

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -1,0 +1,16 @@
+name: oc
+services:
+  dev-edk2-docs:
+    extends:
+      file: docker-compose.yaml
+      service: dev-docs
+    build:
+      args:
+        OC_DEV_DOCS_BASE: oc-dev-edk2
+      tags:
+        - "oc-dev-edk2-docs"
+    volumes:
+      - .:/com.docker.devenvironments.code
+    entrypoint:
+      - sleep
+      - infinity

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,45 @@
+name: oc
+services:
+  dev-edk2:
+    build:
+      context: Dockerfiles/oc-dev-edk2
+      tags:
+        - "oc-dev-edk2"
+  dev-docs:
+    build:
+      context: Dockerfiles/oc-dev-docs
+      tags:
+        - "oc-dev-docs"
+  build-oc:
+    depends_on:
+      - dev-edk2
+    image: oc-dev-edk2
+    volumes:
+      - .:/com.docker.devenvironments.code
+    working_dir: /com.docker.devenvironments.code
+    entrypoint:
+      - /bin/bash
+      - -c
+      - "{ . ~/.edk2_rc.sh && eval \"$$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh)\" && ./build_oc.tool ; } || exit 1"
+  build-duet:
+    depends_on:
+      - dev-edk2
+    image: oc-dev-edk2
+    volumes:
+      - .:/com.docker.devenvironments.code
+    working_dir: /com.docker.devenvironments.code
+    entrypoint:
+      - /bin/bash
+      - -c
+      - "{ . ~/.edk2_rc.sh && eval \"$$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh)\" && ./build_duet.tool ; } || exit 1"
+  build-docs:
+    depends_on:
+      - dev-docs
+    image: oc-dev-docs
+    volumes:
+      - .:/com.docker.devenvironments.code
+    working_dir: /com.docker.devenvironments.code
+    entrypoint:
+      - /bin/bash
+      - -c
+      - "{ doxygen Doxyfile &> log.txt && cd Doxy/latex && make pdf &> log.txt ; } || { tail -200 log.txt ; exit 1 ; }"


### PR DESCRIPTION
Docker allows to set up a portable development environment in a container. This can be useful to test Linux toolchains on macOS. Introduce such environments for EDK II and documentation development.

The current implementation supports both Dev Environments by Docker Desktop and Dev Containers by Visual Studio Code. To reduce the maintenance burden, use these environments for the Linux-based GitHub Actions as well. Non-x86 hosts, including Apple Silicon, are supported via GCC cross-compilation.