### PR TITLE
4G Decoding CpuIo/PciRootBridgeIo/PciIo fix for Aptio 4 / Ivy Bridge

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -8600,6 +8600,14 @@ for additional options.
   applications to receive notifications from the macOS bootloader.
 
 \item
+  \texttt{PciIo}\\
+  \textbf{Type}: \texttt{plist\ boolean}\\
+  \textbf{Failsafe}: \texttt{false}\\
+  \textbf{Description}: Replaces functions in CpuIo and PciRootBridgeIo with
+  64-bit MMIO compatible ones to fix \texttt{Invalid Parameter} when using 4G Decoding.
+  Platforms earlier than APTIO V (Haswell and older) are typically affected.
+
+\item
   \texttt{UnicodeCollation}\\
   \textbf{Type}: \texttt{plist\ boolean}\\
   \textbf{Failsafe}: \texttt{false}\\

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -8605,6 +8605,7 @@ for additional options.
   \textbf{Failsafe}: \texttt{false}\\
   \textbf{Description}: Replaces functions in CpuIo and PciRootBridgeIo with
   64-bit MMIO compatible ones to fix \texttt{Invalid Parameter} when using 4G Decoding.
+  This affects UEFI drivers such as \texttt{AudioDxe} which access 64-bit MMIO devices.
   Platforms earlier than APTIO V (Haswell and older) are typically affected.
 
 \item

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1894,6 +1894,8 @@
 			<false/>
 			<key>OSInfo</key>
 			<false/>
+			<key>PciIo</key>
+			<false/>
 			<key>UnicodeCollation</key>
 			<false/>
 		</dict>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -2262,6 +2262,8 @@
 			<false/>
 			<key>OSInfo</key>
 			<false/>
+			<key>PciIo</key>
+			<false/>
 			<key>UnicodeCollation</key>
 			<false/>
 		</dict>

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -725,6 +725,7 @@ OC_DECLARE (OC_UEFI_OUTPUT)
   _(BOOLEAN                     , FirmwareVolume              ,     , FALSE  , ()) \
   _(BOOLEAN                     , HashServices                ,     , FALSE  , ()) \
   _(BOOLEAN                     , OSInfo                      ,     , FALSE  , ()) \
+  _(BOOLEAN                     , PciIo                       ,     , FALSE  , ()) \
   _(BOOLEAN                     , UnicodeCollation            ,     , FALSE  , ())
 OC_DECLARE (OC_UEFI_PROTOCOL_OVERRIDES)
 

--- a/Include/Acidanthera/Library/OcPciIoLib.h
+++ b/Include/Acidanthera/Library/OcPciIoLib.h
@@ -13,7 +13,7 @@
 #ifndef OC_PCI_IO_LIB_H
 #define OC_PCI_IO_LIB_H
 
-#include <Protocol/PciIo.h>
+#include <Protocol/CpuIo2.h>
 
 /**
   The user Entry Point for PciIo.
@@ -25,7 +25,7 @@
   @returns Installed protocol.
   @retval NULL  There was an error installing the protocol.
 **/
-EFI_PCI_IO_PROTOCOL *
+EFI_CPU_IO2_PROTOCOL *
 OcPciIoInstallProtocol (
   IN BOOLEAN  Reinstall
   );

--- a/Include/Acidanthera/Library/OcPciIoLib.h
+++ b/Include/Acidanthera/Library/OcPciIoLib.h
@@ -1,5 +1,7 @@
 /** @file
-  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2023, xCuri0. All rights reserved.
+
+  All rights reserved.
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License

--- a/Include/Acidanthera/Library/OcPciIoLib.h
+++ b/Include/Acidanthera/Library/OcPciIoLib.h
@@ -1,0 +1,33 @@
+/** @file
+  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+**/
+
+#ifndef OC_PCI_IO_LIB_H
+#define OC_PCI_IO_LIB_H
+
+#include <Protocol/PciIo.h>
+
+/**
+  The user Entry Point for PciIo.
+
+  This function fixes PciIo related protocols.
+
+  @param[in] Reinstall  Replace any installed protocol.
+
+  @returns Installed protocol.
+  @retval NULL  There was an error installing the protocol.
+**/
+EFI_PCI_IO_PROTOCOL *
+OcPciIoInstallProtocol (
+  IN BOOLEAN  Reinstall
+  );
+
+#endif // OC_PCI_IO_LIB_H

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -750,6 +750,7 @@ OC_SCHEMA
   OC_SCHEMA_BOOLEAN_IN ("FirmwareVolume",          OC_GLOBAL_CONFIG, Uefi.ProtocolOverrides.FirmwareVolume),
   OC_SCHEMA_BOOLEAN_IN ("HashServices",            OC_GLOBAL_CONFIG, Uefi.ProtocolOverrides.HashServices),
   OC_SCHEMA_BOOLEAN_IN ("OSInfo",                  OC_GLOBAL_CONFIG, Uefi.ProtocolOverrides.OSInfo),
+  OC_SCHEMA_BOOLEAN_IN ("PciIo",                   OC_GLOBAL_CONFIG, Uefi.ProtocolOverrides.PciIo),
   OC_SCHEMA_BOOLEAN_IN ("UnicodeCollation",        OC_GLOBAL_CONFIG, Uefi.ProtocolOverrides.UnicodeCollation)
 };
 

--- a/Library/OcMainLib/OcMainLib.inf
+++ b/Library/OcMainLib/OcMainLib.inf
@@ -99,6 +99,7 @@
   OcMachoLib
   OcMiscLib
   OcOSInfoLib
+  OcPciIoLib
   OcSmbiosLib
   OcSmcLib
   OcStorageLib

--- a/Library/OcMainLib/OpenCoreUefi.c
+++ b/Library/OcMainLib/OpenCoreUefi.c
@@ -49,6 +49,7 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include <Library/OcSmcLib.h>
 #include <Library/OcOSInfoLib.h>
 #include <Library/OcUnicodeCollationEngGenericLib.h>
+#include <Library/OcPciIoLib.h>
 #include <Library/OcVariableLib.h>
 #include <Library/PrintLib.h>
 #include <Library/UefiBootServicesTableLib.h>
