### PR TITLE
Fix console

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,10 @@ OpenCore Changelog
 - Enabled `GopBurstMode` even with natively supported cards, in EnableGop firmware driver
 - Fixed inability to patch force-injected kexts
 - Fixed `ExternalDiskIcons` quirk on macOS 13.3+, thx @fusion71au
+- Fixed various recent reversions and some longer-standing minor bugs in `Builtin` text renderer
+- Applied some additional minor optimizations to `Builtin` text renderer
+- Implemented `InitialMode` option to allow fine control over text renderer operating mode
+- Added support for `ConsoleMode` text resolution setting to `Builtin` renderer
 
 #### v0.9.1
 - Fixed long comment printing for ACPI patches, thx @corpnewt

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -8107,6 +8107,19 @@ for additional options.
 \begin{enumerate}
 
 \item
+  \texttt{InitialMode}\\
+  \textbf{Type}: \texttt{plist\ string}\\
+  \textbf{Failsafe}: \texttt{Auto}\\
+  \textbf{Description}: Selects initial \texttt{ConsoleControl} mode to use before applying \texttt{TextRenderer} option.
+
+  Available values are \texttt{Auto}, \texttt{Text} and \texttt{Graphics}.
+  When \texttt{Text} or \texttt{Graphics} are specified, will attempt to set the system
+  \texttt{ConsoleControl} protocol to the specified value, and will then report being in
+  specified mode even if it could not set it, e.g. if there is no system \texttt{ConsoleControl}
+  protocol. For \texttt{Auto}, reports the existing \texttt{ConsoleControl} mode, defaulting
+  to \texttt{Text} if there is no system \texttt{ConsoleControl} protocol.
+
+\item
   \texttt{TextRenderer}\\
   \textbf{Type}: \texttt{plist\ string}\\
   \textbf{Failsafe}: \texttt{BuiltinGraphics}\\
@@ -8161,7 +8174,22 @@ for additional options.
   and \texttt{ClearScreenOnModeSwitch} are more specific, and their use
   depends on the firmware.
 
