### PR TITLE
Add Optional contentVisibility Qualification

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ OpenCore Changelog
 ==================
 #### v0.9.4
 - Fixed kext blocker `Exclude` strategy for prelinked on 32-bit versions of macOS
+- Added `InstanceIdentifier` setting and option to limit `.contentVisibility` to specific OpenCore instances
 
 #### v0.9.3
 - Added `--force-codec` option to AudioDxe, thx @xCuri0

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3148,21 +3148,21 @@ The algorithm to determine boot options behaves as follows:
   \item For file device paths, check for presence on the file system directly.
   % Just kill all \EFI\APPLE\ paths.
   \item Exclude entries if there is a \texttt{.contentVisibility} file (near a loader or within a boot directory)
-  with contents starting with \texttt{Disabled}. \\
+  with contents starting with \texttt{Ignore}. \\
   See \texttt{Qualified .contentVisibility files} below for more.
   \item Mark device handle as \textit{used} in the list of partition handles if any.
   % Each partition handle will basically have a list of boot option entries for quick lookup later.
   \item Register the resulting entries as primary options and determine their types. \\
   The option will become auxiliary for some types (e.g. Apple HFS recovery)
-  or if its \texttt{.contentVisibility} file contents start with \texttt{Auxiliary}. \\
+  or if its \texttt{.contentVisibility} file contents start with \texttt{Cloak}. \\
   See \texttt{Qualified .contentVisibility files} below for more.
   \item Qualified \texttt{.contentVisibility} files.
     \begin{itemize}
     \item \texttt{.contentVisibility} files may optionally target only specific instances
-    of OpenCore when such files contain \texttt{(Disabled|Auxiliary) [\{Instance-Set\}]}. \\
+    of OpenCore when such files contain \texttt{(Ignore|Cloak) [\{Instance-Set\}]}. \\
     Where \texttt{Instance-Set} is a set of one or more OpenCore \texttt{InstanceIdentifiers},
     specified in \texttt{config.plist}, each bounded by a tilde (\texttt{~}). \\
-    For example, if \texttt{Disabled ~ABC~XYZ~} is entered, the target item will be ignored on instances with
+    For example, if \texttt{Ignore ~ABC~XYZ~} is entered, the target item will be ignored on instances with
     \texttt{ABC} or \texttt{XYZ} defined as \texttt{InstanceIdentifier} in their \texttt{config.plist} files.
     \item When an \texttt{Instance-Set} is present in a \texttt{.contentVisibility} file, the
     visibility instruction is only applied if the \texttt{InstanceIdentifier} value of the

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3125,6 +3125,8 @@ installed on the media, while alternate options represent recovery options for t
 \end{itemize} \medskip
 \end{itemize}
 
+\subsubsection{Boot Algorithm}\label{bootalgorithm}
+
 The algorithm to determine boot options behaves as follows:
 
 \begin{enumerate}
@@ -3145,18 +3147,33 @@ The algorithm to determine boot options behaves as follows:
   \item For disk device paths (not specifying a bootloader), execute ``bless'' (may return > 1 entry).
   \item For file device paths, check for presence on the file system directly.
   % Just kill all \EFI\APPLE\ paths.
-  \item Exclude entries if there is a \texttt{.contentVisibility} file near the bootloader or
-  inside the boot directory with \texttt{Disabled} contents (ASCII).
+  \item Exclude entries if there is a \texttt{.contentVisibility} file (near a loader or within a boot directory)
+  with contents starting with \texttt{Disabled}. \\
+  See \texttt{Qualified .contentVisibility files} below for more.
   \item Mark device handle as \textit{used} in the list of partition handles if any.
-  % Each partition handle will basically have a list of boot option entries for later quick lookup.
+  % Each partition handle will basically have a list of boot option entries for quick lookup later.
   \item Register the resulting entries as primary options and determine their types. \\
   The option will become auxiliary for some types (e.g. Apple HFS recovery)
