### PR TITLE
AudioDxe: Add --force-codec

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -7006,6 +7006,11 @@ the driver within the \texttt{UEFI/Drivers} section:
   will be achieved by using \texttt{Audio} section \texttt{SetupDelay} if any audio setup delay
   is required. Where required, values of up to one second may be needed. \medskip
 
+  \item \texttt{-{}-force-codec} - Integer value, default \texttt{0}. \medskip
+
+  Force use of an audio codec, this value should be equal to \texttt{Audio} section \texttt{AudioCodec}.
+  Can result in faster boot especially when used in conjuction with \texttt{-{}-force-device}. \medskip
+
 	\item \texttt{-{}-force-device} - String value, no default. \medskip
 
   When this option is present and has a value (e.g. \texttt{-{}-force-device=PciRoot(0x0)/Pci(0x1f,0x3)}), it
@@ -7075,11 +7080,6 @@ the driver within the \texttt{UEFI/Drivers} section:
   be added to AudioDxe driver arguments.
   Not enabled by default, since restoring the flag can prevent sound from working in macOS on
   some other systems. \medskip
-
-  \item \texttt{-{}-force-codec} - Integer value, default \texttt{0}. \medskip
-
-  Force use of an audio codec, this value should be equal to \texttt{Audio} section \texttt{AudioCodec}.
-  Can result in faster boot especially when used in conjuction with \texttt{-{}-force-device}. \medskip
 \end{itemize}
 
 \subsection{OpenVariableRuntimeDxe}\label{emunvram}

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -7075,6 +7075,11 @@ the driver within the \texttt{UEFI/Drivers} section:
   be added to AudioDxe driver arguments.
   Not enabled by default, since restoring the flag can prevent sound from working in macOS on
   some other systems. \medskip
+
+  \item \texttt{-{}-force-codec} - Integer value, default \texttt{0}. \medskip
+
+  Force use of an audio codec, this value should be equal to \texttt{Audio} section \texttt{AudioCodec}.
+  Can result in faster boot especially when used in conjuction with \texttt{-{}-force-device}. \medskip
 \end{itemize}
 
 \subsection{OpenVariableRuntimeDxe}\label{emunvram}

--- a/Staging/AudioDxe/AudioDxe.c
+++ b/Staging/AudioDxe/AudioDxe.c
@@ -47,6 +47,12 @@ EFI_DEVICE_PATH_PROTOCOL *
 UINTN
   gCodecSetupDelay = 0;
 
+BOOLEAN
+  gForceCodec = FALSE;
+
+UINTN
+  gCodec = 0;
+
 /**
   HdaController Driver Binding.
 **/
@@ -119,6 +125,11 @@ AudioDxeInit (
     }
 
     OcParsedVarsGetInt (ParsedLoadOptions, L"--codec-setup-delay", &gCodecSetupDelay, OcStringFormatUnicode);
