### PR TITLE
OcConsoleLib: Fix BuiltinGraphics init error present since b07843fe1d47454747ae4eda9ea0189aa9fb8c03

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ OpenCore Changelog
 - Fixed possible hang with `GopBurstMode` enabled on DEBUG builds
 - Enabled `GopBurstMode` even with natively supported cards, in EnableGop firmware driver
 - Fixed inability to patch force-injected kexts
+- Fixed `BuiltinGraphics` failure to display graphics in DEBUG builds on some systems since 0.8.9
 
 #### v0.9.1
 - Fixed long comment printing for ACPI patches, thx @corpnewt

--- a/Library/OcConsoleLib/TextOutputBuiltin.c
+++ b/Library/OcConsoleLib/TextOutputBuiltin.c
@@ -357,6 +357,9 @@ RenderScroll (
                      );
 }
 
+//
+// Resync text renderer. May fail, e.g. if resolution is too small to use.
+//
 STATIC
 EFI_STATUS
 RenderResync (
@@ -997,8 +1000,13 @@ OcUseBuiltinTextOutput (
   Status       = AsciiTextResetEx (&mAsciiTextOutputProtocol, TRUE, TRUE);
 
   if (!EFI_ERROR (Status)) {
-    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, NULL);
+    //
+    // We are intentionally setting the mode using the pre-existing protocol,
+    // if present, then not using the pre-existing protocol again, even if this
+    // means that subsequent mode changes can't 'really' change the mode.
+    //
     OcConsoleControlSetMode (Mode);
+    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, NULL);
 
     gST->ConOut    = &mAsciiTextOutputProtocol;
     gST->Hdr.CRC32 = 0;

--- a/Library/OcConsoleLib/TextOutputSystem.c
+++ b/Library/OcConsoleLib/TextOutputSystem.c
@@ -343,13 +343,22 @@ OcUseSystemTextOutput (
     ReplaceTabWithSpace
     ));
 
+  //
+  // For all except generic, set requested mode using pre-existing protocol, if
+  // present, before installing replacement.
+  // Note: We need the installed renderer to report the correct (intended) mode,
+  // even if there was no original protocol present.
+  //
   if (Renderer == OcConsoleRendererSystemGraphics) {
+    mConsoleMode = EfiConsoleControlScreenGraphics;
+    OcConsoleControlSetMode (mConsoleMode);
     OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, NULL);
-    OcConsoleControlSetMode (EfiConsoleControlScreenGraphics);
   } else if (Renderer == OcConsoleRendererSystemText) {
+    mConsoleMode = EfiConsoleControlScreenText;
+    OcConsoleControlSetMode (mConsoleMode);
     OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, NULL);
-    OcConsoleControlSetMode (EfiConsoleControlScreenText);
   } else {
+    ASSERT (Renderer == OcConsoleRendererSystemGeneric);
     OcConsoleControlInstallProtocol (&mConsoleControlProtocol, &mOriginalConsoleControlProtocol, &mConsoleMode);
   }
 


### PR DESCRIPTION
I have only just spotted that BuiltinGraphics was not entering graphics mode properly after b07843fe1d47454747ae4eda9ea0189aa9fb8c03. This addresses the reason why.