### PR TITLE
OcConsoleLib: Prevent failure to properly start console in graphics mode…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ OpenCore Changelog
 - Fixed loading macOS with legacy boot without Apple Secure Boot
 - Added Linux support to legacy boot BootInstall script
 - Updated builtin firmware versions for SMBIOS and the rest
+- Fixed incomplete console mode initialisation when started in graphics mode
 
 #### v0.8.8
 - Updated underlying EDK II package to edk2-stable202211

--- a/Library/OcConsoleLib/ConsoleControl.c
+++ b/Library/OcConsoleLib/ConsoleControl.c
@@ -72,9 +72,9 @@ OcConsoleControlSetMode (
 
 EFI_STATUS
 OcConsoleControlInstallProtocol (
-  IN  EFI_CONSOLE_CONTROL_PROTOCOL     *NewProtocol,
-  OUT EFI_CONSOLE_CONTROL_PROTOCOL     *OldProtocol  OPTIONAL,
-  OUT EFI_CONSOLE_CONTROL_SCREEN_MODE  *OldMode  OPTIONAL
+  IN  EFI_CONSOLE_CONTROL_PROTOCOL        *NewProtocol,
+  OUT EFI_CONSOLE_CONTROL_PROTOCOL        *OldProtocol  OPTIONAL,
+  IN OUT EFI_CONSOLE_CONTROL_SCREEN_MODE  *OldMode  OPTIONAL
   )
 {
   EFI_STATUS                    Status;

--- a/Library/OcConsoleLib/OcConsoleLibInternal.h
+++ b/Library/OcConsoleLib/OcConsoleLibInternal.h
@@ -49,11 +49,14 @@ OcSetConsoleModeForProtocol (
   IN  UINT32                           Height
   );
 
+//
+// Note: OldMode remains unchanged if no native console control protocol implementation is found.
+//
 EFI_STATUS
 OcConsoleControlInstallProtocol (
-  IN  EFI_CONSOLE_CONTROL_PROTOCOL     *NewProtocol,
-  OUT EFI_CONSOLE_CONTROL_PROTOCOL     *OldProtocol  OPTIONAL,
-  OUT EFI_CONSOLE_CONTROL_SCREEN_MODE  *OldMode  OPTIONAL
+  IN     EFI_CONSOLE_CONTROL_PROTOCOL     *NewProtocol,
+  OUT EFI_CONSOLE_CONTROL_PROTOCOL        *OldProtocol  OPTIONAL,
+  IN OUT EFI_CONSOLE_CONTROL_SCREEN_MODE  *OldMode  OPTIONAL
   );
 
 EFI_STATUS

--- a/Library/OcConsoleLib/TextOutputBuiltin.c
+++ b/Library/OcConsoleLib/TextOutputBuiltin.c
@@ -973,8 +973,8 @@ OcUseBuiltinTextOutput (
   Status = AsciiTextResetEx (&mAsciiTextOutputProtocol, TRUE, TRUE);
 
   if (!EFI_ERROR (Status)) {
-    OcConsoleControlSetMode (Mode);
     OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, NULL);
+    OcConsoleControlSetMode (Mode);
 
     gST->ConOut    = &mAsciiTextOutputProtocol;
     gST->Hdr.CRC32 = 0;

--- a/Library/OcConsoleLib/TextOutputSystem.c
+++ b/Library/OcConsoleLib/TextOutputSystem.c
@@ -344,11 +344,11 @@ OcUseSystemTextOutput (
     ));
 
   if (Renderer == OcConsoleRendererSystemGraphics) {
+    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, NULL);
     OcConsoleControlSetMode (EfiConsoleControlScreenGraphics);
-    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, &mConsoleMode);
   } else if (Renderer == OcConsoleRendererSystemText) {
+    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, NULL);
     OcConsoleControlSetMode (EfiConsoleControlScreenText);
-    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, &mConsoleMode);
   } else {
     OcConsoleControlInstallProtocol (&mConsoleControlProtocol, &mOriginalConsoleControlProtocol, &mConsoleMode);
   }


### PR DESCRIPTION
…when previous console control protocol is non-existent or limited

Having already raised and briefly discussed this issue by PM, this is a PR for it.

I encountered this when developing #414 . The issue is the known problem of APFS log lines appearing too early (pre native picker) in the boot sequence, occurring again with the #414 driver. In this case this is fixable within OC, see https://github.com/mikebeaton/OpenCorePkg/blob/enable-gop/Staging/EnableGop/EnableGop.c#L49-L87 for a description of the problem (EDIT: sample code which was linked in preceding is now removed).