-  or if its \texttt{.contentVisibility} file contains \texttt{Auxiliary}.
+  or if its \texttt{.contentVisibility} file contents start with \texttt{Auxiliary}. \\
+  See \texttt{Qualified .contentVisibility files} below for more.
+  \item Qualified \texttt{.contentVisibility} files.
+    \begin{itemize}
+    \item \texttt{.contentVisibility} files may optionally target only specific instances
+    of OpenCore when such files contain \texttt{(Disabled|Auxiliary) [\{Instance-Set\}]}. \\
+    Where \texttt{Instance-Set} is a set of one or more OpenCore \texttt{InstanceIdentifiers},
+    specified in \texttt{config.plist}, each bounded by a tilde (\texttt{~}). \\
+    For example, if \texttt{Disabled ~ABC~XYZ~} is entered, the target item will be ignored on instances with
+    \texttt{ABC} or \texttt{XYZ} defined as \texttt{InstanceIdentifier} in their \texttt{config.plist} files.
+    \item When an \texttt{Instance-Set} is present in a \texttt{.contentVisibility} file, the
+    visibility instruction is only applied if the \texttt{InstanceIdentifier} value of the
+    current OpenCore instance is included in the set. When \texttt{Instance-Set} is absent,
+    visibility instructions are applied to all OpenCore instances.
+    \end{itemize}
   \end{itemize}
 \item For each partition handle:
   \begin{itemize}
   \item If the partition handle is marked as \textit{unused}, execute ``bless'' primary option list retrieval. \\
-    In case a \texttt{BlessOverride} list is set, both standard and custom ``bless'' paths will be found.
+  In case a \texttt{BlessOverride} list is set, both standard and custom ``bless'' paths will be found.
   \item On the OpenCore boot partition, exclude OpenCore bootstrap files using header checks.
   \item Register the resulting entries as primary options and determine their types if found. \\
   The option will become auxiliary for some types (e.g. Apple HFS recovery).
@@ -3172,7 +3189,7 @@ The algorithm to determine boot options behaves as follows:
 The display order of the boot options in the OpenCore picker and the boot process
 are determined separately from the scanning algorithm.
 
-The display order as follows:
+The display order is as follows:
 
 \begin{itemize}
 \tightlist
@@ -3390,6 +3407,17 @@ the default boot entry choice will remain changed until the next manual reconfig
 
   To display all entries, the picker menu can be reloaded into ``Extended Mode'' by pressing the
   \texttt{Spacebar} key. Hiding auxiliary entries may increase boot performance on multi-disk systems.
+
+
+\item
+  \texttt{InstanceIdentifier}\\
+  \textbf{Type}: \texttt{plist\ string}\\
+  \textbf{Failsafe}: Empty\\
+  \textbf{Description}: An optional identifier for the current instance of OpenCore.
+
+  This should typically be a short alphanumeric string. The current use of this value is
+  to optionally target \texttt{.contentVisibility} files to specific instances of OpenCore,
+  as explained in the \hyperref[bootalgorithm]{Boot Algorithm} section.
 
 \item
   \texttt{LauncherOption}\\
@@ -7104,7 +7132,7 @@ the driver within the \texttt{UEFI/Drivers} section:
   On some sound cards enabling this option will enable additional usable audio channels (e.g.
   the bass or treble speaker of a pair, where only one is found without it).
   \medskip
-  
+
   \emph{Note}: Enabling this option may increase the available channels, in which case any
   custom setting of \texttt{AudioOutMask} may need to be changed to match the new channel list.
   \medskip
@@ -8150,7 +8178,7 @@ for additional options.
   \texttt{Text} and \texttt{Graphics} specify the named mode. \texttt{Auto}
   uses the current mode of the system \texttt{ConsoleControl} protocol when
   one exists, defaulting to \texttt{Text} mode otherwise.
- 
+
   UEFI firmware typically supports \texttt{ConsoleControl} with two
   rendering modes: \texttt{Graphics} and \texttt{Text}. Some types of firmware
   do not provide a native \texttt{ConsoleControl} and rendering modes. OpenCore

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1084,6 +1084,8 @@
 			<false/>
 			<key>HideAuxiliary</key>
 			<true/>
