### PR TITLE
Build: Provide EDK-II BaseTools in releases

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ OpenCore Changelog
 - Added version number to EnableGop UI section, so tool builders can track it
 - Added `ProvideCurrentCpuInfo` support for macOS 13.3 DP
 - Added AMD support, GOP offset auto-detection and macOS 10.11+ support to EnableGop vBIOS insertion script
+- Included precompiled EDK-II `EfiRom` and `GenFfs` in `Utilities/BaseTools` with OpenCore releases
 
 #### v0.8.9
 - Improved debug logging when applying ACPI patches

--- a/build_oc.tool
+++ b/build_oc.tool
@@ -275,6 +275,16 @@ package() {
     cp "${selfdir}/Staging/EnableGop/${file}" "${dstdir}/Utilities/EnableGop"/ || exit 1
   done
 
+  # Provide EDK-II BaseTools.
+  mkdir "${dstdir}/Utilities/BaseTools" || exit 1
+  if [ "$(unamer)" = "Windows" ]; then
+    cp "${selfdir}/UDK/BaseTools/Bin/Win32/EfiRom.exe" "${dstdir}/Utilities/BaseTools" || exit 1
+    cp "${selfdir}/UDK/BaseTools/Bin/Win32/GenFfs.exe" "${dstdir}/Utilities/BaseTools" || exit 1
+  else
+    cp "${selfdir}/UDK/BaseTools/Source/C/bin/EfiRom" "${dstdir}/Utilities/BaseTools" || exit 1
+    cp "${selfdir}/UDK/BaseTools/Source/C/bin/GenFfs" "${dstdir}/Utilities/BaseTools" || exit 1
+  fi
+
   utils=(
     "ACPIe"
     "acdtinfo"


### PR DESCRIPTION
This might be useful - as discussed EfiRom is useful for EnableGop vBiosInsert.sh script - it's not particularly easy to find pre-built [EDK-II BaseTools](https://edk2-docs.gitbook.io/edk-ii-basetools-user-guides/tianocompress) (perhaps especially for macOS), and it is easy for us to provide them.

Adds about 1Mb to the release zip size.

<img width="1041" alt="Screenshot 2023-03-01 at 23 07 16" src="https://user-images.githubusercontent.com/11946605/222287264-a0cd75d2-1232-49a5-9b82-38f5d913965a.png">

