### PR TITLE
Build: Use latest Windows image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
 
   build-windows:
     name: Windows VS2019
-    runs-on: windows-2019
+    runs-on: windows-latest
     env:
       HAS_OPENSSL_BUILD: 0
       CC: gcc


### PR DESCRIPTION
This closes https://github.com/acidanthera/bugtracker/issues/1962, as the issue has been fixed upstream.