@@ -424,6 +425,10 @@ OcReinstallProtocols (
 
   if (OcAppleKeyMapInstallProtocols (Config->Uefi.ProtocolOverrides.AppleKeyMap) == NULL) {
     DEBUG ((DEBUG_INFO, "OC: Failed to install key map protocols\n"));
+  }
+
+  if (OcPciIoInstallProtocol (Config->Uefi.ProtocolOverrides.PciIo) == NULL) {
+    DEBUG ((DEBUG_INFO, "OC: Failed to install pci io protocol\n"));
   }
 
   InstallAppleEvent  = TRUE;

--- a/Library/OcMainLib/OpenCoreUefi.c
+++ b/Library/OcMainLib/OpenCoreUefi.c
@@ -428,7 +428,7 @@ OcReinstallProtocols (
   }
 
   if (OcPciIoInstallProtocol (Config->Uefi.ProtocolOverrides.PciIo) == NULL) {
-    DEBUG ((DEBUG_INFO, "OC: Failed to install pci io protocol\n"));
+    DEBUG ((DEBUG_INFO, "OC: Failed to install cpuio/pcirootbridgeio overrides\n"));
   }
 
   InstallAppleEvent  = TRUE;

--- a/Library/OcPciIoLib/OcPciIoLib.c
+++ b/Library/OcPciIoLib/OcPciIoLib.c
@@ -27,7 +27,8 @@ OcPciIoInstallProtocol (
     return NULL;
   }
 
-  if (Reinstall) {
+  DEBUG ((DEBUG_INFO, "OCPIO: Reinstall %d\n", Reinstall));
+  if (!Reinstall) {
     return mCpuIo;
   } else {
     Tpl    = gBS->RaiseTPL (TPL_HIGH_LEVEL);

--- a/Library/OcPciIoLib/OcPciIoLib.c
+++ b/Library/OcPciIoLib/OcPciIoLib.c
@@ -9,32 +9,30 @@
 #include "OcPciIoU.h"
 #include <Library/OcPciIoLib.h>
 
-EFI_PCI_IO_PROTOCOL *
+EFI_CPU_IO2_PROTOCOL *
 OcPciIoInstallProtocol (
   IN BOOLEAN  Reinstall
   )
 {
   EFI_TPL                          tpl;
-  EFI_STATUS                       Status = 0;
-  EFI_CPU_IO2_PROTOCOL             *mCpuIo;
+  UINTN                            Index;
+  EFI_STATUS                       Status  = 0;
+  EFI_CPU_IO2_PROTOCOL             *mCpuIo = NULL;
   UINTN                            HandleCount;
   EFI_HANDLE                       *HandleBuffer;
   EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL  *PciRootBridgeIo;
-  UINTN                            Index;
 
   if (Reinstall) {
-    // TODO: if we need it
+    return NULL;
   } else {
-    DEBUG ((DEBUG_INFO, "OCPIO: Init CpuIo2\n"));
     mCpuIo = InitializeCpuIo2 ();
-    DEBUG ((DEBUG_INFO, "OCPIO: Fixing CpuIo2\n"));
 
     tpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
-
-    if (EFI_ERROR (Status)) {
+    if (!mCpuIo) {
       return NULL;
     }
 
+    DEBUG ((DEBUG_INFO, "OCPIO: Fixing CpuIo2\n"));
     // Override with 64-bit MMIO compatible functions
     mCpuIo->Mem.Read  = CpuMemoryServiceRead;
     mCpuIo->Mem.Write = CpuMemoryServiceWrite;
@@ -47,6 +45,11 @@ OcPciIoInstallProtocol (
                     &HandleBuffer
                     );
 
+    if (EFI_ERROR (Status)) {
+      mCpuIo = NULL;
+      goto Free;
+    }
+
     for (Index = 0; Index < HandleCount; ++Index) {
       DEBUG ((DEBUG_INFO, "OCPIO: Fixing PciRootBridgeIo %d\n", Index));
       Status = gBS->HandleProtocol (
@@ -55,7 +58,8 @@ OcPciIoInstallProtocol (
                       (VOID **)&PciRootBridgeIo
                       );
       if (EFI_ERROR (Status)) {
-        continue;
+        mCpuIo = NULL;
+        goto Free;
       }
 
       // Override with 64-bit MMIO compatible functions
@@ -63,12 +67,10 @@ OcPciIoInstallProtocol (
       PciRootBridgeIo->Mem.Write = RootBridgeIoMemWrite;
     }
 
-    FreePool (HandleBuffer);
-
     gBS->RestoreTPL (tpl);
-
-    return NULL;
   }
 
-  return NULL;
+Free:
+  FreePool (HandleBuffer);
+  return mCpuIo;
 }

--- a/Library/OcPciIoLib/OcPciIoLib.c
+++ b/Library/OcPciIoLib/OcPciIoLib.c
@@ -23,7 +23,7 @@ OcPciIoInstallProtocol (
   EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL  *PciRootBridgeIo;
 
   CpuIo = InitializeCpuIo2 ();
-  if (!CpuIo) {
+  if (CpuIo == NULL) {
     return NULL;
   }
 

--- a/Library/OcPciIoLib/OcPciIoLib.c
+++ b/Library/OcPciIoLib/OcPciIoLib.c
@@ -30,7 +30,7 @@ OcPciIoInstallProtocol (
   if (Reinstall) {
     return mCpuIo;
   } else {
-    Tpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
+    Tpl    = gBS->RaiseTPL (TPL_HIGH_LEVEL);
     Status = gBS->LocateHandleBuffer (
                     ByProtocol,
                     &gEfiPciRootBridgeIoProtocolGuid,
@@ -61,6 +61,7 @@ OcPciIoInstallProtocol (
         mCpuIo = NULL;
         goto Free;
       }
+
       // Override with 64-bit MMIO compatible functions
       PciRootBridgeIo->Mem.Read  = RootBridgeIoMemRead;
       PciRootBridgeIo->Mem.Write = RootBridgeIoMemWrite;

--- a/Library/OcPciIoLib/OcPciIoLib.c
+++ b/Library/OcPciIoLib/OcPciIoLib.c
@@ -1,0 +1,74 @@
+/** @file
+   PciIo overrides
+
+   Copyright (c) 2023, xCuri0. All rights reserved.<BR>
+   SPDX-License-Identifier: BSD-2-Clause-Patent
+
+ **/
+
+#include "OcPciIoU.h"
+#include <Library/OcPciIoLib.h>
+
+EFI_PCI_IO_PROTOCOL *
+OcPciIoInstallProtocol (
+  IN BOOLEAN  Reinstall
+  )
+{
+  EFI_TPL                          tpl;
+  EFI_STATUS                       Status = 0;
+  EFI_CPU_IO2_PROTOCOL             *mCpuIo;
+  UINTN                            HandleCount;
+  EFI_HANDLE                       *HandleBuffer;
+  EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL  *PciRootBridgeIo;
+  UINTN                            Index;
+
+  if (Reinstall) {
+    // TODO: if we need it
+  } else {
+    DEBUG ((DEBUG_INFO, "OCPIO: Init CpuIo2\n"));
+    mCpuIo = InitializeCpuIo2 ();
+    DEBUG ((DEBUG_INFO, "OCPIO: Fixing CpuIo2\n"));
+
+    tpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
+
+    if (EFI_ERROR (Status)) {
+      return NULL;
+    }
+
+    // Override with 64-bit MMIO compatible functions
+    mCpuIo->Mem.Read  = CpuMemoryServiceRead;
+    mCpuIo->Mem.Write = CpuMemoryServiceWrite;
+
+    Status = gBS->LocateHandleBuffer (
+                    ByProtocol,
+                    &gEfiPciRootBridgeIoProtocolGuid,
+                    NULL,
+                    &HandleCount,
+                    &HandleBuffer
+                    );
+
+    for (Index = 0; Index < HandleCount; ++Index) {
+      DEBUG ((DEBUG_INFO, "OCPIO: Fixing PciRootBridgeIo %d\n", Index));
+      Status = gBS->HandleProtocol (
+                      HandleBuffer[Index],
+                      &gEfiPciRootBridgeIoProtocolGuid,
+                      (VOID **)&PciRootBridgeIo
+                      );
+      if (EFI_ERROR (Status)) {
+        continue;
+      }
+
+      // Override with 64-bit MMIO compatible functions
+      PciRootBridgeIo->Mem.Read  = RootBridgeIoMemRead;
+      PciRootBridgeIo->Mem.Write = RootBridgeIoMemWrite;
+    }
+
+    FreePool (HandleBuffer);
+
+    gBS->RestoreTPL (tpl);
+
+    return NULL;
+  }
+
+  return NULL;
+}

--- a/Library/OcPciIoLib/OcPciIoLib.c
+++ b/Library/OcPciIoLib/OcPciIoLib.c
@@ -27,7 +27,6 @@ OcPciIoInstallProtocol (
     return NULL;
   }
 
-  DEBUG ((DEBUG_INFO, "OCPIO: Reinstall %d\n", Reinstall));
   if (!Reinstall) {
     return mCpuIo;
   } else {

--- a/Library/OcPciIoLib/OcPciIoLib.c
+++ b/Library/OcPciIoLib/OcPciIoLib.c
@@ -30,6 +30,7 @@ OcPciIoInstallProtocol (
   if (!Reinstall) {
     return CpuIo;
   }
+
   Tpl    = gBS->RaiseTPL (TPL_HIGH_LEVEL);
   Status = gBS->LocateHandleBuffer (
                   ByProtocol,
@@ -58,7 +59,7 @@ OcPciIoInstallProtocol (
                     (VOID **)&PciRootBridgeIo
                     );
     if (EFI_ERROR (Status)) {
-        break;
+      break;
     }
 
     // Override with 64-bit MMIO compatible functions

--- a/Library/OcPciIoLib/OcPciIoLib.inf
+++ b/Library/OcPciIoLib/OcPciIoLib.inf
@@ -1,0 +1,49 @@
+## @file
+#
+#  Component description file for the library producing the English version of Unicode Collation Protocol.
+#
+#  Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
+#
+# This program and the accompanying materials
+# are licensed and made available under the terms and conditions of the BSD License
+# which accompanies this distribution.  The full text of the license may be found at
+# http://opensource.org/licenses/bsd-license.php
+#
+# THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+# WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = OcPciIoLib
+  FILE_GUID                      = BC045E46-093A-4217-B836-8FF2CD890FCC
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = OcPciIoLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_DRIVER UEFI_APPLICATION DXE_SMM_DRIVER DXE_SAL_DRIVER
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF EBC
+#
+
+[Sources]
+  OcPciIoU.c
+  OcPciIoLib.c
+  OcPciIoU.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OpenCorePkg/OpenCorePkg.dec
+
+[Protocols]
+  gEfiPciIoProtocolGuid  ## SOMETIMES_PRODUCES
+  gEfiCpuIo2ProtocolGuid ## SOMETIMES_CONSUMES
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+  OcMiscLib
+  UefiBootServicesTableLib

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -45,21 +45,25 @@ UINT8  mOutStride[] = {
 };
 
 EFI_CPU_IO2_PROTOCOL *
-InitializeCpuIo2 ( VOID )
+InitializeCpuIo2 (
+  VOID
+  )
 {
-  EFI_STATUS Status;
+  EFI_STATUS  Status;
 
-  if (mCpuIo)
+  if (mCpuIo) {
     return mCpuIo;
+  }
 
   Status = gBS->LocateProtocol (
-         &gEfiCpuIo2ProtocolGuid,
-         NULL,
-         (VOID **)&mCpuIo
-         );
+                  &gEfiCpuIo2ProtocolGuid,
+                  NULL,
+                  (VOID **)&mCpuIo
+                  );
 
-  if (EFI_ERROR(Status))
+  if (EFI_ERROR (Status)) {
     return NULL;
+  }
 
   return mCpuIo;
 }
@@ -250,11 +254,11 @@ CpuMemoryServiceRead (
     if (OperationWidth == EfiCpuIoWidthUint8) {
       *Uint8Buffer = MmioRead8 ((UINTN)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
-      *((UINT16 *)Uint8Buffer) = ReadUnaligned16 ((UINT16*)Address);
+      *((UINT16 *)Uint8Buffer) = ReadUnaligned16 ((UINT16 *)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
-      *((UINT32 *)Uint8Buffer) = ReadUnaligned32 ((UINT32*)Address);
+      *((UINT32 *)Uint8Buffer) = ReadUnaligned32 ((UINT32 *)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint64) {
-      *((UINT64 *)Uint8Buffer) = ReadUnaligned64 ((UINT64*)Address);
+      *((UINT64 *)Uint8Buffer) = ReadUnaligned64 ((UINT64 *)Address);
     }
   }
 
@@ -331,11 +335,11 @@ CpuMemoryServiceWrite (
     if (OperationWidth == EfiCpuIoWidthUint8) {
       MmioWrite8 ((UINTN)Address, *Uint8Buffer);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
-      WriteUnaligned16 ((UINT16*)Address, *((UINT16 *)Uint8Buffer));
+      WriteUnaligned16 ((UINT16 *)Address, *((UINT16 *)Uint8Buffer));
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
-      WriteUnaligned32 ((UINT32*)Address, *((UINT32 *)Uint8Buffer));
+      WriteUnaligned32 ((UINT32 *)Address, *((UINT32 *)Uint8Buffer));
     } else if (OperationWidth == EfiCpuIoWidthUint64) {
-      WriteUnaligned64 ((UINT64*)Address, *((UINT64 *)Uint8Buffer));
+      WriteUnaligned64 ((UINT64 *)Address, *((UINT64 *)Uint8Buffer));
     }
   }
 

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -254,11 +254,11 @@ CpuMemoryServiceRead (
     if (OperationWidth == EfiCpuIoWidthUint8) {
       *((UINT8 *)Uint8Buffer) = *((UINT8 *)(UINTN)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
-      *((UINT16 *)Uint8Buffer) = ReadUnaligned16 ((UINT16 *)(UINTN)Address);
+      WriteUnaligned16((UINT16 *)Uint8Buffer, ReadUnaligned16 ((UINT16 *)(UINTN)Address));
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
-      *((UINT32 *)Uint8Buffer) = ReadUnaligned32 ((UINT32 *)(UINTN)Address);
+      WriteUnaligned32((UINT32 *)Uint8Buffer, ReadUnaligned32 ((UINT32 *)(UINTN)Address));
     } else if (OperationWidth == EfiCpuIoWidthUint64) {
-      *((UINT64 *)Uint8Buffer) = ReadUnaligned64 ((UINT64 *)(UINTN)Address);
+      WriteUnaligned64((UINT64 *)Uint8Buffer, ReadUnaligned64 ((UINT64 *)(UINTN)Address));
     }
   }
 

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -254,11 +254,11 @@ CpuMemoryServiceRead (
     if (OperationWidth == EfiCpuIoWidthUint8) {
       *Uint8Buffer = MmioRead8 ((UINTN)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
-      *((UINT16 *)Uint8Buffer) = ReadUnaligned16 ((UINT16 *)Address);
+      *((UINT16 *)Uint8Buffer) = ReadUnaligned16 ((UINT16 *)(UINTN)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
-      *((UINT32 *)Uint8Buffer) = ReadUnaligned32 ((UINT32 *)Address);
+      *((UINT32 *)Uint8Buffer) = ReadUnaligned32 ((UINT32 *)(UINTN)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint64) {
-      *((UINT64 *)Uint8Buffer) = ReadUnaligned64 ((UINT64 *)Address);
+      *((UINT64 *)Uint8Buffer) = ReadUnaligned64 ((UINT64 *)(UINTN)Address);
     }
   }
 
@@ -335,11 +335,11 @@ CpuMemoryServiceWrite (
     if (OperationWidth == EfiCpuIoWidthUint8) {
       MmioWrite8 ((UINTN)Address, *Uint8Buffer);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
-      WriteUnaligned16 ((UINT16 *)Address, *((UINT16 *)Uint8Buffer));
+      WriteUnaligned16 ((UINT16 *)(UINTN)Address, *((UINT16 *)Uint8Buffer));
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
-      WriteUnaligned32 ((UINT32 *)Address, *((UINT32 *)Uint8Buffer));
+      WriteUnaligned32 ((UINT32 *)(UINTN)Address, *((UINT32 *)Uint8Buffer));
     } else if (OperationWidth == EfiCpuIoWidthUint64) {
-      WriteUnaligned64 ((UINT64 *)Address, *((UINT64 *)Uint8Buffer));
+      WriteUnaligned64 ((UINT64 *)(UINTN)Address, *((UINT64 *)Uint8Buffer));
     }
   }
 

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -48,6 +48,7 @@ EFI_CPU_IO2_PROTOCOL *
 InitializeCpuIo2 (
   )
 {
+  mCpuIo = NULL;
   gBS->LocateProtocol (
          &gEfiCpuIo2ProtocolGuid,
          NULL,

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -51,7 +51,7 @@ InitializeCpuIo2 (
 {
   EFI_STATUS  Status;
 
-  if (mCpuIo) {
+  if (mCpuIo != NULL) {
     return mCpuIo;
   }
 

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -9,7 +9,7 @@
 
 #include "OcPciIoU.h"
 
-EFI_CPU_IO2_PROTOCOL  *mCpuIo;
+EFI_CPU_IO2_PROTOCOL  *mCpuIo = NULL;
 
 UINT8  mInStride[] = {
   1,      // EfiCpuIoWidthUint8
@@ -45,15 +45,22 @@ UINT8  mOutStride[] = {
 };
 
 EFI_CPU_IO2_PROTOCOL *
-InitializeCpuIo2 (
-  )
+InitializeCpuIo2 ( VOID )
 {
-  mCpuIo = NULL;
-  gBS->LocateProtocol (
+  EFI_STATUS Status;
+
+  if (mCpuIo)
+    return mCpuIo;
+
+  Status = gBS->LocateProtocol (
          &gEfiCpuIo2ProtocolGuid,
          NULL,
          (VOID **)&mCpuIo
          );
+
+  if (EFI_ERROR(Status))
+    return NULL;
+
   return mCpuIo;
 }
 
@@ -243,11 +250,11 @@ CpuMemoryServiceRead (
     if (OperationWidth == EfiCpuIoWidthUint8) {
       *Uint8Buffer = MmioRead8 ((UINTN)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
-      *((UINT16 *)Uint8Buffer) = MmioRead16 ((UINTN)Address);
+      *((UINT16 *)Uint8Buffer) = ReadUnaligned16 ((UINT16*)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
-      *((UINT32 *)Uint8Buffer) = MmioRead32 ((UINTN)Address);
+      *((UINT32 *)Uint8Buffer) = ReadUnaligned32 ((UINT32*)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint64) {
-      *((UINT64 *)Uint8Buffer) = MmioRead64 ((UINTN)Address);
+      *((UINT64 *)Uint8Buffer) = ReadUnaligned64 ((UINT64*)Address);
     }
   }
 
@@ -324,11 +331,11 @@ CpuMemoryServiceWrite (
     if (OperationWidth == EfiCpuIoWidthUint8) {
       MmioWrite8 ((UINTN)Address, *Uint8Buffer);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
-      MmioWrite16 ((UINTN)Address, *((UINT16 *)Uint8Buffer));
+      WriteUnaligned16 ((UINT16*)Address, *((UINT16 *)Uint8Buffer));
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
-      MmioWrite32 ((UINTN)Address, *((UINT32 *)Uint8Buffer));
+      WriteUnaligned32 ((UINT32*)Address, *((UINT32 *)Uint8Buffer));
     } else if (OperationWidth == EfiCpuIoWidthUint64) {
-      MmioWrite64 ((UINTN)Address, *((UINT64 *)Uint8Buffer));
+      WriteUnaligned64 ((UINT64*)Address, *((UINT64 *)Uint8Buffer));
     }
   }
 

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -9,9 +9,9 @@
 
 #include "OcPciIoU.h"
 
-EFI_CPU_IO2_PROTOCOL  *mCpuIo = NULL;
+STATIC EFI_CPU_IO2_PROTOCOL  *mCpuIo = NULL;
 
-UINT8  mInStride[] = {
+STATIC CONST UINT8  mInStride[] = {
   1,      // EfiCpuIoWidthUint8
   2,      // EfiCpuIoWidthUint16
   4,      // EfiCpuIoWidthUint32
@@ -29,7 +29,7 @@ UINT8  mInStride[] = {
 //
 // Lookup table for increment values based on transfer widths
 //
-UINT8  mOutStride[] = {
+STATIC CONST UINT8  mOutStride[] = {
   1,      // EfiCpuIoWidthUint8
   2,      // EfiCpuIoWidthUint16
   4,      // EfiCpuIoWidthUint32
@@ -252,7 +252,7 @@ CpuMemoryServiceRead (
   OperationWidth = (EFI_CPU_IO_PROTOCOL_WIDTH)(Width & 0x03);
   for (Uint8Buffer = Buffer; Count > 0; Address += InStride, Uint8Buffer += OutStride, Count--) {
     if (OperationWidth == EfiCpuIoWidthUint8) {
-      *Uint8Buffer = MmioRead8 ((UINTN)Address);
+      *((UINT8 *)Uint8Buffer) = *((UINT8 *)(UINTN)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
       *((UINT16 *)Uint8Buffer) = ReadUnaligned16 ((UINT16 *)(UINTN)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
@@ -333,7 +333,7 @@ CpuMemoryServiceWrite (
   OperationWidth = (EFI_CPU_IO_PROTOCOL_WIDTH)(Width & 0x03);
   for (Uint8Buffer = Buffer; Count > 0; Address += InStride, Uint8Buffer += OutStride, Count--) {
     if (OperationWidth == EfiCpuIoWidthUint8) {
-      MmioWrite8 ((UINTN)Address, *Uint8Buffer);
+      *((UINT8 *)(UINTN)Address) = *((UINT8 *)Uint8Buffer);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
       WriteUnaligned16 ((UINT16 *)(UINTN)Address, *((UINT16 *)Uint8Buffer));
     } else if (OperationWidth == EfiCpuIoWidthUint32) {

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -254,11 +254,11 @@ CpuMemoryServiceRead (
     if (OperationWidth == EfiCpuIoWidthUint8) {
       *((UINT8 *)Uint8Buffer) = *((UINT8 *)(UINTN)Address);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
-      WriteUnaligned16((UINT16 *)Uint8Buffer, ReadUnaligned16 ((UINT16 *)(UINTN)Address));
+      WriteUnaligned16 ((UINT16 *)Uint8Buffer, ReadUnaligned16 ((UINT16 *)(UINTN)Address));
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
-      WriteUnaligned32((UINT32 *)Uint8Buffer, ReadUnaligned32 ((UINT32 *)(UINTN)Address));
+      WriteUnaligned32 ((UINT32 *)Uint8Buffer, ReadUnaligned32 ((UINT32 *)(UINTN)Address));
     } else if (OperationWidth == EfiCpuIoWidthUint64) {
-      WriteUnaligned64((UINT64 *)Uint8Buffer, ReadUnaligned64 ((UINT64 *)(UINTN)Address));
+      WriteUnaligned64 ((UINT64 *)Uint8Buffer, ReadUnaligned64 ((UINT64 *)(UINTN)Address));
     }
   }
 

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -335,11 +335,11 @@ CpuMemoryServiceWrite (
     if (OperationWidth == EfiCpuIoWidthUint8) {
       *((UINT8 *)(UINTN)Address) = *((UINT8 *)Uint8Buffer);
     } else if (OperationWidth == EfiCpuIoWidthUint16) {
-      WriteUnaligned16 ((UINT16 *)(UINTN)Address, *((UINT16 *)Uint8Buffer));
+      WriteUnaligned16 ((UINT16 *)(UINTN)Address, ReadUnaligned16 ((UINT16 *)Uint8Buffer));
     } else if (OperationWidth == EfiCpuIoWidthUint32) {
-      WriteUnaligned32 ((UINT32 *)(UINTN)Address, *((UINT32 *)Uint8Buffer));
+      WriteUnaligned32 ((UINT32 *)(UINTN)Address, ReadUnaligned32 ((UINT32 *)Uint8Buffer));
     } else if (OperationWidth == EfiCpuIoWidthUint64) {
-      WriteUnaligned64 ((UINT64 *)(UINTN)Address, *((UINT64 *)Uint8Buffer));
+      WriteUnaligned64 ((UINT64 *)(UINTN)Address, ReadUnaligned64 ((UINT64 *)Uint8Buffer));
     }
   }
 

--- a/Library/OcPciIoLib/OcPciIoU.c
+++ b/Library/OcPciIoLib/OcPciIoU.c
@@ -1,0 +1,445 @@
+/** @file
+   EFI PCI IO protocol functions implementation for PCI Bus module.
+
+   Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+   Copyright (c) 2023, xCuri0. All rights reserved.<BR>
+   SPDX-License-Identifier: BSD-2-Clause-Patent
+
+ **/
+
+#include "OcPciIoU.h"
+
+EFI_CPU_IO2_PROTOCOL  *mCpuIo;
+
+UINT8  mInStride[] = {
+  1,      // EfiCpuIoWidthUint8
+  2,      // EfiCpuIoWidthUint16
+  4,      // EfiCpuIoWidthUint32
+  8,      // EfiCpuIoWidthUint64
+  0,      // EfiCpuIoWidthFifoUint8
+  0,      // EfiCpuIoWidthFifoUint16
+  0,      // EfiCpuIoWidthFifoUint32
+  0,      // EfiCpuIoWidthFifoUint64
+  1,      // EfiCpuIoWidthFillUint8
+  2,      // EfiCpuIoWidthFillUint16
+  4,      // EfiCpuIoWidthFillUint32
+  8       // EfiCpuIoWidthFillUint64
+};
+
+//
+// Lookup table for increment values based on transfer widths
+//
+UINT8  mOutStride[] = {
+  1,      // EfiCpuIoWidthUint8
+  2,      // EfiCpuIoWidthUint16
+  4,      // EfiCpuIoWidthUint32
+  8,      // EfiCpuIoWidthUint64
+  1,      // EfiCpuIoWidthFifoUint8
+  2,      // EfiCpuIoWidthFifoUint16
+  4,      // EfiCpuIoWidthFifoUint32
+  8,      // EfiCpuIoWidthFifoUint64
+  0,      // EfiCpuIoWidthFillUint8
+  0,      // EfiCpuIoWidthFillUint16
+  0,      // EfiCpuIoWidthFillUint32
+  0       // EfiCpuIoWidthFillUint64
+};
+
+EFI_CPU_IO2_PROTOCOL *
+InitializeCpuIo2 (
+  )
+{
+  gBS->LocateProtocol (
+         &gEfiCpuIo2ProtocolGuid,
+         NULL,
+         (VOID **)&mCpuIo
+         );
+  return mCpuIo;
+}
+
+/**
+   Check parameters to a CPU I/O 2 Protocol service request.
+
+   The I/O operations are carried out exactly as requested. The caller is responsible
+   for satisfying any alignment and I/O width restrictions that a PI System on a
+   platform might require. For example on some platforms, width requests of
+   EfiCpuIoWidthUint64 do not work. Misaligned buffers, on the other hand, will
+   be handled by the driver.
+
+   @param[in] MmioOperation  TRUE for an MMIO operation, FALSE for I/O Port operation.
+   @param[in] Width          Signifies the width of the I/O or Memory operation.
+   @param[in] Address        The base address of the I/O operation.
+   @param[in] Count          The number of I/O operations to perform. The number of
+                            bytes moved is Width size * Count, starting at Address.
+   @param[in] Buffer         For read operations, the destination buffer to store the results.
+                            For write operations, the source buffer from which to write data.
+
+   @retval EFI_SUCCESS            The parameters for this request pass the checks.
+   @retval EFI_INVALID_PARAMETER  Width is invalid for this PI system.
+   @retval EFI_INVALID_PARAMETER  Buffer is NULL.
+   @retval EFI_UNSUPPORTED        The Buffer is not aligned for the given Width.
+   @retval EFI_UNSUPPORTED        The address range specified by Address, Width,
+                                 and Count is not valid for this PI system.
+
+ **/
+EFI_STATUS
+CpuIoCheckParameter (
+  IN BOOLEAN                    MmioOperation,
+  IN EFI_CPU_IO_PROTOCOL_WIDTH  Width,
+  IN UINT64                     Address,
+  IN UINTN                      Count,
+  IN VOID                       *Buffer
+  )
+{
+  UINT64  MaxCount;
+  UINT64  Limit;
+
+  //
+  // Check to see if Buffer is NULL
+  //
+  if (Buffer == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Check to see if Width is in the valid range
+  //
+  if ((UINT32)Width >= EfiCpuIoWidthMaximum) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // For FIFO type, the target address won't increase during the access,
+  // so treat Count as 1
+  //
+  if ((Width >= EfiCpuIoWidthFifoUint8) && (Width <= EfiCpuIoWidthFifoUint64)) {
+    Count = 1;
+  }
+
+  //
+  // Check to see if Width is in the valid range for I/O Port operations
+  //
+  Width = (EFI_CPU_IO_PROTOCOL_WIDTH)(Width & 0x03);
+  if (!MmioOperation && (Width == EfiCpuIoWidthUint64)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Check to see if Address is aligned
+  //
+  if ((Address & ((UINT64)mInStride[Width] - 1)) != 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Check to see if any address associated with this transfer exceeds the maximum
+  // allowed address.  The maximum address implied by the parameters passed in is
+  // Address + Size * Count.  If the following condition is met, then the transfer
+  // is not supported.
+  //
+  //    Address + Size * Count > (MmioOperation ? MAX_ADDRESS : MAX_IO_PORT_ADDRESS) + 1
+  //
+  // Since MAX_ADDRESS can be the maximum integer value supported by the CPU and Count
+  // can also be the maximum integer value supported by the CPU, this range
+  // check must be adjusted to avoid all oveflow conditions.
+  //
+  // The following form of the range check is equivalent but assumes that
+  // MAX_ADDRESS and MAX_IO_PORT_ADDRESS are of the form (2^n - 1).
+  //
+  Limit = (MmioOperation ? MAX_ADDRESS : MAX_IO_PORT_ADDRESS);
+  if (Count == 0) {
+    if (Address > Limit) {
+      return EFI_UNSUPPORTED;
+    }
+  } else {
+    MaxCount = RShiftU64 (Limit, Width);
+    if (MaxCount < (Count - 1)) {
+      return EFI_UNSUPPORTED;
+    }
+
+    if (Address > LShiftU64 (MaxCount - Count + 1, Width)) {
+      return EFI_UNSUPPORTED;
+    }
+  }
+
+  //
+  // Check to see if Buffer is aligned
+  // (IA-32 allows UINT64 and INT64 data types to be 32-bit aligned.)
+  //
+  if (((UINTN)Buffer & ((MIN (sizeof (UINTN), mInStride[Width])  - 1))) != 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Reads memory-mapped registers.
+
+   The I/O operations are carried out exactly as requested. The caller is responsible
+   for satisfying any alignment and I/O width restrictions that a PI System on a
+   platform might require. For example on some platforms, width requests of
+   EfiCpuIoWidthUint64 do not work. Misaligned buffers, on the other hand, will
+   be handled by the driver.
+
+   If Width is EfiCpuIoWidthUint8, EfiCpuIoWidthUint16, EfiCpuIoWidthUint32,
+   or EfiCpuIoWidthUint64, then both Address and Buffer are incremented for
+   each of the Count operations that is performed.
+
+   If Width is EfiCpuIoWidthFifoUint8, EfiCpuIoWidthFifoUint16,
+   EfiCpuIoWidthFifoUint32, or EfiCpuIoWidthFifoUint64, then only Buffer is
+   incremented for each of the Count operations that is performed. The read or
+   write operation is performed Count times on the same Address.
+
+   If Width is EfiCpuIoWidthFillUint8, EfiCpuIoWidthFillUint16,
+   EfiCpuIoWidthFillUint32, or EfiCpuIoWidthFillUint64, then only Address is
+   incremented for each of the Count operations that is performed. The read or
+   write operation is performed Count times from the first element of Buffer.
+
+   @param[in]  This     A pointer to the EFI_CPU_IO2_PROTOCOL instance.
+   @param[in]  Width    Signifies the width of the I/O or Memory operation.
+   @param[in]  Address  The base address of the I/O operation.
+   @param[in]  Count    The number of I/O operations to perform. The number of
+                       bytes moved is Width size * Count, starting at Address.
+   @param[out] Buffer   For read operations, the destination buffer to store the results.
+                       For write operations, the source buffer from which to write data.
+
+   @retval EFI_SUCCESS            The data was read from or written to the PI system.
+   @retval EFI_INVALID_PARAMETER  Width is invalid for this PI system.
+   @retval EFI_INVALID_PARAMETER  Buffer is NULL.
+   @retval EFI_UNSUPPORTED        The Buffer is not aligned for the given Width.
+   @retval EFI_UNSUPPORTED        The address range specified by Address, Width,
+                                 and Count is not valid for this PI system.
+
+ **/
+EFI_STATUS
+EFIAPI
+CpuMemoryServiceRead (
+  IN EFI_CPU_IO2_PROTOCOL       *This,
+  IN EFI_CPU_IO_PROTOCOL_WIDTH  Width,
+  IN UINT64                     Address,
+  IN UINTN                      Count,
+  OUT VOID                      *Buffer
+  )
+{
+  EFI_STATUS                 Status;
+  UINT8                      InStride;
+  UINT8                      OutStride;
+  EFI_CPU_IO_PROTOCOL_WIDTH  OperationWidth;
+  UINT8                      *Uint8Buffer;
+
+  Status = CpuIoCheckParameter (TRUE, Width, Address, Count, Buffer);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Select loop based on the width of the transfer
+  //
+  InStride       = mInStride[Width];
+  OutStride      = mOutStride[Width];
+  OperationWidth = (EFI_CPU_IO_PROTOCOL_WIDTH)(Width & 0x03);
+  for (Uint8Buffer = Buffer; Count > 0; Address += InStride, Uint8Buffer += OutStride, Count--) {
+    if (OperationWidth == EfiCpuIoWidthUint8) {
+      *Uint8Buffer = MmioRead8 ((UINTN)Address);
+    } else if (OperationWidth == EfiCpuIoWidthUint16) {
+      *((UINT16 *)Uint8Buffer) = MmioRead16 ((UINTN)Address);
+    } else if (OperationWidth == EfiCpuIoWidthUint32) {
+      *((UINT32 *)Uint8Buffer) = MmioRead32 ((UINTN)Address);
+    } else if (OperationWidth == EfiCpuIoWidthUint64) {
+      *((UINT64 *)Uint8Buffer) = MmioRead64 ((UINTN)Address);
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Writes memory-mapped registers.
+
+   The I/O operations are carried out exactly as requested. The caller is responsible
+   for satisfying any alignment and I/O width restrictions that a PI System on a
+   platform might require. For example on some platforms, width requests of
+   EfiCpuIoWidthUint64 do not work. Misaligned buffers, on the other hand, will
+   be handled by the driver.
+
+   If Width is EfiCpuIoWidthUint8, EfiCpuIoWidthUint16, EfiCpuIoWidthUint32,
+   or EfiCpuIoWidthUint64, then both Address and Buffer are incremented for
+   each of the Count operations that is performed.
+
+   If Width is EfiCpuIoWidthFifoUint8, EfiCpuIoWidthFifoUint16,
+   EfiCpuIoWidthFifoUint32, or EfiCpuIoWidthFifoUint64, then only Buffer is
+   incremented for each of the Count operations that is performed. The read or
+   write operation is performed Count times on the same Address.
+
+   If Width is EfiCpuIoWidthFillUint8, EfiCpuIoWidthFillUint16,
+   EfiCpuIoWidthFillUint32, or EfiCpuIoWidthFillUint64, then only Address is
+   incremented for each of the Count operations that is performed. The read or
+   write operation is performed Count times from the first element of Buffer.
+
+   @param[in]  This     A pointer to the EFI_CPU_IO2_PROTOCOL instance.
+   @param[in]  Width    Signifies the width of the I/O or Memory operation.
+   @param[in]  Address  The base address of the I/O operation.
+   @param[in]  Count    The number of I/O operations to perform. The number of
+                       bytes moved is Width size * Count, starting at Address.
+   @param[in]  Buffer   For read operations, the destination buffer to store the results.
+                       For write operations, the source buffer from which to write data.
+
+   @retval EFI_SUCCESS            The data was read from or written to the PI system.
+   @retval EFI_INVALID_PARAMETER  Width is invalid for this PI system.
+   @retval EFI_INVALID_PARAMETER  Buffer is NULL.
+   @retval EFI_UNSUPPORTED        The Buffer is not aligned for the given Width.
+   @retval EFI_UNSUPPORTED        The address range specified by Address, Width,
+                                 and Count is not valid for this PI system.
+
+ **/
+EFI_STATUS
+EFIAPI
+CpuMemoryServiceWrite (
+  IN EFI_CPU_IO2_PROTOCOL       *This,
+  IN EFI_CPU_IO_PROTOCOL_WIDTH  Width,
+  IN UINT64                     Address,
+  IN UINTN                      Count,
+  IN VOID                       *Buffer
+  )
+{
+  EFI_STATUS                 Status;
+  UINT8                      InStride;
+  UINT8                      OutStride;
+  EFI_CPU_IO_PROTOCOL_WIDTH  OperationWidth;
+  UINT8                      *Uint8Buffer;
+
+  Status = CpuIoCheckParameter (TRUE, Width, Address, Count, Buffer);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Select loop based on the width of the transfer
+  //
+  InStride       = mInStride[Width];
+  OutStride      = mOutStride[Width];
+  OperationWidth = (EFI_CPU_IO_PROTOCOL_WIDTH)(Width & 0x03);
+  for (Uint8Buffer = Buffer; Count > 0; Address += InStride, Uint8Buffer += OutStride, Count--) {
+    if (OperationWidth == EfiCpuIoWidthUint8) {
+      MmioWrite8 ((UINTN)Address, *Uint8Buffer);
+    } else if (OperationWidth == EfiCpuIoWidthUint16) {
+      MmioWrite16 ((UINTN)Address, *((UINT16 *)Uint8Buffer));
+    } else if (OperationWidth == EfiCpuIoWidthUint32) {
+      MmioWrite32 ((UINTN)Address, *((UINT32 *)Uint8Buffer));
+    } else if (OperationWidth == EfiCpuIoWidthUint64) {
+      MmioWrite64 ((UINTN)Address, *((UINT64 *)Uint8Buffer));
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Enables a PCI driver to access PCI controller registers in the PCI root
+   bridge memory space.
+
+   The Mem.Read(), and Mem.Write() functions enable a driver to access PCI
+   controller registers in the PCI root bridge memory space.
+   The memory operations are carried out exactly as requested. The caller is
+   responsible for satisfying any alignment and memory width restrictions that a
+   PCI Root Bridge on a platform might require.
+
+   @param[in]   This      A pointer to the EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.
+   @param[in]   Width     Signifies the width of the memory operation.
+   @param[in]   Address   The base address of the memory operation. The caller
+                         is responsible for aligning the Address if required.
+   @param[in]   Count     The number of memory operations to perform. Bytes
+                         moved is Width size * Count, starting at Address.
+   @param[out]  Buffer    For read operations, the destination buffer to store
+                         the results. For write operations, the source buffer
+                         to write data from.
+
+   @retval EFI_SUCCESS            The data was read from or written to the PCI
+                                 root bridge.
+   @retval EFI_INVALID_PARAMETER  Width is invalid for this PCI root bridge.
+   @retval EFI_INVALID_PARAMETER  Buffer is NULL.
+   @retval EFI_OUT_OF_RESOURCES   The request could not be completed due to a
+                                 lack of resources.
+ **/
+EFI_STATUS
+EFIAPI
+RootBridgeIoMemRead (
+  IN EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL        *This,
+  IN EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_WIDTH  Width,
+  IN UINT64                                 Address,
+  IN UINTN                                  Count,
+  OUT VOID                                  *Buffer
+  )
+{
+  if (Buffer == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Width < 0) || (Width >= EfiPciWidthMaximum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Don't check check memory access limit because firmware data is incorrect
+  return mCpuIo->Mem.Read (
+                       mCpuIo,
+                       (EFI_CPU_IO_PROTOCOL_WIDTH)Width,
+                       Address,
+                       Count,
+                       Buffer
+                       );
+}
+
+/**
+   Enables a PCI driver to access PCI controller registers in the PCI root
+   bridge memory space.
+
+   The Mem.Read(), and Mem.Write() functions enable a driver to access PCI
+   controller registers in the PCI root bridge memory space.
+   The memory operations are carried out exactly as requested. The caller is
+   responsible for satisfying any alignment and memory width restrictions that a
+   PCI Root Bridge on a platform might require.
+
+   @param[in]   This      A pointer to the EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL.
+   @param[in]   Width     Signifies the width of the memory operation.
+   @param[in]   Address   The base address of the memory operation. The caller
+                         is responsible for aligning the Address if required.
+   @param[in]   Count     The number of memory operations to perform. Bytes
+                         moved is Width size * Count, starting at Address.
+   @param[in]   Buffer    For read operations, the destination buffer to store
+                         the results. For write operations, the source buffer
+                         to write data from.
+
+   @retval EFI_SUCCESS            The data was read from or written to the PCI
+                                 root bridge.
+   @retval EFI_INVALID_PARAMETER  Width is invalid for this PCI root bridge.
+   @retval EFI_INVALID_PARAMETER  Buffer is NULL.
+   @retval EFI_OUT_OF_RESOURCES   The request could not be completed due to a
+                                 lack of resources.
+ **/
+EFI_STATUS
+EFIAPI
+RootBridgeIoMemWrite (
+  IN EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL        *This,
+  IN EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_WIDTH  Width,
+  IN UINT64                                 Address,
+  IN UINTN                                  Count,
+  IN VOID                                   *Buffer
+  )
+{
+  if (Buffer == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Width < 0) || (Width >= EfiPciWidthMaximum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Don't check check memory access limit because firmware data is incorrect
+  return mCpuIo->Mem.Write (
+                       mCpuIo,
+                       (EFI_CPU_IO_PROTOCOL_WIDTH)Width,
+                       Address,
+                       Count,
+                       Buffer
+                       );
+}

--- a/Library/OcPciIoLib/OcPciIoU.h
+++ b/Library/OcPciIoLib/OcPciIoU.h
@@ -25,7 +25,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define MAX_IO_PORT_ADDRESS  0xFFFF
 
 EFI_CPU_IO2_PROTOCOL *
-InitializeCpuIo2 ( VOID );
+InitializeCpuIo2 (
+  VOID
+  );
 
 /**
   Reads memory-mapped registers.

--- a/Library/OcPciIoLib/OcPciIoU.h
+++ b/Library/OcPciIoLib/OcPciIoU.h
@@ -11,30 +11,16 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define _EFI_PCI_IO_PROTOCOL_H_
 
 #include <Uefi.h>
-
-#include <Guid/GlobalVariable.h>
-
 #include <Library/BaseLib.h>
-#include <Library/BaseOverflowLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/OcMiscLib.h>
-#include <Library/UefiDriverEntryPoint.h>
 #include <Library/UefiBootServicesTableLib.h>
-#include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/MemoryAllocationLib.h>
 
 #include <Protocol/PciRootBridgeIo.h>
-#include <Protocol/LoadFile2.h>
-#include <Protocol/PciIo.h>
-#include <Protocol/PciHotPlugInit.h>
 #include <Protocol/CpuIo2.h>
-#include <Protocol/BusSpecificDriverOverride.h>
 #include <Library/IoLib.h>
-
-#include <IndustryStandard/Pci.h>
-#include <IndustryStandard/PeImage2.h>
-#include <IndustryStandard/Acpi.h>
 
 #define MAX_IO_PORT_ADDRESS  0xFFFF
 

--- a/Library/OcPciIoLib/OcPciIoU.h
+++ b/Library/OcPciIoLib/OcPciIoU.h
@@ -1,0 +1,195 @@
+/** @file
+  EFI PCI IO protocol functions declaration for PCI Bus module.
+
+Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2023, xCuri0. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _EFI_PCI_IO_PROTOCOL_H_
+#define _EFI_PCI_IO_PROTOCOL_H_
+
+#include <Uefi.h>
+
+#include <Guid/GlobalVariable.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseOverflowLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/OcMiscLib.h>
+#include <Library/UefiDriverEntryPoint.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+#include <Protocol/PciRootBridgeIo.h>
+#include <Protocol/LoadFile2.h>
+#include <Protocol/PciIo.h>
+#include <Protocol/PciHotPlugInit.h>
+#include <Protocol/CpuIo2.h>
+#include <Protocol/BusSpecificDriverOverride.h>
+#include <Library/IoLib.h>
+
+#include <IndustryStandard/Pci.h>
+#include <IndustryStandard/PeImage2.h>
+#include <IndustryStandard/Acpi.h>
+
+#define MAX_IO_PORT_ADDRESS  0xFFFF
+
+EFI_CPU_IO2_PROTOCOL *
+InitializeCpuIo2 (
+  );
+
+/**
+  Reads memory-mapped registers.
+
+  The I/O operations are carried out exactly as requested. The caller is responsible
+  for satisfying any alignment and I/O width restrictions that a PI System on a
+  platform might require. For example on some platforms, width requests of
+  EfiCpuIoWidthUint64 do not work. Misaligned buffers, on the other hand, will
+  be handled by the driver.
+
+  If Width is EfiCpuIoWidthUint8, EfiCpuIoWidthUint16, EfiCpuIoWidthUint32,
+  or EfiCpuIoWidthUint64, then both Address and Buffer are incremented for
+  each of the Count operations that is performed.
+
+  If Width is EfiCpuIoWidthFifoUint8, EfiCpuIoWidthFifoUint16,
+  EfiCpuIoWidthFifoUint32, or EfiCpuIoWidthFifoUint64, then only Buffer is
+  incremented for each of the Count operations that is performed. The read or
+  write operation is performed Count times on the same Address.
+
+  If Width is EfiCpuIoWidthFillUint8, EfiCpuIoWidthFillUint16,
+  EfiCpuIoWidthFillUint32, or EfiCpuIoWidthFillUint64, then only Address is
+  incremented for each of the Count operations that is performed. The read or
+  write operation is performed Count times from the first element of Buffer.
+
+  @param[in]  This     A pointer to the EFI_CPU_IO2_PROTOCOL instance.
+  @param[in]  Width    Signifies the width of the I/O or Memory operation.
+  @param[in]  Address  The base address of the I/O operation.
+  @param[in]  Count    The number of I/O operations to perform. The number of
+                       bytes moved is Width size * Count, starting at Address.
+  @param[out] Buffer   For read operations, the destination buffer to store the results.
+                       For write operations, the source buffer from which to write data.
+
+  @retval EFI_SUCCESS            The data was read from or written to the PI system.
+  @retval EFI_INVALID_PARAMETER  Width is invalid for this PI system.
+  @retval EFI_INVALID_PARAMETER  Buffer is NULL.
+  @retval EFI_UNSUPPORTED        The Buffer is not aligned for the given Width.
+  @retval EFI_UNSUPPORTED        The address range specified by Address, Width,
+                                 and Count is not valid for this PI system.
+
+**/
+EFI_STATUS
+EFIAPI
+CpuMemoryServiceRead (
+  IN  EFI_CPU_IO2_PROTOCOL       *This,
+  IN  EFI_CPU_IO_PROTOCOL_WIDTH  Width,
+  IN  UINT64                     Address,
+  IN  UINTN                      Count,
+  OUT VOID                       *Buffer
+  );
+
+/**
+  Writes memory-mapped registers.
+
+  The I/O operations are carried out exactly as requested. The caller is responsible
+  for satisfying any alignment and I/O width restrictions that a PI System on a
+  platform might require. For example on some platforms, width requests of
+  EfiCpuIoWidthUint64 do not work. Misaligned buffers, on the other hand, will
+  be handled by the driver.
+
+  If Width is EfiCpuIoWidthUint8, EfiCpuIoWidthUint16, EfiCpuIoWidthUint32,
+  or EfiCpuIoWidthUint64, then both Address and Buffer are incremented for
+  each of the Count operations that is performed.
+
+  If Width is EfiCpuIoWidthFifoUint8, EfiCpuIoWidthFifoUint16,
+  EfiCpuIoWidthFifoUint32, or EfiCpuIoWidthFifoUint64, then only Buffer is
+  incremented for each of the Count operations that is performed. The read or
+  write operation is performed Count times on the same Address.
+
+  If Width is EfiCpuIoWidthFillUint8, EfiCpuIoWidthFillUint16,
+  EfiCpuIoWidthFillUint32, or EfiCpuIoWidthFillUint64, then only Address is
+  incremented for each of the Count operations that is performed. The read or
+  write operation is performed Count times from the first element of Buffer.
+
+  @param[in]  This     A pointer to the EFI_CPU_IO2_PROTOCOL instance.
+  @param[in]  Width    Signifies the width of the I/O or Memory operation.
+  @param[in]  Address  The base address of the I/O operation.
+  @param[in]  Count    The number of I/O operations to perform. The number of
+                       bytes moved is Width size * Count, starting at Address.
+  @param[in]  Buffer   For read operations, the destination buffer to store the results.
+                       For write operations, the source buffer from which to write data.
+
+  @retval EFI_SUCCESS            The data was read from or written to the PI system.
+  @retval EFI_INVALID_PARAMETER  Width is invalid for this PI system.
+  @retval EFI_INVALID_PARAMETER  Buffer is NULL.
+  @retval EFI_UNSUPPORTED        The Buffer is not aligned for the given Width.
+  @retval EFI_UNSUPPORTED        The address range specified by Address, Width,
+                                 and Count is not valid for this PI system.
+
+**/
+EFI_STATUS
+EFIAPI
+CpuMemoryServiceWrite (
+  IN EFI_CPU_IO2_PROTOCOL       *This,
+  IN EFI_CPU_IO_PROTOCOL_WIDTH  Width,
+  IN UINT64                     Address,
+  IN UINTN                      Count,
+  IN VOID                       *Buffer
+  );
+
+/**
+
+  Allow read from memory mapped I/O space.
+
+  @param This     -  Pointer to EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL instance.
+  @param Width    -  The width of memory operation.
+  @param Address  -  Base address of the memory operation.
+  @param Count    -  Number of memory opeartion to perform.
+  @param Buffer   -  The destination buffer to store data.
+
+  @retval EFI_SUCCESS            -  Success.
+  @retval EFI_INVALID_PARAMETER  -  Invalid parameter found.
+  @retval EFI_OUT_OF_RESOURCES   -  Fail due to lack of resources.
+
+**/
+EFI_STATUS
+EFIAPI
+RootBridgeIoMemRead (
+  IN     EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL        *This,
+  IN     EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_WIDTH  Width,
+  IN     UINT64                                 Address,
+  IN     UINTN                                  Count,
+  IN OUT VOID                                   *Buffer
+  )
+;
+
+/**
+
+  Allow write to memory mapped I/O space.
+
+  @param This     -  Pointer to EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL instance.
+  @param Width    -  The width of memory operation.
+  @param Address  -  Base address of the memory operation.
+  @param Count    -  Number of memory opeartion to perform.
+  @param Buffer   -  The source buffer to write data from.
+
+  @retval EFI_SUCCESS            -  Success.
+  @retval EFI_INVALID_PARAMETER  -  Invalid parameter found.
+  @retval EFI_OUT_OF_RESOURCES   -  Fail due to lack of resources.
+
+**/
+EFI_STATUS
+EFIAPI
+RootBridgeIoMemWrite (
+  IN     EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL        *This,
+  IN     EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_WIDTH  Width,
+  IN     UINT64                                 Address,
+  IN     UINTN                                  Count,
+  IN OUT VOID                                   *Buffer
+  )
+;
+
+#endif

--- a/Library/OcPciIoLib/OcPciIoU.h
+++ b/Library/OcPciIoLib/OcPciIoU.h
@@ -25,8 +25,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define MAX_IO_PORT_ADDRESS  0xFFFF
 
 EFI_CPU_IO2_PROTOCOL *
-InitializeCpuIo2 (
-  );
+InitializeCpuIo2 ( VOID );
 
 /**
   Reads memory-mapped registers.

--- a/OpenCorePkg.dsc
+++ b/OpenCorePkg.dsc
@@ -122,6 +122,7 @@
   OcMiscLib|OpenCorePkg/Library/OcMiscLib/OcMiscLib.inf
   OcMp3Lib|OpenCorePkg/Library/OcMp3Lib/OcMp3Lib.inf
   OcOSInfoLib|OpenCorePkg/Library/OcOSInfoLib/OcOSInfoLib.inf
+  OcPciIoLib|OpenCorePkg/Library/OcPciIoLib/OcPciIoLib.inf
   OcPngLib|OpenCorePkg/Library/OcPngLib/OcPngLib.inf
   OcRngLib|OpenCorePkg/Library/OcRngLib/OcRngLib.inf
   OcRtcLib|OpenCorePkg/Library/OcRtcLib/OcRtcLib.inf
@@ -290,6 +291,7 @@
   OpenCorePkg/Library/OcTimerLib/OcTimerLib.inf
   OpenCorePkg/Library/OcUnicodeCollationEngLib/OcUnicodeCollationEngGenericLib.inf
   OpenCorePkg/Library/OcUnicodeCollationEngLib/OcUnicodeCollationEngLocalLib.inf
+  OpenCorePkg/Library/OcPciIoLib/OcPciIoLib.inf
   OpenCorePkg/Library/OcVirtualFsLib/OcVirtualFsLib.inf
   OpenCorePkg/Library/OcWaveLib/OcWaveLib.inf
   OpenCorePkg/Library/OcXmlLib/OcXmlLib.inf


### PR DESCRIPTION
This UEFI has several bugs relating to 4G Decoding which need to be fixed
* PciRootBridgeIo Mem can't access above 4GB MMIO (Done)
* CpuIo can't access above 4GB MMIO (Done)
* PciIo can't access extended configuration. ```ResizeUsePciRbIo``` works around this for resizable BAR

Boot audio now plays on my system with this patch. Loading time is kinda slow configuring the amp but seems similar to original PciIo.