+
+    Status = OcParsedVarsGetInt (ParsedLoadOptions, L"--force-codec", &gCodec, OcStringFormatUnicode);
+    if (Status != EFI_NOT_FOUND) {
+      gForceCodec = TRUE;
+    }
 
     OcFlexArrayFree (&ParsedLoadOptions);
   } else if (Status != EFI_NOT_FOUND) {

--- a/Staging/AudioDxe/AudioDxe.c
+++ b/Staging/AudioDxe/AudioDxe.c
@@ -48,10 +48,10 @@ UINTN
   gCodecSetupDelay = 0;
 
 BOOLEAN
-  gForceCodec = FALSE;
+  gUseForcedCodec = FALSE;
 
 UINTN
-  gCodec = 0;
+  gForcedCodec = 0;
 
 /**
   HdaController Driver Binding.
@@ -126,9 +126,9 @@ AudioDxeInit (
 
     OcParsedVarsGetInt (ParsedLoadOptions, L"--codec-setup-delay", &gCodecSetupDelay, OcStringFormatUnicode);
 
-    Status = OcParsedVarsGetInt (ParsedLoadOptions, L"--force-codec", &gCodec, OcStringFormatUnicode);
+    Status = OcParsedVarsGetInt (ParsedLoadOptions, L"--force-codec", &gForcedCodec, OcStringFormatUnicode);
     if (Status != EFI_NOT_FOUND) {
-      gForceCodec = TRUE;
+      gUseForcedCodec = TRUE;
     }
 
     OcFlexArrayFree (&ParsedLoadOptions);

--- a/Staging/AudioDxe/AudioDxe.h
+++ b/Staging/AudioDxe/AudioDxe.h
@@ -119,4 +119,16 @@ extern
 UINTN
   gCodecSetupDelay;
 
+//
+// If to use forced codec
+//
+extern BOOLEAN
+  gForceCodec;
+
+//
+// Forced codec number
+//
+extern UINTN
+  gCodec;
+
 #endif // EFI_AUDIODXE_H

--- a/Staging/AudioDxe/AudioDxe.h
+++ b/Staging/AudioDxe/AudioDxe.h
@@ -120,15 +120,15 @@ UINTN
   gCodecSetupDelay;
 
 //
-// If to use forced codec
+// Whether to use forced codec.
 //
 extern BOOLEAN
-  gForceCodec;
+  gUseForcedCodec;
 
 //
-// Forced codec number
+// Forced codec number.
 //
 extern UINTN
-  gCodec;
+  gForcedCodec;
 
 #endif // EFI_AUDIODXE_H

--- a/Staging/AudioDxe/HdaCodec/HdaCodec.c
+++ b/Staging/AudioDxe/HdaCodec/HdaCodec.c
@@ -1727,7 +1727,7 @@ HdaCodecDriverBindingSupported (
   }
 
   // Check --force-codec
-  if (gForceCodec && (gCodec != CodecAddress)) {
+  if (gUseForcedCodec && (gForcedCodec != CodecAddress)) {
     Status = EFI_UNSUPPORTED;
     goto CLOSE_CODEC;
   }

--- a/Staging/AudioDxe/HdaCodec/HdaCodec.c
+++ b/Staging/AudioDxe/HdaCodec/HdaCodec.c
@@ -1726,7 +1726,7 @@ HdaCodecDriverBindingSupported (
     goto CLOSE_CODEC;
   }
 
-  // Check --force-codec
+  // Check --force-codec.
   if (gUseForcedCodec && (gForcedCodec != CodecAddress)) {
     Status = EFI_UNSUPPORTED;
     goto CLOSE_CODEC;

--- a/Staging/AudioDxe/HdaCodec/HdaCodec.c
+++ b/Staging/AudioDxe/HdaCodec/HdaCodec.c
@@ -1726,6 +1726,12 @@ HdaCodecDriverBindingSupported (
     goto CLOSE_CODEC;
   }
 
+  // Check --force-codec
+  if (gForceCodec && (gCodec != CodecAddress)) {
+    Status = EFI_UNSUPPORTED;
+    goto CLOSE_CODEC;
+  }
+
   // Codec can be supported.
   DEBUG ((DEBUG_INFO, "HDA: Connecting codec 0x%X\n", CodecAddress));
   Status = EFI_SUCCESS;


### PR DESCRIPTION
Provides boot time reduction (especially printing verbose) when used in conjunction with ```--force-device``` and we don't use the other codecs anyways.

Possible to also add an option to use bitmask for outputs but I don't think that's worth the insignificant boot time gain.

On my system most of the time is consumed checking output amps, even though only one is used afaik (output bitmask 2)
```
00:631 00:006 OC: Driver AudioDxe.efi at 1 needs connection.
00:637 00:005 OC: Connecting drivers...
00:649 00:011 HDA: Connecting controller - PciRoot(0x0)/Pci(0x1B,0x0)
00:655 00:006 HDA: Controller disable no snoop
00:660 00:004 HDA: Controller version 1.0
00:665 00:004 HDA: Capabilities:
00:669 00:003 HDA:  | 64-bit: Yes  Serial Data Out Signals: 0
00:675 00:006 HDA:  | Bidir streams: 0  Input streams: 4  Output streams: 4
00:682 00:006 HDA: Controller is Intel 7 Series HD Audio Controller
00:789 00:106 HDA: Controller protocols installed
00:814 00:025 HDA: Controller initialized
00:819 00:004 HDA: Connecting codec 0x2
00:828 00:009 HDA:  | Codec ID: 0x10EC:0x887
00:838 00:009 HDA:  | Codec name: Realtek ALC888B
00:848 00:010 HDA:  | Codec contains 1 function groups, start @ 0x1, end @ 0x1
00:860 00:012 HDA:  | Function group @ 0x1 is of type 0x1
00:891 00:030 HDA:  | Function group @ 0x1 output amp capabilities: 0x0
00:908 00:016 HDA:  | Function group @ 0x1 GPIO capabilities: 0x40000002
00:920 00:011 HDA:  | Function group @ 0x1 contains 37 widgets, start @ 0x2, end @ 0x26
00:952 00:032 HDA:  | Widget @ 0x2 output amp capabilities: 0x34040
01:019 00:066 HDA:  | Widget @ 0x3 output amp capabilities: 0x34040
01:085 00:066 HDA:  | Widget @ 0x4 output amp capabilities: 0x34040
01:152 00:066 HDA:  | Widget @ 0x5 output amp capabilities: 0x34040
01:964 00:812 HDA:  | Widget @ 0x14 output amp capabilities: 0x80000000
02:046 00:081 HDA:  | Widget @ 0x15 output amp capabilities: 0x80000000
02:122 00:076 HDA:  | Widget @ 0x16 output amp capabilities: 0x80000000
02:199 00:076 HDA:  | Widget @ 0x17 output amp capabilities: 0x80000000
02:341 00:141 HDA:  | Widget @ 0x18 output amp capabilities: 0x80000000
02:483 00:141 HDA:  | Widget @ 0x19 output amp capabilities: 0x80000000
02:625 00:141 HDA:  | Widget @ 0x1A output amp capabilities: 0x80000000
02:766 00:141 HDA:  | Widget @ 0x1B output amp capabilities: 0x80000000
03:333 00:567 HDA:  | Widget @ 0x25 output amp capabilities: 0x34040
03:425 00:091 HDA:  |  Widget @ 0x10 (type 0x0)
03:430 00:005 HDA:  | Port widget @ 0x11 is an output (pin defaults 0x99430130) (bitmask 1)
03:438 00:008 HDA:  |  Widget @ 0xC (type 0x2)
03:443 00:004 HDA:  |  Widget @ 0x2 (type 0x0)
03:448 00:004 HDA:  | Port widget @ 0x14 is an output (pin defaults 0x1014410) (bitmask 2)
03:471 00:023 HDA:  |  Widget @ 0xC (type 0x2)
03:476 00:004 HDA:  |  Widget @ 0x2 (type 0x0)
03:481 00:004 HDA:  | Port widget @ 0x18 is an output (pin defaults 0x1A19C50) (bitmask 4)
03:494 00:013 HDA:  |  Widget @ 0xC (type 0x2)
03:499 00:004 HDA:  |  Widget @ 0x2 (type 0x0)
03:504 00:004 HDA:  | Port widget @ 0x19 is an output (pin defaults 0x2A19C60) (bitmask 8)
03:517 00:013 HDA:  |  Widget @ 0xC (type 0x2)
03:522 00:004 HDA:  |  Widget @ 0x2 (type 0x0)
03:527 00:004 HDA:  | Port widget @ 0x1A is an output (pin defaults 0x181345F) (bitmask 16)
03:540 00:013 HDA:  |  Widget @ 0xC (type 0x2)
03:545 00:004 HDA:  |  Widget @ 0x2 (type 0x0)
03:550 00:004 HDA:  | Port widget @ 0x1B is an output (pin defaults 0x2214C20) (bitmask 32)
03:568 00:018 HDA: Codec protocols installed
03:573 00:004 HDA: Codec initialized
```

Could move the output check to when it prints the output amp capaibilites. Then an ```--audio-out-mask``` could exit scanning widgets once the highest one is reached (bitmask 2 / 0x14 output in this case). Or better would be having a ```--widget-mask``` but it would take more effort to configure.