### PR TITLE
OcAppleKernelLib: Fix ExternalDiskIcons quirk on macOS 13.3+

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ OpenCore Changelog
 - Fixed possible hang with `GopBurstMode` enabled on DEBUG builds
 - Enabled `GopBurstMode` even with natively supported cards, in EnableGop firmware driver
 - Fixed inability to patch force-injected kexts
+- Fixed `ExternalDiskIcons` quirk on macOS 13.3+, thx @fusion71au
 
 #### v0.9.1
 - Fixed long comment printing for ACPI patches, thx @corpnewt

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -1007,7 +1007,7 @@ PATCHER_GENERIC_PATCH
   .Replace     = mIOAHCIPortPatchReplace,
   .ReplaceMask = NULL,
   .Size        = sizeof (mIOAHCIPortPatchFind),
-  .Count       = 1,
+  .Count       = 1,  ///< 2 for macOS 13.3+
   .Skip        = 0
 };
 
@@ -1023,6 +1023,13 @@ PatchForceInternalDiskIcons (
   if (Patcher == NULL) {
     DEBUG ((DEBUG_INFO, "OCAK: [OK] Skipping %a on NULL Patcher on %u\n", __func__, KernelVersion));
     return EFI_NOT_FOUND;
+  }
+
+  //
+  // Override patch count to 2 on macOS 13.3+ (Darwin 22.4.0).
+  //
+  if (OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_VENTURA, 4, 0), 0)) {
+    mIOAHCIPortPatch.Count = 2;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIOAHCIPortPatch);

--- a/Library/OcAppleKernelLib/CommonPatches.c
+++ b/Library/OcAppleKernelLib/CommonPatches.c
@@ -1030,6 +1030,8 @@ PatchForceInternalDiskIcons (
   //
   if (OcMatchDarwinVersion (KernelVersion, KERNEL_VERSION (KERNEL_VERSION_VENTURA, 4, 0), 0)) {
     mIOAHCIPortPatch.Count = 2;
+  } else {
+    mIOAHCIPortPatch.Count = 1;
   }
 
   Status = PatcherApplyGenericPatch (Patcher, &mIOAHCIPortPatch);


### PR DESCRIPTION
This closes https://github.com/acidanthera/bugtracker/issues/2256.

Thanks [@fusion71au](https://www.insanelymac.com/forum/profile/846696-fusion71au/) for discovering this.

Ref: https://www.insanelymac.com/forum/topic/350754-opencore-general-discussion/page/337/#comment-2803365