+			<key>InstanceIdentifier</key>
+			<string></string>
 			<key>LauncherOption</key>
 			<string>Disabled</string>
 			<key>LauncherPath</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -1084,6 +1084,8 @@
 			<false/>
 			<key>HideAuxiliary</key>
 			<true/>
+			<key>InstanceIdentifier</key>
+			<string></string>
 			<key>LauncherOption</key>
 			<string>Disabled</string>
 			<key>LauncherPath</key>

--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -32,6 +32,16 @@
 #endif
 
 /**
+  Maximum safe instance identifier size.
+**/
+#define OC_MAX_INSTANCE_IDENTIFIER_SIZE  64
+
+/**
+  Maximum safe contentVisibility size.
+**/
+#define OC_MAX_VISIBILITY_INSTRUCTION_SIZE  512
+
+/**
   Primary picker context.
 **/
 typedef struct OC_PICKER_CONTEXT_ OC_PICKER_CONTEXT;
@@ -934,6 +944,10 @@ struct OC_PICKER_CONTEXT_ {
   // Picker icon set variant (refer to docs for requested behaviour).
   //
   CONST CHAR8                 *PickerVariant;
+  //
+  // Boot loader instance identifier.
+  //
+  CONST CHAR8                 *InstanceIdentifier;
   //
   // Enable polling boot arguments.
   //

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -335,6 +335,7 @@ OC_DECLARE (OC_MISC_BLESS_ARRAY)
 #define OC_MISC_BOOT_FIELDS(_, __) \
   _(OC_STRING                   , PickerMode                  ,     , OC_STRING_CONSTR ("Builtin", _, __) , OC_DESTR (OC_STRING)) \
   _(OC_STRING                   , HibernateMode               ,     , OC_STRING_CONSTR ("None", _, __)    , OC_DESTR (OC_STRING)) \
+  _(OC_STRING                   , InstanceIdentifier          ,     , OC_STRING_CONSTR ("", _, __)        , OC_DESTR (OC_STRING)) \
   _(OC_STRING                   , LauncherOption              ,     , OC_STRING_CONSTR ("Disabled", _, __), OC_DESTR (OC_STRING) ) \
   _(OC_STRING                   , LauncherPath                ,     , OC_STRING_CONSTR ("Default", _, __) , OC_DESTR (OC_STRING) ) \
   _(UINT32                      , ConsoleAttributes           ,     , 0                                   , ())                   \

--- a/Include/Acidanthera/Protocol/OcBootEntry.h
+++ b/Include/Acidanthera/Protocol/OcBootEntry.h
@@ -28,7 +28,7 @@
 
   WARNING: This protocol is currently undergoing active design.
 **/
-#define OC_BOOT_ENTRY_PROTOCOL_REVISION  3
+#define OC_BOOT_ENTRY_PROTOCOL_REVISION  4
 
 /**
   Forward declaration of OC_BOOT_ENTRY_PROTOCOL structure.

--- a/Include/Acidanthera/Protocol/OcInterface.h
+++ b/Include/Acidanthera/Protocol/OcInterface.h
@@ -24,7 +24,7 @@
 
   WARNING: This protocol is currently undergoing active design.
 **/
-#define OC_INTERFACE_REVISION  8
+#define OC_INTERFACE_REVISION  9
 
 /**
   The GUID of the OC_INTERFACE_PROTOCOL.

--- a/Library/OcBootManagementLib/BootEntryManagement.c
+++ b/Library/OcBootManagementLib/BootEntryManagement.c
@@ -328,18 +328,34 @@ ReadEntryVisibility (
   VisibilityFlag = FALSE;
 
   //
-  // Handle 'Disabled' instruction.
+  // Handle instruction: 'Ignore'.
+  // Handle instruction: 'Disabled' (Deprecated).
+  // Former instruction deprecated for legacy compatibility.
   //
-  if (AsciiStrnCmp (Visibility, "Disabled", L_STR_LEN ("Disabled")) == 0) {
+  if (  (AsciiStrnCmp (Visibility, "Ignore", L_STR_LEN ("Ignore")) == 0)
+     || ((AsciiStrnCmp (Visibility, "Disabled", L_STR_LEN ("Disabled")) == 0)))
+  {
     //
     // Check absolute content if content qualification is absent.
     //
     if (!CheckQualifiers) {
       VisibilityFlag = TRUE;
-      DEBUG ((
-        DEBUG_INFO,
-        "OCB: Found .contentVisibility with instruction:- 'Disabled'\n"
-        ));
+
+      DEBUG_CODE_BEGIN ();
+
+      if (AsciiStrnCmp (Visibility, "Ignore", L_STR_LEN ("Ignore")) == 0) {
+        DEBUG ((
+          DEBUG_INFO,
+          "OCB: Found visibility instruction:- Ignore on all instances\n"
+          ));
+      } else {
+        DEBUG ((
+          DEBUG_INFO,
+          "OCB: Found deprecated visibility instruction:- Disabled on all instances\n"
+          ));
+      }
+
+      DEBUG_CODE_END ();
     }
 
     //
@@ -348,11 +364,28 @@ ReadEntryVisibility (
     //
     if (!VisibilityFlag && CheckQualifiers && QualifiedVisibility) {
       VisibilityFlag = TRUE;
-      DEBUG ((
-        DEBUG_INFO,
-        "OCB: Found .contentVisibility with instruction:- 'Disabled ... %a'\n",
-        InstanceName
-        ));
+
+      DEBUG_CODE_BEGIN ();
+
+      if (AsciiStrnCmp (Visibility, "Ignore", L_STR_LEN ("Ignore")) == 0) {
+        DEBUG ((
+          DEBUG_INFO,
+          "OCB: Found visibility instruction:- Ignore on '%a' instances\n",
+          InstanceName
+          ));
+      } else {
+        DEBUG ((
+          DEBUG_INFO,
+          "OCB: Found deprecated visibility instruction:- Disabled on '%a' instances\n",
+          InstanceName
+          ));
+        DEBUG ((
+          DEBUG_WARN,
+          "OCB: Deprecated 'Disabled' instruction should not be qualified! Replace with 'Ignore'\n"
+          ));
+      }
+
+      DEBUG_CODE_END ();
     }
 
     if (VisibilityFlag) {
@@ -363,18 +396,34 @@ ReadEntryVisibility (
   }
 
   //
-  // Handle 'Auxiliary' instruction.
+  // Handle instruction: 'Cloak'.
+  // Handle instruction: 'Auxiliary' (Deprecated).
+  // Former instruction deprecated for legacy compatibility.
   //
-  if (AsciiStrnCmp (Visibility, "Auxiliary", L_STR_LEN ("Auxiliary")) == 0) {
+  if (  (AsciiStrnCmp (Visibility, "Cloak", L_STR_LEN ("Cloak")) == 0)
+     || ((AsciiStrnCmp (Visibility, "Auxiliary", L_STR_LEN ("Auxiliary")) == 0)))
+  {
     //
     // Check absolute content if content qualification is absent.
     //
     if (!CheckQualifiers) {
       VisibilityFlag = TRUE;
-      DEBUG ((
-        DEBUG_INFO,
-        "OCB: Found .contentVisibility with instruction:- 'Auxiliary'\n"
-        ));
+
+      DEBUG_CODE_BEGIN ();
+
+      if (AsciiStrnCmp (Visibility, "Cloak", L_STR_LEN ("Cloak")) == 0) {
+        DEBUG ((
+          DEBUG_INFO,
+          "OCB: Found visibility instruction:- Cloak on all instances\n"
+          ));
+      } else {
+        DEBUG ((
+          DEBUG_INFO,
+          "OCB: Found deprecated visibility instruction:- Auxiliary on all instances\n"
+          ));
+      }
+
+      DEBUG_CODE_END ();
     }
 
     //
@@ -383,11 +432,28 @@ ReadEntryVisibility (
     //
     if (!VisibilityFlag && CheckQualifiers && QualifiedVisibility) {
       VisibilityFlag = TRUE;
-      DEBUG ((
-        DEBUG_INFO,
-        "OCB: Found .contentVisibility with instruction:- 'Auxiliary ... %a'\n",
-        InstanceName
-        ));
+
+      DEBUG_CODE_BEGIN ();
+
+      if (AsciiStrnCmp (Visibility, "Cloak", L_STR_LEN ("Cloak")) == 0) {
+        DEBUG ((
+          DEBUG_INFO,
+          "OCB: Found visibility instruction:- Cloak on '%a' instances\n",
+          InstanceName
+          ));
+      } else {
+        DEBUG ((
+          DEBUG_INFO,
+          "OCB: Found deprecated visibility instruction:- Auxiliary on '%a' instances\n",
+          InstanceName
+          ));
+        DEBUG ((
+          DEBUG_WARN,
+          "OCB: Deprecated 'Auxiliary' instruction should not be qualified! Replace with 'Cloak'\n"
+          ));
+      }
+
+      DEBUG_CODE_END ();
     }
 
     if (VisibilityFlag) {

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -410,6 +410,7 @@ OC_SCHEMA
   OC_SCHEMA_STRING_IN ("HibernateMode",         OC_GLOBAL_CONFIG, Misc.Boot.HibernateMode),
   OC_SCHEMA_BOOLEAN_IN ("HibernateSkipsPicker", OC_GLOBAL_CONFIG, Misc.Boot.HibernateSkipsPicker),
   OC_SCHEMA_BOOLEAN_IN ("HideAuxiliary",        OC_GLOBAL_CONFIG, Misc.Boot.HideAuxiliary),
+  OC_SCHEMA_STRING_IN ("InstanceIdentifier",    OC_GLOBAL_CONFIG, Misc.Boot.InstanceIdentifier),
   OC_SCHEMA_STRING_IN ("LauncherOption",        OC_GLOBAL_CONFIG, Misc.Boot.LauncherOption),
   OC_SCHEMA_STRING_IN ("LauncherPath",          OC_GLOBAL_CONFIG, Misc.Boot.LauncherPath),
   OC_SCHEMA_INTEGER_IN ("PickerAttributes",     OC_GLOBAL_CONFIG, Misc.Boot.PickerAttributes),

--- a/Library/OcMainLib/OpenCoreMisc.c
+++ b/Library/OcMainLib/OpenCoreMisc.c
@@ -790,6 +790,7 @@ OcMiscBoot (
   CHAR16                  **BlessOverride;
   CONST CHAR8             *AsciiPicker;
   CONST CHAR8             *AsciiPickerVariant;
+  CONST CHAR8             *AsciiInstanceIdentifier;
   CONST CHAR8             *AsciiDmg;
 
   AsciiPicker = OC_BLOB_GET (&Config->Misc.Boot.PickerMode);
@@ -805,7 +806,8 @@ OcMiscBoot (
     PickerMode = OcPickerModeBuiltin;
   }
 
-  AsciiPickerVariant = OC_BLOB_GET (&Config->Misc.Boot.PickerVariant);
+  AsciiPickerVariant      = OC_BLOB_GET (&Config->Misc.Boot.PickerVariant);
+  AsciiInstanceIdentifier = OC_BLOB_GET (&Config->Misc.Boot.InstanceIdentifier);
 
   AsciiDmg = OC_BLOB_GET (&Config->Misc.Security.DmgLoading);
 
@@ -934,6 +936,7 @@ OcMiscBoot (
   Context->ConsoleAttributes    = Config->Misc.Boot.ConsoleAttributes;
   Context->PickerAttributes     = Config->Misc.Boot.PickerAttributes;
   Context->PickerVariant        = AsciiPickerVariant;
+  Context->InstanceIdentifier   = AsciiInstanceIdentifier;
   Context->BlacklistAppleUpdate = Config->Misc.Security.BlacklistAppleUpdate;
 
   if ((Config->Misc.Security.ExposeSensitiveData & OCS_EXPOSE_VERSION_UI) != 0) {

--- a/Utilities/ocvalidate/ValidateMisc.c
+++ b/Utilities/ocvalidate/ValidateMisc.c
@@ -185,6 +185,42 @@ CheckBlessOverride (
 
 STATIC
 UINT32
+ValidateInstanceIdentifier (
+  IN CONST CHAR8  *InstanceIdentifier
+  )
+{
+  UINT32  ErrorCount;
+  CHAR8   InstanceIdentifierCopy[OC_MAX_INSTANCE_IDENTIFIER_SIZE];
+  UINTN   Length;
+
+  ErrorCount = 0;
+
+  if (AsciiStrSize (InstanceIdentifier) > OC_MAX_INSTANCE_IDENTIFIER_SIZE) {
+    DEBUG ((DEBUG_WARN, "Misc->Boot->InstanceIdentifier should be %d bytes or less!\n", OC_MAX_INSTANCE_IDENTIFIER_SIZE));
+    ++ErrorCount;
+  } else {
+    if (AsciiStrStr (InstanceIdentifier, "~") != NULL) {
+      DEBUG ((DEBUG_WARN, "Misc->Boot->InstanceIdentifier should not contain tilde (~)!\n"));
+      ++ErrorCount;
+    }
+
+    //
+    // Illegal chars
+    //
+    Length = AsciiStrLen (InstanceIdentifier);
+    AsciiStrnCpyS (InstanceIdentifierCopy, OC_MAX_INSTANCE_IDENTIFIER_SIZE, InstanceIdentifier, Length);
+    AsciiFilterString (InstanceIdentifierCopy, TRUE);
+    if (OcAsciiStrniCmp (InstanceIdentifierCopy, InstanceIdentifier, Length) != 0) {
+      DEBUG ((DEBUG_WARN, "Misc->Boot->InstanceIdentifier should not contain any non-ASCII characters!\n"));
+      ++ErrorCount;
+    }
+  }
+
+  return ErrorCount;
+}
+
+STATIC
+UINT32
 CheckMiscBoot (
   IN  OC_GLOBAL_CONFIG  *Config
   )
@@ -199,6 +235,7 @@ CheckMiscBoot (
   BOOLEAN               HasOpenCanopyEfiDriver;
   CONST CHAR8           *PickerMode;
   CONST CHAR8           *PickerVariant;
+  CONST CHAR8           *InstanceIdentifier;
   UINTN                 PVSumSize;
   UINTN                 PVPathFixedSize;
   BOOLEAN               IsPickerAudioAssistEnabled;
@@ -257,6 +294,9 @@ CheckMiscBoot (
     DEBUG ((DEBUG_WARN, "Misc->Boot->PickerVariant cannot be empty!\n"));
     ++ErrorCount;
   }
+
+  InstanceIdentifier = OC_BLOB_GET (&Config->Misc.Boot.InstanceIdentifier);
+  ErrorCount        += ValidateInstanceIdentifier (InstanceIdentifier);
 
   //
   // Check the length of path relative to OC directory.


### PR DESCRIPTION
It is possible to run multiple OpenCore instances but the `contentVisibility` feature currently does not allow targeting specific instances. This PR seeks to allow this via optional qualification of the contentVisibility instruction. The qualification string is of the form `@OPENCORE_PARENT_FOLDER_NAME@` and there can be more than one.

If qualification is not present, the contentVisibility instruction will work as it currently does. That is, apply to any instance.

An indication that an additional `Enable` instruction may be preferable was considered but while certainly easier, it appears to be far less flexible than qualifying the existing instructions. 
1. A new `Enable` instruction would be limited to disabling or enabling instances but qualifying allows application to both of the current instructions and can be extended to future instructions.
2. A new `Enable` instruction would not accommodate adding a new instance without changing expected default behaviour 

Needs an eye cast over some items such as memory allocation and leak avoidance in particular ... cc @PMheart