### PR TITLE
OcAppleKernelLib: Remove Ventura check for AppleCpuPmCfgLock

### DIFF
--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -60,6 +60,12 @@ PatchAppleCpuPmCfgLock (
   UINT8  *WalkerEnd;
   UINT8  *WalkerTmp;
 
+  //
+  // NOTE: As of macOS 13.0 AICPUPM kext is removed.
+  // However, legacy version of this kext may be injected and patched,
+  // thus no need to perform system version check here.
+  //
+
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: [OK] Skipping %a on NULL Patcher on kernel version %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -60,16 +60,6 @@ PatchAppleCpuPmCfgLock (
   UINT8  *WalkerEnd;
   UINT8  *WalkerTmp;
 
-  //
-  // NOTE: As of macOS 13.0 AICPUPM kext is removed.
-  // However, we may remove this check later, if an older version can be injected correctly
-  // such that it will patched.
-  //
-  if (OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION_VENTURA_MIN, 0)) {
-    DEBUG ((DEBUG_INFO, "OCAK: [OK] Skipping AppleCpuPmCfgLock patch on kernel version %u\n", KernelVersion));
-    return EFI_SUCCESS;
-  }
-
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: [OK] Skipping %a on NULL Patcher on kernel version %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;


### PR DESCRIPTION
As it says in the comment that the check can be removed if an older version can be injected correctly.

If you have an Ivy Bridge CPU or older that uses the AppleIntelCPUPowermanagent and AppleIntelCPUPowerManagementClient kexts you can inject these ones [from the OCLP project](https://github.com/dortania/OpenCore-Legacy-Patcher/tree/main/payloads/Kexts/Misc) and they will work in Ventura but only if you have the CFG lock previously disabled or else there will be a kernel panic 

The PR removes the Ventura check to allow the patch to work in the injected kexts so its no longer necessary to unlock the CFG lock. Already tested with a build and the patch is working correctly 
