### PR TITLE
OcMemoryLib: Optionally return page table level and control bits from OcGetPhysicalAddress

### DIFF
--- a/Include/Acidanthera/Library/OcMemoryLib.h
+++ b/Include/Acidanthera/Library/OcMemoryLib.h
@@ -391,17 +391,21 @@ OcGetCurrentPageTable (
 /**
   Return physical addrress for given virtual addrress.
 
-  @param[in]  PageTable       Page table to use for solving.
-  @param[in]  VirtualAddr     Virtual address to look up.
-  @param[out] PhysicalAddr    Physical address to return.
+  @param[in,out]  PageTable       Page table to use for solving.
+  @param[in]      VirtualAddr     Virtual address to look up.
+  @param[out]     PhysicalAddr    Physical address to return.
+  @param[out]     Level           Page table mapping level, 1, 2 or 4 for 1Gb, 2Mb or 4kb.
+  @param[out]     Bits            Page table raw mapping and flag bits.
 
   @retval EFI_SUCCESS on successful lookup.
 **/
 EFI_STATUS
 OcGetPhysicalAddress (
-  IN  PAGE_MAP_AND_DIRECTORY_POINTER  *PageTable  OPTIONAL,
-  IN  EFI_VIRTUAL_ADDRESS             VirtualAddr,
-  OUT EFI_PHYSICAL_ADDRESS            *PhysicalAddr
+  IN OUT  PAGE_MAP_AND_DIRECTORY_POINTER  *PageTable  OPTIONAL,
+  IN      EFI_VIRTUAL_ADDRESS             VirtualAddr,
+  OUT     EFI_PHYSICAL_ADDRESS            *PhysicalAddr,
+  OUT     UINTN                           *Level      OPTIONAL,
+  OUT     UINT64                          *Bits       OPTIONAL
   );
 
 /**

--- a/Include/Intel/IndustryStandard/ProcessorInfo.h
+++ b/Include/Intel/IndustryStandard/ProcessorInfo.h
@@ -128,15 +128,15 @@
 #define MSR_DRAM_PERF_STATUS    0x61B
 #define MSR_DRAM_POWER_INFO     0x61C
 
-/// x86 Page Address Translation
+/// x86 Page Attribute Table (PAT) cache types
 enum {
-  PageAddressTranslationUncached       = 0,
-  PageAddressTranslationWriteCombining = 1,
-  PageAddressTranslationWriteThrough   = 4,
-  PageAddressTranslationWriteProtected = 5,
-  PageAddressTranslationWriteBack      = 6,
+  PageAttributeTableUncached       = 0,
+  PageAttributeTableWriteCombining = 1,
+  PageAttributeTableWriteThrough   = 4,
+  PageAttributeTableWriteProtected = 5,
+  PageAttributeTableWriteBack      = 6,
   /// Uncached, but can be overriden by MTRR
-  PageAddressTranslationOverridableUncached = 7,
+  PageAttributeTableOverridableUncached = 7,
 };
 
 #define K8_FIDVID_STATUS   0xC0010042

--- a/Library/OcMemoryLib/VirtualMemory.c
+++ b/Library/OcMemoryLib/VirtualMemory.c
@@ -71,9 +71,11 @@ EnablePageTableWriteProtection (
 
 EFI_STATUS
 OcGetPhysicalAddress (
-  IN  PAGE_MAP_AND_DIRECTORY_POINTER  *PageTable  OPTIONAL,
-  IN  EFI_VIRTUAL_ADDRESS             VirtualAddr,
-  OUT EFI_PHYSICAL_ADDRESS            *PhysicalAddr
+  IN OUT  PAGE_MAP_AND_DIRECTORY_POINTER  *PageTable  OPTIONAL,
+  IN      EFI_VIRTUAL_ADDRESS             VirtualAddr,
+  OUT     EFI_PHYSICAL_ADDRESS            *PhysicalAddr,
+  OUT     UINTN                           *Level      OPTIONAL,
+  OUT     UINT64                          *Bits       OPTIONAL
   )
 {
   EFI_PHYSICAL_ADDRESS            Start;
@@ -128,6 +130,15 @@ OcGetPhysicalAddress (
     PTE1G         = (PAGE_TABLE_1G_ENTRY *)PDPE;
     Start         = PTE1G->Uint64 & PAGING_1G_ADDRESS_MASK_64;
     *PhysicalAddr = Start + VA.Pg1G.PhysPgOffset;
+
+    if (Level != NULL) {
+      *Level = 1;
+    }
+
+    if (Bits != NULL) {
+      *Bits = PTE1G->Uint64;
+    }
+
     return EFI_SUCCESS;
   }
 
@@ -150,6 +161,15 @@ OcGetPhysicalAddress (
     PTE2M         = (PAGE_TABLE_2M_ENTRY *)PDE;
     Start         = PTE2M->Uint64 & PAGING_2M_ADDRESS_MASK_64;
     *PhysicalAddr = Start + VA.Pg2M.PhysPgOffset;
+
+    if (Level != NULL) {
+      *Level = 2;
+    }
+
+    if (Bits != NULL) {
+      *Bits = PTE2M->Uint64;
+    }
+
     return EFI_SUCCESS;
   }
 
@@ -167,6 +187,14 @@ OcGetPhysicalAddress (
 
   Start         = PTE4K->Uint64 & PAGING_4K_ADDRESS_MASK_64;
   *PhysicalAddr = Start + VA.Pg4K.PhysPgOffset;
+
+  if (Level != NULL) {
+    *Level = 4;
+  }
+
+  if (Bits != NULL) {
+    *Bits = PTE4K->Uint64;
+  }
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
Optionally return page table level and mapping flags from OcGetPhysicalAddress. Useful when examining/debugging the page table entries for a memory location.