-  \emph{Note}: Some Macs, such as the \texttt{MacPro5,1}, may have incompatible
+  \emph{Note 1}: As required to work round issues with some legacy firmware,
+  both \texttt{Builtin} protocols use the system \texttt{ConsoleControl} protocol
+  to set \texttt{Text} or \texttt{Graphics} mode as specified in the option name, but
+  then behave internally (e.g. as to whether text output is shown in \texttt{Text}
+  mode or suppressed in \texttt{Graphics} mode) and report to other systems as if they
+  were in the mode present \emph{before} the protocol was applied (defaulting
+  to \texttt{Text} mode when there is no system \texttt{ConsoleControl} protocol).
+  To control this internal mode value, the \texttt{InitialMode} option should be used.
+
+  \emph{Note 2}: The \texttt{System} protocols will set and report the mode
+  specified in the option name, as long as there is a native \texttt{ConsoleControl}
+  protocol. To gain control over the reported mode whether or not there is an existing
+  system \texttt{ConsoleControl} protocol, the \texttt{InitialMode} option should
+  be used.
+
+  \emph{Note 3}: Some Macs, such as the \texttt{MacPro5,1}, may have incompatible
   console output when using modern GPUs, and thus only \texttt{BuiltinGraphics}
   may work for them in such cases. NVIDIA GPUs may require additional
   \href{https://github.com/acidanthera/bugtracker/issues/1280}{firmware upgrades}.
@@ -8294,7 +8322,7 @@ for additional options.
   \textbf{Description}: Some types of firmware output text onscreen in both graphics and
   text mode. This is typically unexpected as random text may appear over
   graphical images and cause UI corruption. Setting this option to \texttt{true} will
-  discard all text output when console control is in a different mode from \texttt{Text}.
+  discard all text output if console control is not in \texttt{Text} mode.
 
   \emph{Note}: This option only applies to the \texttt{System} renderer.
 

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -8202,8 +8202,6 @@ for additional options.
   with the \texttt{WxH} (e.g. \texttt{80x24}) formatted string.
 
   Set to \texttt{Max} to attempt using the largest available console mode.
-  This option is currently ignored as the \texttt{Builtin} text renderer
-  only supports one console mode.
 
   \emph{Note}: This field is best left empty on most types of firmware.
 

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -8123,7 +8123,7 @@ for additional options.
   UEFI firmware typically supports \texttt{ConsoleControl} with two
   rendering modes: \texttt{Graphics} and \texttt{Text}. Some types of firmware
   do not support \texttt{ConsoleControl} and rendering modes. OpenCore
-  and macOS expect text to only be shown in \texttt{Graphics} mode and
+  and macOS expect text to only be shown in \texttt{Text} mode but
   graphics to be drawn in any mode. Since this is not required by UEFI
   specification, exact behaviour varies.
 
@@ -8150,7 +8150,7 @@ for additional options.
   The use of \texttt{BuiltinGraphics} is straightforward.
   For most platforms, it is necessary to enable \texttt{ProvideConsoleGop}
   and set \texttt{Resolution} to \texttt{Max}. The \texttt{BuiltinText} variant is
-  an alternative \texttt{BuiltinGraphics} for some very old and defective
+  an alternative to \texttt{BuiltinGraphics} for some very old and defective
   laptop firmware, which can only draw in \texttt{Text} mode.
 
   The use of \texttt{System} protocols is more complicated. Typically,

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -8110,14 +8110,21 @@ for additional options.
   \texttt{InitialMode}\\
   \textbf{Type}: \texttt{plist\ string}\\
   \textbf{Failsafe}: \texttt{Auto}\\
-  \textbf{Description}: Selects initial \texttt{ConsoleControl} mode to use before applying \texttt{TextRenderer} option.
+  \textbf{Description}: Selects the internal \texttt{ConsoleControl} mode in
+  which \texttt{TextRenderer} will operate.
 
   Available values are \texttt{Auto}, \texttt{Text} and \texttt{Graphics}.
-  When \texttt{Text} or \texttt{Graphics} are specified, will attempt to set the system
-  \texttt{ConsoleControl} protocol to the specified value, and will then report being in
-  specified mode even if it could not set it, e.g. if there is no system \texttt{ConsoleControl}
-  protocol. For \texttt{Auto}, reports the existing \texttt{ConsoleControl} mode, defaulting
-  to \texttt{Text} if there is no system \texttt{ConsoleControl} protocol.
+  \texttt{Text} and \texttt{Graphics} specify the named mode. \texttt{Auto}
+  uses the current mode of the system \texttt{ConsoleControl} protocol when
+  one exists, defaulting to \texttt{Text} mode otherwise.
+ 
+  UEFI firmware typically supports \texttt{ConsoleControl} with two
+  rendering modes: \texttt{Graphics} and \texttt{Text}. Some types of firmware
+  do not provide a native \texttt{ConsoleControl} and rendering modes. OpenCore
+  and macOS expect text to only be shown in \texttt{Text} mode but
+  graphics to be drawn in any mode, and this is how the OpenCore \texttt{Builtin}
+  renderer behaves. Since this is not required by UEFI specification, behaviour
+  of the system \texttt{ConsoleControl} protocol, when it exists, varies.
 
 \item
   \texttt{TextRenderer}\\
@@ -8128,36 +8135,41 @@ for additional options.
 
   Currently two renderers are supported: \texttt{Builtin} and
   \texttt{System}. \texttt{System} renderer uses firmware services
-  for text rendering. \texttt{Builtin} bypasses firmware services
-  and performs text rendering on its own. Different renderers support
-  a different set of options. It is recommended to use \texttt{Builtin}
-  renderer, as it supports HiDPI mode and uses full screen resolution.
+  for text rendering, however with additional options provided to
+  santize the output. \texttt{Builtin} renderer bypasses firmware
+  services and performs text rendering on its own. Each renderer
+  supports a different set of options. It is recommended to use
+  \texttt{Builtin} renderer, as it supports HiDPI mode and uses
+  full screen resolution.
 
-  UEFI firmware typically supports \texttt{ConsoleControl} with two
-  rendering modes: \texttt{Graphics} and \texttt{Text}. Some types of firmware
-  do not support \texttt{ConsoleControl} and rendering modes. OpenCore
-  and macOS expect text to only be shown in \texttt{Text} mode but
-  graphics to be drawn in any mode. Since this is not required by UEFI
-  specification, exact behaviour varies.
+  Each renderer provides its own \texttt{ConsoleControl} protocol
+  (in the case of \texttt{SystemGeneric} only, this passes some
+  operations through to the system \texttt{ConsoleControl} protocol,
+  if one exists).
 
-  Valid values are combinations of text renderer and rendering mode:
+  Valid values of this option are combinations of the renderer to use
+  and the \texttt{ConsoleControl} mode to set on the underlying system
+  \texttt{ConsoleControl} protocol before starting. To control the initial
+  mode of the provided \texttt{ConsoleControl} protocol once started, use
+  the \texttt{InitalMode} option.
 
   \begin{itemize}
   \tightlist
   \item \texttt{BuiltinGraphics} --- Switch to \texttt{Graphics}
-    mode and use \texttt{Builtin} renderer with
+    mode then use \texttt{Builtin} renderer with
     custom \texttt{ConsoleControl}.
   \item \texttt{BuiltinText} --- Switch to \texttt{Text}
-    mode and use \texttt{Builtin} renderer with
+    mode then use \texttt{Builtin} renderer with
     custom \texttt{ConsoleControl}.
   \item \texttt{SystemGraphics} --- Switch to \texttt{Graphics}
-    mode and use \texttt{System} renderer with
+    mode then use \texttt{System} renderer with
     custom \texttt{ConsoleControl}.
   \item \texttt{SystemText} --- Switch to \texttt{Text}
-    mode and use \texttt{System} renderer with
+    mode then use \texttt{System} renderer with
     custom \texttt{ConsoleControl}.
   \item \texttt{SystemGeneric} --- Use \texttt{System} renderer with
-    system \texttt{ConsoleControl} assuming it behaves correctly.
+    custom a \texttt{ConsoleControl} protocol which passes its mode set and
+    get operations through to system \texttt{ConsoleControl} when it exists.
   \end{itemize}
 
   The use of \texttt{BuiltinGraphics} is straightforward.
@@ -8174,22 +8186,7 @@ for additional options.
   and \texttt{ClearScreenOnModeSwitch} are more specific, and their use
   depends on the firmware.
 
-  \emph{Note 1}: As required to work round issues with some legacy firmware,
-  both \texttt{Builtin} protocols use the system \texttt{ConsoleControl} protocol
-  to set \texttt{Text} or \texttt{Graphics} mode as specified in the option name, but
-  then behave internally (e.g. as to whether text output is shown in \texttt{Text}
-  mode or suppressed in \texttt{Graphics} mode) and report to other systems as if they
-  were in the mode present \emph{before} the protocol was applied (defaulting
-  to \texttt{Text} mode when there is no system \texttt{ConsoleControl} protocol).
-  To control this internal mode value, the \texttt{InitialMode} option should be used.
-
-  \emph{Note 2}: The \texttt{System} protocols will set and report the mode
-  specified in the option name, as long as there is a native \texttt{ConsoleControl}
-  protocol. To gain control over the reported mode whether or not there is an existing
-  system \texttt{ConsoleControl} protocol, the \texttt{InitialMode} option should
-  be used.
-
-  \emph{Note 3}: Some Macs, such as the \texttt{MacPro5,1}, may have incompatible
+  \emph{Note}: Some Macs, such as the \texttt{MacPro5,1}, may have incompatible
   console output when using modern GPUs, and thus only \texttt{BuiltinGraphics}
   may work for them in such cases. NVIDIA GPUs may require additional
   \href{https://github.com/acidanthera/bugtracker/issues/1280}{firmware upgrades}.

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1837,6 +1837,8 @@
 			<string>Disabled</string>
 			<key>IgnoreTextInGraphics</key>
 			<false/>
+			<key>InitialMode</key>
+			<string>Auto</string>
 			<key>ProvideConsoleGop</key>
 			<true/>
 			<key>ReconnectGraphicsOnConnect</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -2205,6 +2205,8 @@
 			<string>Disabled</string>
 			<key>IgnoreTextInGraphics</key>
 			<false/>
+			<key>InitialMode</key>
+			<string>Auto</string>
 			<key>ProvideConsoleGop</key>
 			<true/>
 			<key>ReconnectGraphicsOnConnect</key>

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -687,6 +687,7 @@ OC_DECLARE (OC_UEFI_INPUT)
 #define OC_UEFI_OUTPUT_FIELDS(_, __) \
   _(OC_STRING                   , ConsoleMode                 ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING)) \
   _(OC_STRING                   , Resolution                  ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING)) \
