### PR TITLE
User: Corrects ASSERT behavior in UserPcd

### DIFF
--- a/User/Library/UserMisc.c
+++ b/User/Library/UserMisc.c
@@ -14,10 +14,7 @@ CpuBreakpoint (
   VOID
   )
 {
-  ASSERT (FALSE);
-
-  while (TRUE) {
-  }
+  abort ();
 }
 
 VOID

--- a/User/Library/UserPcd.c
+++ b/User/Library/UserPcd.c
@@ -4,10 +4,14 @@
 **/
 
 #include <UserPcd.h>
+#include <Library/DebugLib.h>
 
 #define _PCD_VALUE_PcdUefiLibMaxPrintBufferSize         320U
 #define _PCD_VALUE_PcdUgaConsumeSupport                 ((BOOLEAN)1U)
-#define _PCD_VALUE_PcdDebugPropertyMask                 0x23U
+#define _PCD_VALUE_PcdDebugPropertyMask                 (\
+  DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED \
+  | DEBUG_PROPERTY_DEBUG_PRINT_ENABLED \
+  | DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED )
 #define _PCD_VALUE_PcdDebugClearMemoryValue             0xAFU
 #define _PCD_VALUE_PcdFixedDebugPrintErrorLevel         0x80000002U
 #define _PCD_VALUE_PcdDebugPrintErrorLevel              0x80000002U


### PR DESCRIPTION
The CpuBreakPoint in UserMisc normally shouldn't enter dead-loop condition, instead it should break the program using abort signal. Also sets DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED bit by default in PcdDebugPropertyMask. As a background was a problem with fuzzing when program process falls into dead-loop condition instead of just to exit with crash