### PR TITLE
OcMainLib/OpenCoreAcpi: Fix orders for `RebaseRegions` and `SyncTableIds`

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -857,9 +857,10 @@ ACPI changes apply globally (to every operating system) with the following effec
 \begin{itemize}
 \tightlist
 \item \texttt{Delete} is processed.
-\item \texttt{Quirks} are processed.
+\item \texttt{Quirks} are processed, with the exception of \texttt{RebaseRegions} and \texttt{SyncTableIds}.
 \item \texttt{Patch} is processed.
 \item \texttt{Add} is processed.
+\item \texttt{RebaseRegions} and \texttt{SyncTableIds} are processed, if requested.
 \end{itemize}
 
 Applying the changes globally resolves the problems of incorrect operating system

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -857,11 +857,12 @@ ACPI changes apply globally (to every operating system) with the following effec
 \begin{itemize}
 \tightlist
 \item \texttt{Delete} is processed.
-\item \texttt{Quirks} are processed, with the exception of \texttt{RebaseRegions} and \texttt{SyncTableIds}.
+\item \texttt{Quirks} are processed.
 \item \texttt{Patch} is processed.
 \item \texttt{Add} is processed.
-\item \texttt{RebaseRegions} and \texttt{SyncTableIds} are processed, if requested.
 \end{itemize}
+
+\emph{Note}: \texttt{RebaseRegions} and \texttt{SyncTableIds} quirks are special and are processed after all other ACPI changes since they can only be applied on the final ACPI configuration including all the patches and added tables.
 
 Applying the changes globally resolves the problems of incorrect operating system
 detection (consistent with the ACPI specification, not possible before the operating

--- a/Library/OcMainLib/OpenCoreAcpi.c
+++ b/Library/OcMainLib/OpenCoreAcpi.c
@@ -243,21 +243,21 @@ OcLoadAcpiSupport (
   //
   AcpiHandleHardwareSignature (&Context, Config->Acpi.Quirks.ResetHwSig);
 
-  if (Config->Acpi.Quirks.RebaseRegions) {
-    AcpiRelocateRegions (&Context);
-  }
-
   if (Config->Acpi.Quirks.NormalizeHeaders) {
     AcpiNormalizeHeaders (&Context);
-  }
-
-  if (Config->Acpi.Quirks.SyncTableIds) {
-    AcpiSyncTableIds (&Context);
   }
 
   OcAcpiPatchTables (Config, &Context);
 
   OcAcpiAddTables (Config, Storage, &Context);
+
+  if (Config->Acpi.Quirks.RebaseRegions) {
+    AcpiRelocateRegions (&Context);
+  }
+
+  if (Config->Acpi.Quirks.SyncTableIds) {
+    AcpiSyncTableIds (&Context);
+  }
 
   AcpiApplyContext (&Context);
 


### PR DESCRIPTION
Closes https://github.com/acidanthera/bugtracker/issues/2275

This fixes regression introduced by https://github.com/acidanthera/OpenCorePkg/commit/f604848c61d7082860fceb23ac54d5e03e620478.