+  _(OC_STRING                   , InitialMode                 ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING)) \
   _(OC_STRING                   , TextRenderer                ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING)) \
   _(OC_STRING                   , GopPassThrough              ,     , OC_STRING_CONSTR ("Disabled", _, __), OC_DESTR (OC_STRING)) \
   _(BOOLEAN                     , IgnoreTextInGraphics        ,     , FALSE  , ()) \

--- a/Include/Acidanthera/Library/OcConsoleLib.h
+++ b/Include/Acidanthera/Library/OcConsoleLib.h
@@ -36,7 +36,10 @@ typedef enum {
 /**
   Special commands sent to Builtin text renderer through TestString.
 **/
-#define OC_CONSOLE_MARK_CONTROLLED    L"MarkControlled"
+/**
+  Extension to notify OpenCore builtin renderer that any text it may have produced
+  on screen is mixed with graphics which it did not control.
+**/
 #define OC_CONSOLE_MARK_UNCONTROLLED  L"MarkUncontrolled"
 
 /**

--- a/Include/Acidanthera/Library/OcConsoleLib.h
+++ b/Include/Acidanthera/Library/OcConsoleLib.h
@@ -42,6 +42,7 @@ typedef enum {
 /**
   Configure console control protocol with given options.
 
+  @param[in] InitialMode              Initial mode to use, or set max. value to use existing mode.
   @param[in] Renderer                 Renderer to use.
   @param[in] IgnoreTextOutput         Skip console output in text mode.
   @param[in] SanitiseClearScreen      Workaround ClearScreen breaking resolution.
@@ -50,11 +51,12 @@ typedef enum {
 **/
 VOID
 OcSetupConsole (
-  IN OC_CONSOLE_RENDERER  Renderer,
-  IN BOOLEAN              IgnoreTextOutput,
-  IN BOOLEAN              SanitiseClearScreen,
-  IN BOOLEAN              ClearScreenOnModeSwitch,
-  IN BOOLEAN              ReplaceTabWithSpace
+  IN EFI_CONSOLE_CONTROL_SCREEN_MODE  InitialMode,
+  IN OC_CONSOLE_RENDERER              Renderer,
+  IN BOOLEAN                          IgnoreTextOutput,
+  IN BOOLEAN                          SanitiseClearScreen,
+  IN BOOLEAN                          ClearScreenOnModeSwitch,
+  IN BOOLEAN                          ReplaceTabWithSpace
   );
 
 /**
@@ -67,6 +69,16 @@ OcSetupConsole (
 EFI_CONSOLE_CONTROL_SCREEN_MODE
 OcConsoleControlSetMode (
   IN EFI_CONSOLE_CONTROL_SCREEN_MODE  Mode
+  );
+
+/**
+  Get existing console control screen mode, default to text if no existing console control protocol.
+
+  @retval existing console control mode.
+**/
+EFI_CONSOLE_CONTROL_SCREEN_MODE
+OcConsoleControlGetMode (
+  VOID
   );
 
 /**

--- a/Include/Acidanthera/Library/OcConsoleLib.h
+++ b/Include/Acidanthera/Library/OcConsoleLib.h
@@ -51,6 +51,8 @@ typedef enum {
   @param[in] SanitiseClearScreen      Workaround ClearScreen breaking resolution.
   @param[in] ClearScreenOnModeSwitch  Clear graphic screen when switching to text mode.
   @param[in] ReplaceTabWithSpace      Replace invisible tab characters with spaces in OutputString.
+  @param[in] Width                    Width to set - applies to builtin renderer only.
+  @param[in] Height                   Height to set - applies to builtin renderer only.
 **/
 VOID
 OcSetupConsole (
@@ -59,7 +61,9 @@ OcSetupConsole (
   IN BOOLEAN                          IgnoreTextOutput,
   IN BOOLEAN                          SanitiseClearScreen,
   IN BOOLEAN                          ClearScreenOnModeSwitch,
-  IN BOOLEAN                          ReplaceTabWithSpace
+  IN BOOLEAN                          ReplaceTabWithSpace,
+  IN UINT32                           Width,
+  IN UINT32                           Height
   );
 
 /**

--- a/Library/OcBootManagementLib/BuiltinPicker.c
+++ b/Library/OcBootManagementLib/BuiltinPicker.c
@@ -429,11 +429,7 @@ OcShowSimpleBootMenu (
     gST->ConOut->SetAttribute (gST->ConOut, BootContext->PickerContext->ConsoleAttributes & 0x7FU);
   }
 
-  //
-  // Extension for OpenCore direct text render for faster redraw with custom background.
-  //
   gST->ConOut->ClearScreen (gST->ConOut);
-  gST->ConOut->TestString (gST->ConOut, OC_CONSOLE_MARK_CONTROLLED);
 
   while (TRUE) {
     if (FirstIndexRow != -1) {
@@ -858,7 +854,6 @@ OcShowSimplePasswordRequest (
   OcConsoleControlSetMode (EfiConsoleControlScreenText);
   gST->ConOut->EnableCursor (gST->ConOut, FALSE);
   gST->ConOut->ClearScreen (gST->ConOut);
-  gST->ConOut->TestString (gST->ConOut, OC_CONSOLE_MARK_CONTROLLED);
 
   for (Index = 0; Index < OC_PASSWORD_MAX_RETRIES; ++Index) {
     PwIndex = 0;

--- a/Library/OcBootManagementLib/OcBootManagementLib.c
+++ b/Library/OcBootManagementLib/OcBootManagementLib.c
@@ -165,50 +165,6 @@ InternalRunRequestPrivilege (
   return Status;
 }
 
-//
-// Since the Apple picker is GOP-based, it is reasonable to use specifically GOP to clear up after it.
-// Note that depending on settings, resetting ConsoleControl to text mode followed by ConOut->ClearScreen,
-// within the builtin picker, is not always sufficient to display it after the Apple picker, with no left-
-// over Apple picker baggage on screen, so we add this.
-//
-STATIC
-EFI_STATUS
-GopClearScreen (
-  VOID
-  )
-{
-  EFI_STATUS                           Status;
-  EFI_GRAPHICS_OUTPUT_PROTOCOL         *Gop;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  Pixel;
-
-  Status = gBS->HandleProtocol (
-                  gST->ConsoleOutHandle,
-                  &gEfiGraphicsOutputProtocolGuid,
-                  (VOID **)&Gop
-                  );
-
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  Pixel.Raw = 0x0;
-
-  Gop->Blt (
-         Gop,
-         &Pixel.Pixel,
-         EfiBltVideoFill,
-         0,
-         0,
-         0,
-         0,
-         Gop->Mode->Info->HorizontalResolution,
-         Gop->Mode->Info->VerticalResolution,
-         0
-         );
-
-  return EFI_UNSUPPORTED;
-}
-
 EFI_STATUS
 OcRunBootPicker (
   IN OC_PICKER_CONTEXT  *Context
@@ -311,7 +267,7 @@ OcRunBootPicker (
         if (IsApplePickerSelection) {
           DEBUG ((DEBUG_WARN, "OCB: Apple Picker returned no entry valid under OC, falling back to builtin\n"));
           Context->PickerMode = OcPickerModeBuiltin;
-          GopClearScreen ();
+          gST->ConOut->TestString (gST->ConOut, OC_CONSOLE_MARK_UNCONTROLLED);
         } else {
           DEBUG ((DEBUG_INFO, "OCB: System has no boot entries, showing picker with auxiliary\n"));
         }

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -821,6 +821,7 @@ OC_SCHEMA
   OC_SCHEMA_BOOLEAN_IN ("GopBurstMode",               OC_GLOBAL_CONFIG, Uefi.Output.GopBurstMode),
   OC_SCHEMA_STRING_IN ("GopPassThrough",              OC_GLOBAL_CONFIG, Uefi.Output.GopPassThrough),
   OC_SCHEMA_BOOLEAN_IN ("IgnoreTextInGraphics",       OC_GLOBAL_CONFIG, Uefi.Output.IgnoreTextInGraphics),
+  OC_SCHEMA_STRING_IN ("InitialMode",                 OC_GLOBAL_CONFIG, Uefi.Output.InitialMode),
   OC_SCHEMA_BOOLEAN_IN ("ProvideConsoleGop",          OC_GLOBAL_CONFIG, Uefi.Output.ProvideConsoleGop),
   OC_SCHEMA_BOOLEAN_IN ("ReconnectGraphicsOnConnect", OC_GLOBAL_CONFIG, Uefi.Output.ReconnectGraphicsOnConnect),
   OC_SCHEMA_BOOLEAN_IN ("ReconnectOnResChange",       OC_GLOBAL_CONFIG, Uefi.Output.ReconnectOnResChange),

--- a/Library/OcConsoleLib/ConsoleControl.c
+++ b/Library/OcConsoleLib/ConsoleControl.c
@@ -70,6 +70,39 @@ OcConsoleControlSetMode (
   return OldMode;
 }
 
+EFI_CONSOLE_CONTROL_SCREEN_MODE
+OcConsoleControlGetMode (
+  VOID
+  )
+{
+  EFI_STATUS                       Status;
+  EFI_CONSOLE_CONTROL_PROTOCOL     *ConsoleControl;
+  EFI_CONSOLE_CONTROL_SCREEN_MODE  ExistingMode;
+
+  Status = OcHandleProtocolFallback (
+             &gST->ConsoleOutHandle,
+             &gEfiConsoleControlProtocolGuid,
+             (VOID *)&ConsoleControl
+             );
+
+  if (EFI_ERROR (Status)) {
+    return EfiConsoleControlScreenText;
+  }
+
+  Status = ConsoleControl->GetMode (
+                             ConsoleControl,
+                             &ExistingMode,
+                             NULL,
+                             NULL
+                             );
+
+  if (EFI_ERROR (Status)) {
+    return EfiConsoleControlScreenText;
+  }
+
+  return ExistingMode;
+}
+
 EFI_STATUS
 OcConsoleControlInstallProtocol (
   IN  EFI_CONSOLE_CONTROL_PROTOCOL        *NewProtocol,

--- a/Library/OcConsoleLib/ConsoleControl.c
+++ b/Library/OcConsoleLib/ConsoleControl.c
@@ -156,6 +156,13 @@ OcConsoleControlInstallProtocol (
     return EFI_SUCCESS;
   }
 
+  if (OldProtocol != NULL) {
+    ZeroMem (
+      OldProtocol,
+      sizeof (*OldProtocol)
+      );
+  }
+
   Status = gBS->InstallMultipleProtocolInterfaces (
                   &gST->ConsoleOutHandle,
                   &gEfiConsoleControlProtocolGuid,
@@ -166,4 +173,38 @@ OcConsoleControlInstallProtocol (
   DEBUG ((DEBUG_INFO, "OCC: Install console control, new - %r\n", Status));
 
   return Status;
+}
+
+EFI_STATUS
+OcConsoleControlRestoreProtocol (
+  IN EFI_CONSOLE_CONTROL_PROTOCOL  *OldProtocol
+  )
+{
+  EFI_STATUS                    Status;
+  EFI_CONSOLE_CONTROL_PROTOCOL  *ConsoleControl;
+
+  Status = gBS->HandleProtocol (
+                  &gST->ConsoleOutHandle,
+                  &gEfiConsoleControlProtocolGuid,
+                  (VOID *)&ConsoleControl
+                  );
+
+  if (OldProtocol->GetMode == NULL) {
+    Status = gBS->UninstallMultipleProtocolInterfaces (
+                    &gST->ConsoleOutHandle,
+                    &gEfiConsoleControlProtocolGuid,
+                    ConsoleControl,
+                    NULL
+                    );
+
+    return Status;
+  }
+
+  CopyMem (
+    ConsoleControl,
+    OldProtocol,
+    sizeof (*ConsoleControl)
+    );
+
+  return EFI_SUCCESS;
 }

--- a/Library/OcConsoleLib/OcConsoleLib.c
+++ b/Library/OcConsoleLib/OcConsoleLib.c
@@ -386,19 +386,25 @@ OcSetConsoleMode (
 
 VOID
 OcSetupConsole (
-  IN OC_CONSOLE_RENDERER  Renderer,
-  IN BOOLEAN              IgnoreTextOutput,
-  IN BOOLEAN              SanitiseClearScreen,
-  IN BOOLEAN              ClearScreenOnModeSwitch,
-  IN BOOLEAN              ReplaceTabWithSpace
+  IN EFI_CONSOLE_CONTROL_SCREEN_MODE  InitialMode,
+  IN OC_CONSOLE_RENDERER              Renderer,
+  IN BOOLEAN                          IgnoreTextOutput,
+  IN BOOLEAN                          SanitiseClearScreen,
+  IN BOOLEAN                          ClearScreenOnModeSwitch,
+  IN BOOLEAN                          ReplaceTabWithSpace
   )
 {
+  if (InitialMode == EfiConsoleControlScreenMaxValue) {
+    InitialMode = OcConsoleControlGetMode ();
+  }
+
   if (Renderer == OcConsoleRendererBuiltinGraphics) {
-    OcUseBuiltinTextOutput (EfiConsoleControlScreenGraphics);
+    OcUseBuiltinTextOutput (InitialMode, EfiConsoleControlScreenGraphics);
   } else if (Renderer == OcConsoleRendererBuiltinText) {
-    OcUseBuiltinTextOutput (EfiConsoleControlScreenText);
+    OcUseBuiltinTextOutput (InitialMode, EfiConsoleControlScreenText);
   } else {
     OcUseSystemTextOutput (
+      InitialMode,
       Renderer,
       IgnoreTextOutput,
       SanitiseClearScreen,

--- a/Library/OcConsoleLib/OcConsoleLib.c
+++ b/Library/OcConsoleLib/OcConsoleLib.c
@@ -391,7 +391,9 @@ OcSetupConsole (
   IN BOOLEAN                          IgnoreTextOutput,
   IN BOOLEAN                          SanitiseClearScreen,
   IN BOOLEAN                          ClearScreenOnModeSwitch,
-  IN BOOLEAN                          ReplaceTabWithSpace
+  IN BOOLEAN                          ReplaceTabWithSpace,
+  IN UINT32                           Width,
+  IN UINT32                           Height
   )
 {
   if (InitialMode == EfiConsoleControlScreenMaxValue) {
@@ -399,9 +401,9 @@ OcSetupConsole (
   }
 
   if (Renderer == OcConsoleRendererBuiltinGraphics) {
-    OcUseBuiltinTextOutput (InitialMode, EfiConsoleControlScreenGraphics);
+    OcUseBuiltinTextOutput (InitialMode, EfiConsoleControlScreenGraphics, Width, Height);
   } else if (Renderer == OcConsoleRendererBuiltinText) {
-    OcUseBuiltinTextOutput (InitialMode, EfiConsoleControlScreenText);
+    OcUseBuiltinTextOutput (InitialMode, EfiConsoleControlScreenText, Width, Height);
   } else {
     OcUseSystemTextOutput (
       InitialMode,

--- a/Library/OcConsoleLib/OcConsoleLibInternal.h
+++ b/Library/OcConsoleLib/OcConsoleLibInternal.h
@@ -67,7 +67,9 @@ OcConsoleControlRestoreProtocol (
 EFI_STATUS
 OcUseBuiltinTextOutput (
   IN EFI_CONSOLE_CONTROL_SCREEN_MODE  InitialMode,
-  IN EFI_CONSOLE_CONTROL_SCREEN_MODE  Mode
+  IN EFI_CONSOLE_CONTROL_SCREEN_MODE  Mode,
+  IN UINT32                           Width,
+  IN UINT32                           Height
   );
 
 EFI_STATUS

--- a/Library/OcConsoleLib/OcConsoleLibInternal.h
+++ b/Library/OcConsoleLib/OcConsoleLibInternal.h
@@ -61,16 +61,18 @@ OcConsoleControlInstallProtocol (
 
 EFI_STATUS
 OcUseBuiltinTextOutput (
+  IN EFI_CONSOLE_CONTROL_SCREEN_MODE  InitialMode,
   IN EFI_CONSOLE_CONTROL_SCREEN_MODE  Mode
   );
 
 EFI_STATUS
 OcUseSystemTextOutput (
-  IN OC_CONSOLE_RENDERER  Renderer,
-  IN BOOLEAN              IgnoreTextOutput,
-  IN BOOLEAN              SanitiseClearScreen,
-  IN BOOLEAN              ClearScreenOnModeSwitch,
-  IN BOOLEAN              ReplaceTabWithSpace
+  IN EFI_CONSOLE_CONTROL_SCREEN_MODE  InitialMode,
+  IN OC_CONSOLE_RENDERER              Renderer,
+  IN BOOLEAN                          IgnoreTextOutput,
+  IN BOOLEAN                          SanitiseClearScreen,
+  IN BOOLEAN                          ClearScreenOnModeSwitch,
+  IN BOOLEAN                          ReplaceTabWithSpace
   );
 
 #endif // OC_CONSOLE_LIB_INTERNAL_H

--- a/Library/OcConsoleLib/OcConsoleLibInternal.h
+++ b/Library/OcConsoleLib/OcConsoleLibInternal.h
@@ -60,6 +60,11 @@ OcConsoleControlInstallProtocol (
   );
 
 EFI_STATUS
+OcConsoleControlRestoreProtocol (
+  IN EFI_CONSOLE_CONTROL_PROTOCOL  *OldProtocol
+  );
+
+EFI_STATUS
 OcUseBuiltinTextOutput (
   IN EFI_CONSOLE_CONTROL_SCREEN_MODE  InitialMode,
   IN EFI_CONSOLE_CONTROL_SCREEN_MODE  Mode

--- a/Library/OcConsoleLib/TextOutputBuiltin.c
+++ b/Library/OcConsoleLib/TextOutputBuiltin.c
@@ -608,10 +608,6 @@ AsciiTextTestString (
 {
   if (StrCmp (String, OC_CONSOLE_MARK_UNCONTROLLED) == 0) {
     mConsoleUncontrolled = TRUE;
-  } else if (StrCmp (String, OC_CONSOLE_MARK_CONTROLLED) == 0) {
-    mConsoleMaxPosX      = 0;
-    mConsoleMaxPosY      = 0;
-    mConsoleUncontrolled = FALSE;
   }
 
   return EFI_SUCCESS;
@@ -1060,12 +1056,6 @@ OcUseBuiltinTextOutput (
              gST->Hdr.HeaderSize,
              &gST->Hdr.CRC32
              );
-
-      //
-      // Mark dirty due to BIOS logo, early logs, etc. - which will not be cleared
-      // by initial resync when starting in graphics mode.
-      //
-      gST->ConOut->TestString (gST->ConOut, OC_CONSOLE_MARK_UNCONTROLLED);
     }
   }
 

--- a/Library/OcConsoleLib/TextOutputBuiltin.c
+++ b/Library/OcConsoleLib/TextOutputBuiltin.c
@@ -399,7 +399,7 @@ RenderResync (
   mConsoleGopMode = mGraphicsOutput->Mode->Mode;
   MaxWidth        = Info->HorizontalResolution / TGT_CHAR_WIDTH;
   MaxHeight       = Info->VerticalResolution / TGT_CHAR_HEIGHT;
-  if ((mUserWidth < 1) || (mUserHeight < 1)) {
+  if ((mUserWidth == 0) || (mUserHeight == 0)) {
     mConsoleWidth  = MaxWidth;
     mConsoleHeight = MaxHeight;
   } else {
@@ -996,38 +996,6 @@ EFI_CONSOLE_CONTROL_PROTOCOL
   ConsoleControlSetMode,
   ConsoleControlLockStdIn
 };
-
-VOID
-ConsoleControlInstall (
-  VOID
-  )
-{
-  EFI_STATUS                    Status;
-  EFI_CONSOLE_CONTROL_PROTOCOL  *ConsoleControl;
-
-  Status = OcHandleProtocolFallback (
-             &gST->ConsoleOutHandle,
-             &gEfiConsoleControlProtocolGuid,
-             (VOID *)&ConsoleControl
-             );
-
-  if (!EFI_ERROR (Status)) {
-    ConsoleControl->SetMode (ConsoleControl, EfiConsoleControlScreenGraphics);
-
-    CopyMem (
-      ConsoleControl,
-      &mConsoleControlProtocol,
-      sizeof (mConsoleControlProtocol)
-      );
-  }
-
-  gBS->InstallMultipleProtocolInterfaces (
-         &gST->ConsoleOutHandle,
-         &gEfiConsoleControlProtocolGuid,
-         &mConsoleControlProtocol,
-         NULL
-         );
-}
 
 EFI_STATUS
 OcUseBuiltinTextOutput (

--- a/Library/OcConsoleLib/TextOutputBuiltin.c
+++ b/Library/OcConsoleLib/TextOutputBuiltin.c
@@ -977,6 +977,7 @@ ConsoleControlInstall (
 
 EFI_STATUS
 OcUseBuiltinTextOutput (
+  IN EFI_CONSOLE_CONTROL_SCREEN_MODE  InitialMode,
   IN EFI_CONSOLE_CONTROL_SCREEN_MODE  Mode
   )
 {
@@ -999,7 +1000,8 @@ OcUseBuiltinTextOutput (
 
   DEBUG ((DEBUG_INFO, "OCC: Using builtin text renderer with %d scale\n", mFontScale));
 
-  Status = AsciiTextResetEx (&mAsciiTextOutputProtocol, TRUE, TRUE);
+  mConsoleMode = InitialMode;
+  Status       = AsciiTextResetEx (&mAsciiTextOutputProtocol, TRUE, TRUE);
 
   if (!EFI_ERROR (Status)) {
     OcConsoleControlSetMode (Mode);

--- a/Library/OcConsoleLib/TextOutputSystem.c
+++ b/Library/OcConsoleLib/TextOutputSystem.c
@@ -327,11 +327,12 @@ EFI_CONSOLE_CONTROL_PROTOCOL
 
 EFI_STATUS
 OcUseSystemTextOutput (
-  IN OC_CONSOLE_RENDERER  Renderer,
-  IN BOOLEAN              IgnoreTextOutput,
-  IN BOOLEAN              SanitiseClearScreen,
-  IN BOOLEAN              ClearScreenOnModeSwitch,
-  IN BOOLEAN              ReplaceTabWithSpace
+  IN EFI_CONSOLE_CONTROL_SCREEN_MODE  InitialMode,
+  IN OC_CONSOLE_RENDERER              Renderer,
+  IN BOOLEAN                          IgnoreTextOutput,
+  IN BOOLEAN                          SanitiseClearScreen,
+  IN BOOLEAN                          ClearScreenOnModeSwitch,
+  IN BOOLEAN                          ReplaceTabWithSpace
   )
 {
   DEBUG ((
@@ -343,15 +344,18 @@ OcUseSystemTextOutput (
     ReplaceTabWithSpace
     ));
 
+  mConsoleMode = InitialMode;
+
   if (Renderer == OcConsoleRendererSystemGraphics) {
     OcConsoleControlSetMode (EfiConsoleControlScreenGraphics);
-    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, &mConsoleMode);
+    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, NULL);
   } else if (Renderer == OcConsoleRendererSystemText) {
     OcConsoleControlSetMode (EfiConsoleControlScreenText);
-    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, &mConsoleMode);
+    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, NULL);
   } else {
     ASSERT (Renderer == OcConsoleRendererSystemGeneric);
-    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, &mOriginalConsoleControlProtocol, &mConsoleMode);
+    OcConsoleControlSetMode (InitialMode);
+    OcConsoleControlInstallProtocol (&mConsoleControlProtocol, &mOriginalConsoleControlProtocol, NULL);
   }
 
   mIgnoreTextInGraphics    = IgnoreTextOutput;

--- a/Library/OcConsoleLib/TextOutputSystem.c
+++ b/Library/OcConsoleLib/TextOutputSystem.c
@@ -350,6 +350,7 @@ OcUseSystemTextOutput (
     OcConsoleControlSetMode (EfiConsoleControlScreenText);
     OcConsoleControlInstallProtocol (&mConsoleControlProtocol, NULL, &mConsoleMode);
   } else {
+    ASSERT (Renderer == OcConsoleRendererSystemGeneric);
     OcConsoleControlInstallProtocol (&mConsoleControlProtocol, &mOriginalConsoleControlProtocol, &mConsoleMode);
   }
 

--- a/Library/OcMainLib/OpenCoreUefiInOut.c
+++ b/Library/OcMainLib/OpenCoreUefiInOut.c
@@ -185,16 +185,18 @@ OcLoadUefiOutputSupport (
   IN OC_GLOBAL_CONFIG  *Config
   )
 {
-  EFI_STATUS                    Status;
-  CONST CHAR8                   *AsciiRenderer;
-  CONST CHAR8                   *GopPassThrough;
-  EFI_GRAPHICS_OUTPUT_PROTOCOL  *Gop;
-  OC_CONSOLE_RENDERER           Renderer;
-  UINT32                        Width;
-  UINT32                        Height;
-  UINT32                        Bpp;
-  BOOLEAN                       SetMax;
-  UINT8                         UIScale;
+  EFI_STATUS                       Status;
+  CONST CHAR8                      *AsciiMode;
+  CONST CHAR8                      *AsciiRenderer;
+  CONST CHAR8                      *GopPassThrough;
+  EFI_GRAPHICS_OUTPUT_PROTOCOL     *Gop;
+  EFI_CONSOLE_CONTROL_SCREEN_MODE  InitialMode;
+  OC_CONSOLE_RENDERER              Renderer;
+  UINT32                           Width;
+  UINT32                           Height;
+  UINT32                           Bpp;
+  BOOLEAN                          SetMax;
+  UINT8                            UIScale;
 
   GopPassThrough = OC_BLOB_GET (&Config->Uefi.Output.GopPassThrough);
   if (AsciiStrCmp (GopPassThrough, "Enabled") == 0) {
@@ -316,6 +318,19 @@ OcLoadUefiOutputSupport (
     DEBUG ((DEBUG_INFO, "OC: Setting UIScale to %d - %r\n", UIScale, Status));
   }
 
+  AsciiMode = OC_BLOB_GET (&Config->Uefi.Output.InitialMode);
+
+  if ((AsciiMode[0] == '\0') || (AsciiStrCmp (AsciiMode, "Auto") == 0)) {
+    InitialMode = EfiConsoleControlScreenMaxValue;
+  } else if (AsciiStrCmp (AsciiMode, "Text") == 0) {
+    InitialMode = EfiConsoleControlScreenText;
+  } else if (AsciiStrCmp (AsciiMode, "Graphics") == 0) {
+    InitialMode = EfiConsoleControlScreenGraphics;
+  } else {
+    DEBUG ((DEBUG_WARN, "OC: Requested unknown initial mode %a\n", AsciiMode));
+    InitialMode = EfiConsoleControlScreenMaxValue;
+  }
+
   AsciiRenderer = OC_BLOB_GET (&Config->Uefi.Output.TextRenderer);
 
   if ((AsciiRenderer[0] == '\0') || (AsciiStrCmp (AsciiRenderer, "BuiltinGraphics") == 0)) {
@@ -334,6 +349,7 @@ OcLoadUefiOutputSupport (
   }
 
   OcSetupConsole (
+    InitialMode,
     Renderer,
     Config->Uefi.Output.IgnoreTextInGraphics,
     Config->Uefi.Output.SanitiseClearScreen,

--- a/Library/OcMainLib/OpenCoreUefiInOut.c
+++ b/Library/OcMainLib/OpenCoreUefiInOut.c
@@ -348,20 +348,22 @@ OcLoadUefiOutputSupport (
     Renderer = OcConsoleRendererBuiltinGraphics;
   }
 
+  OcParseConsoleMode (
+    OC_BLOB_GET (&Config->Uefi.Output.ConsoleMode),
+    &Width,
+    &Height,
+    &SetMax
+    );
+
   OcSetupConsole (
     InitialMode,
     Renderer,
     Config->Uefi.Output.IgnoreTextInGraphics,
     Config->Uefi.Output.SanitiseClearScreen,
     Config->Uefi.Output.ClearScreenOnModeSwitch,
-    Config->Uefi.Output.ReplaceTabWithSpace
-    );
-
-  OcParseConsoleMode (
-    OC_BLOB_GET (&Config->Uefi.Output.ConsoleMode),
-    &Width,
-    &Height,
-    &SetMax
+    Config->Uefi.Output.ReplaceTabWithSpace,
+    Width,
+    Height
     );
 
   DEBUG ((

--- a/Platform/OpenCanopy/OcBootstrap.c
+++ b/Platform/OpenCanopy/OcBootstrap.c
@@ -59,10 +59,6 @@ OcShowMenuByOcEnter (
     return Status;
   }
 
-  //
-  // Extension for OpenCore builtin renderer to mark that we control text output here.
-  //
-  gST->ConOut->TestString (gST->ConOut, OC_CONSOLE_MARK_CONTROLLED);
   mPreviousMode = OcConsoleControlSetMode (EfiConsoleControlScreenGraphics);
 
   return EFI_SUCCESS;
@@ -75,10 +71,6 @@ OcShowMenuByOcLeave (
   )
 {
   GuiLibDestruct ();
-  //
-  // Extension for OpenCore builtin renderer to mark that we no longer control text output here.
-  //
-  gST->ConOut->TestString (gST->ConOut, OC_CONSOLE_MARK_UNCONTROLLED);
   OcConsoleControlSetMode (mPreviousMode);
 }
 

--- a/Staging/EnableGop/EnableGop.c
+++ b/Staging/EnableGop/EnableGop.c
@@ -60,7 +60,9 @@ LoadUefiOutputSupport (
     FALSE,
     FALSE,
     FALSE,
-    FALSE
+    FALSE,
+    0,
+    0
     );
 
   return EFI_SUCCESS;

--- a/Staging/EnableGop/EnableGop.c
+++ b/Staging/EnableGop/EnableGop.c
@@ -55,6 +55,7 @@ LoadUefiOutputSupport (
   }
 
   OcSetupConsole (
+    EfiConsoleControlScreenGraphics,
     OcConsoleRendererBuiltinGraphics,
     FALSE,
     FALSE,

--- a/Staging/EnableGop/EnableGop.inf
+++ b/Staging/EnableGop/EnableGop.inf
@@ -12,7 +12,7 @@
   BASE_NAME                      = EnableGop
   FILE_GUID                      = 3FBA58B1-F8C0-41BC-ACD8-253043A3A17F
   MODULE_TYPE                    = DXE_DRIVER
-  VERSION_STRING                 = 1.3
+  VERSION_STRING                 = 1.4
   ENTRY_POINT                    = UefiMain
 
 #

--- a/Staging/EnableGop/EnableGopDirect.inf
+++ b/Staging/EnableGop/EnableGopDirect.inf
@@ -12,7 +12,7 @@
   BASE_NAME                      = EnableGopDirect
   FILE_GUID                      = 3FBA58B1-F8C0-41BC-ACD8-253043A3A17F
   MODULE_TYPE                    = DXE_DRIVER
-  VERSION_STRING                 = 1.3
+  VERSION_STRING                 = 1.4
   ENTRY_POINT                    = UefiMain
 
 #

--- a/Staging/EnableGop/README.md
+++ b/Staging/EnableGop/README.md
@@ -3,6 +3,11 @@
 ## Releases
 
 EnableGop version (OpenCore version)
+
+### 1.4 (0.9.3)
+ - Incorporates recent updates to OpenCore console control code, but no difference in behaviour compared
+   to version 1.3 is expect on any supported systems.
+
 ### 1.3 (0.9.2)
  - Included fix to GopBurstMode for non-standard frame buffer information on AMD Radeon HD 7970 and similar
  - Applied GopBurstMode even on natively supported cards, as it can provide a noticable speed up

--- a/Staging/EnableGop/README.md
+++ b/Staging/EnableGop/README.md
@@ -6,7 +6,7 @@ EnableGop version (OpenCore version)
 
 ### 1.4 (0.9.3)
  - Incorporates recent updates to OpenCore console control code, but no difference in behaviour compared
-   to version 1.3 is expect on any supported systems.
+   to version 1.3 is expected on any supported systems.
 
 ### 1.3 (0.9.2)
  - Included fix to GopBurstMode for non-standard frame buffer information on AMD Radeon HD 7970 and similar

--- a/Utilities/ocvalidate/ValidateUefi.c
+++ b/Utilities/ocvalidate/ValidateUefi.c
@@ -643,11 +643,15 @@ CheckUefiOutput (
     &UserSetMax
     );
   if (  (ConsoleMode[0] != '\0')
-     && !UserSetMax
-     && ((UserWidth == 0) || (UserHeight == 0)))
+     && !UserSetMax)
   {
-    DEBUG ((DEBUG_WARN, "UEFI->Output->ConsoleMode is borked, please check Configurations.pdf!\n"));
-    ++ErrorCount;
+    if ((UserWidth == 0) || (UserHeight == 0)) {
+      DEBUG ((DEBUG_WARN, "UEFI->Output->ConsoleMode is borked, please check documentation!\n"));
+      ++ErrorCount;
+    } else if ((UserWidth < 80) || (UserHeight < 25)) {
+      DEBUG ((DEBUG_WARN, "UEFI->Output->ConsoleMode is below minumum supported console text resolution of 80x25, please fix!\n"));
+      ++ErrorCount;
+    }
   }
 
   //
@@ -665,7 +669,7 @@ CheckUefiOutput (
      && !UserSetMax
      && ((UserWidth == 0) || (UserHeight == 0)))
   {
-    DEBUG ((DEBUG_WARN, "UEFI->Output->Resolution is borked, please check Configurations.pdf!\n"));
+    DEBUG ((DEBUG_WARN, "UEFI->Output->Resolution is borked, please check documentation!\n"));
     ++ErrorCount;
   }
 

--- a/Utilities/ocvalidate/ValidateUefi.c
+++ b/Utilities/ocvalidate/ValidateUefi.c
@@ -548,6 +548,7 @@ CheckUefiOutput (
   )
 {
   UINT32       ErrorCount;
+  CONST CHAR8  *InitialMode;
   CONST CHAR8  *TextRenderer;
   CONST CHAR8  *GopPassThrough;
   BOOLEAN      IsTextRendererSystem;
@@ -571,6 +572,15 @@ CheckUefiOutput (
   //
   // Sanitise strings.
   //
+  InitialMode = OC_BLOB_GET (&Config->Uefi.Output.InitialMode);
+  if (  (AsciiStrCmp (InitialMode, "Auto") != 0)
+     && (AsciiStrCmp (InitialMode, "Text") != 0)
+     && (AsciiStrCmp (InitialMode, "Graphics") != 0))
+  {
+    DEBUG ((DEBUG_WARN, "UEFI->Output->InitialMode is illegal (Can only be Auto, Text, or Graphics)!\n"));
+    ++ErrorCount;
+  }
+
   TextRenderer = OC_BLOB_GET (&Config->Uefi.Output.TextRenderer);
   if (  (AsciiStrCmp (TextRenderer, "BuiltinGraphics") != 0)
      && (AsciiStrCmp (TextRenderer, "BuiltinText") != 0)


### PR DESCRIPTION
Apologies for earlier fat finger.

Here it is as a PR.

Commit to go to back to how everything was is now on master, as agreed. But note this causes I believe one different reversion outside of EnableGop (namely initial verbose boot text writes over graphics picker; see subsequent comment for more details), and multiple reversions inside EnableGop (which is temporarily disabled from bundling in OC as agreed).

Then, still in this PR itself:

 - First commit is meant to be non-controversial changes to BuiltinRenderer
 - Second commit implements InitialMode option
 - Third and fourth commits attempt to address all desiderata (see below)
 - Fifth commit (seemed like a good idea) supports ConsoleMode text resolution option in Builtin renderer
 - Sixth just syncs changelog

My understanding (very briefly, see also docs in the relevant commit) of requirement for InitialMode:
 - Set the initial console mode (text, graphics), if you can, but anyway report it as being set, if not
 - For the renderers, initialise them just as they were previously (before all changes), but taking the result of the above as what they think the current mode is, rather than reading the actual current mode (when these differ)

(I believe this code achieves this, but...)

**Desiderata for these changes:**

- APFS log lines must not appear before Mac logo/OC menu (or over UI theme colour) on native Macs using EnableGop, but will do so unless it is possible to start builtin renderer in graphics mode (i.e. reporting itself as graphics mode)
- There should be no flash to console bg (typically black, and in general cannot always match theme UI colour) between native picker and Canopy, but will be unless builtin renderer in EnableGop disables screen clearing in graphics mode, and new builtin renderer in OC disables clearing when staying in graphics mode
- If we were in graphics mode, or uncontrolled text mode, we want a console bg cls before macOS verbose output starts. Note that the ideal timing for this is precisely when macOS itself requests to switch to console mode
- We ideally _don't_ want a cls when verbose output starts and we have the (controlled) builtin picker text on screen
- Mode switches should be cheap or free (Vit's comment)
- Apple picker used as OC picker should switch back to builtin picker cleanly, if it needs to (i.e. not on top of the Apple picker graphics)
- builtin picker (and password prompt) must not overwrite bios logo
- Continues to behave how @dhinakg expects: with InitialMode=Text (or Auto, if this gives Text), debug lines should just run freely over Canopy graphics, as they appear, and without any additional (automatic, or other) clear screens compared to how it was before
- Enter graphics mode tool from builtin picker then return to menu should display menu cleanly, not over previous graphics output

Not sure if it is also worth adding my summary of operation of pre-existing renderers (as they always were, i.e. after reverting any recent changes (as done in first commit)):

- Builtin renderer always starts off reporting as text (regardless of whether it runs in underlying text or graphics (or 'neither', i.e. no cc protocol) (but for reasons as above, we may want it to start off reporting as graphics; particularly if it is taking over from existing graphics - which would be InitialMode=Auto)
- System renderer:
  - In Graphics or Text, we set the requested mode, and then start off reporting as being in the mode we are actually in (but defaulting to text if there is no native console control protocol) (so note that with no InitialMode and no builtin protocol, we can only start off reporting as being in text mode)
  - Generic is somewhat different; firstly, we just use the existing mode, without trying to set either mode first; but secondly, we (attempt to) get the existing console control protocol, and _if_ it exists, we pass through GetMode, SetMode and LockStdIn to it