### PR TITLE
Docs: Comment DVL0 device in SSDT-SBUS-MCHC

### DIFF
--- a/Docs/AcpiSamples/Source/SSDT-SBUS-MCHC.dsl
+++ b/Docs/AcpiSamples/Source/SSDT-SBUS-MCHC.dsl
@@ -29,6 +29,19 @@ DefinitionBlock ("", "SSDT", 2, "ACDT", "MCHCSBUS", 0x00000000)
     {
         Name (_CID, "smbus")  // _CID: Compatible ID
         Name (_ADR, Zero)  // _ADR: Address
+
+        /*
+         * Uncomment replacing 0x57 with your own value which might be found
+         * in SMBus section of Intel datasheet for your motherboard.
+         *
+         * The "diagsvault" is the diagnostic vault where messages are stored.
+         * It's located at address 87 (0x57) on the SMBus controller.
+         * While "diagsvault" may refer to diags, a hardware diagnosis program via EFI for Macs
+         * and communicates with the SMBus controller, the effect is really unknown for hacks.
+         * Uncomment this with caution.
+         */
+
+        /**
         Device (DVL0)
         {
             Name (_ADR, 0x57)  // _ADR: Address
@@ -50,6 +63,8 @@ DefinitionBlock ("", "SSDT", 2, "ACDT", "MCHCSBUS", 0x00000000)
                 })
             }
         }
+        **/
+
         Method (_STA, 0, NotSerialized)  // _STA: Status
         {
             If (_OSI ("Darwin"))

--- a/Docs/AcpiSamples/Source/SSDT-SBUS-MCHC.dsl
+++ b/Docs/AcpiSamples/Source/SSDT-SBUS-MCHC.dsl
@@ -37,7 +37,7 @@ DefinitionBlock ("", "SSDT", 2, "ACDT", "MCHCSBUS", 0x00000000)
          * The "diagsvault" is the diagnostic vault where messages are stored.
          * It's located at address 87 (0x57) on the SMBus controller.
          * While "diagsvault" may refer to diags, a hardware diagnosis program via EFI for Macs
-         * and communicates with the SMBus controller, the effect is really unknown for hacks.
+         * that communicates with the SMBus controller, the effect is really unknown for hacks.
          * Uncomment this with caution.
          */
 


### PR DESCRIPTION
According to https://www.insanelymac.com/forum/topic/233292-patching-sbus-in-dsdt/?do=findComment&comment=1561152, which is the earliest discussion of DVL0 device in SSDT-SBUS I can found,

> This "diagsvault" is the diagnostic vault where messages are stored. It's located at address 87 (0x57) on the SMBus controller. More about the specific SMBus controllers in your hack, can be found in the Intel datasheet (use Google).

By looking into several motherboard datasheets and SMBus specifications, I see Intel makes changes starting from 7 series.
Looking into [Intel® 7 Series / C216 Chipset Family Platform Controller Hub (PCH)](https://www.intel.com/content/dam/www/public/us/en/documents/datasheets/7-series-chipset-pch-datasheet.pdf#page807) pg. 807,

> SPD Write Disable — R/WO.
0 = SPD write enabled.
1 = SPD write disabled. Writes to SMBus addresses 50h - 57h are disabled.

which means 0x57 address write ability is disabled. People in [How to patch BIOS to enable SPD Write capability on Intel 8 Series and higher Chipset Family PCH](http://www.softnology.biz/tips_spdwritecap.html) also discovered that `writes to SMBus addresses 50h - 57h are disabled by default via SMBus Host Controller registers`. Based on the long history of the SSDT-SBUS, it might not be compatible with changing SMBus specifications. Also, there's limited documents that show where 0x57 address comes from. Hence, I believe user should use caution when injecting this DVL0 device which might cause unwanted communication to reserved region.