### PR TITLE
Audio: Add ExitBSWait option

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -7822,6 +7822,15 @@ for additional options.
   \hyperref[uefiaudio]{AudioDxe} section.
 
   \item
+  \texttt{ExitBSWait}\\
+  \textbf{Type}: \texttt{plist\ boolean}\\
+  \textbf{Failsafe}: \texttt{true}\\
+  \textbf{Description}: Wait for audio to finish playing on ExitBootServices
+
+  Enabled by default, you might want to disable this if you use a longer OCEFIAudio_VoiceOver_Boot
+  or other audio file.
+
+  \item
   \texttt{MaximumGain}\\
   \textbf{Type}: \texttt{plist\ integer}\\
   \textbf{Failsafe}: \texttt{-15}\\

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1412,6 +1412,8 @@
 			<false/>
 			<key>DisconnectHda</key>
 			<false/>
+			<key>ExitBSWait</key>
+			<true/>
 			<key>MaximumGain</key>
 			<integer>-15</integer>
 			<key>MinimumAssistGain</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -1780,6 +1780,8 @@
 			<false/>
 			<key>DisconnectHda</key>
 			<false/>
+			<key>ExitBSWait</key>
+			<true/>
 			<key>MaximumGain</key>
 			<integer>-15</integer>
 			<key>MinimumAssistGain</key>

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -664,7 +664,8 @@ OC_DECLARE (OC_UEFI_APPLEINPUT)
   _(INT8                        , MinimumAssistGain  ,     , -30                               , ()) \
   _(INT8                        , MinimumAudibleGain ,     , -128                              , ()) \
   _(BOOLEAN                     , ResetTrafficClass  ,     , FALSE                             , ()) \
-  _(BOOLEAN                     , DisconnectHda      ,     , FALSE                             , ())
+  _(BOOLEAN                     , DisconnectHda      ,     , FALSE                             , ()) \
+  _(BOOLEAN                     , ExitBSWait         ,     , TRUE                              , ())
 OC_DECLARE (OC_UEFI_AUDIO)
 
 ///

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -790,6 +790,7 @@ OC_SCHEMA
   OC_SCHEMA_INTEGER_IN ("AudioOutMask",       OC_GLOBAL_CONFIG, Uefi.Audio.AudioOutMask),
   OC_SCHEMA_BOOLEAN_IN ("AudioSupport",       OC_GLOBAL_CONFIG, Uefi.Audio.AudioSupport),
   OC_SCHEMA_BOOLEAN_IN ("DisconnectHda",      OC_GLOBAL_CONFIG, Uefi.Audio.DisconnectHda),
+  OC_SCHEMA_BOOLEAN_IN ("ExitBSWait",         OC_GLOBAL_CONFIG, Uefi.Audio.ExitBSWait),
   OC_SCHEMA_INTEGER_IN ("MaximumGain",        OC_GLOBAL_CONFIG, Uefi.Audio.MaximumGain),
   OC_SCHEMA_INTEGER_IN ("MinimumAssistGain",  OC_GLOBAL_CONFIG, Uefi.Audio.MinimumAssistGain),
   OC_SCHEMA_INTEGER_IN ("MinimumAudibleGain", OC_GLOBAL_CONFIG, Uefi.Audio.MinimumAudibleGain),

--- a/Library/OcMainLib/OpenCoreUefiAudio.c
+++ b/Library/OcMainLib/OpenCoreUefiAudio.c
@@ -52,6 +52,7 @@ typedef struct OC_AUDIO_FILE_ {
   UINT32    Size;
 } OC_AUDIO_FILE;
 
+STATIC BOOLEAN ExitBSWait;
 STATIC EFI_AUDIO_DECODE_PROTOCOL  *mAudioDecodeProtocol = NULL;
 
 STATIC
@@ -261,7 +262,7 @@ OcAudioExitBootServices (
   OC_AUDIO_PROTOCOL  *OcAudio;
 
   OcAudio = Context;
-  OcAudio->StopPlayback (OcAudio, TRUE);
+  OcAudio->StopPlayback (OcAudio, ExitBSWait);
 }
 
 VOID
@@ -288,6 +289,8 @@ OcLoadUefiAudioSupport (
     DEBUG ((DEBUG_INFO, "OC: Requested not to use audio\n"));
     return;
   }
+
+  ExitBSWait = Config->Uefi.Audio.ExitBSWait;
 
   Status = gBS->LocateProtocol (
                   &gEfiAudioDecodeProtocolGuid,

--- a/Library/OcMainLib/OpenCoreUefiAudio.c
+++ b/Library/OcMainLib/OpenCoreUefiAudio.c
@@ -52,7 +52,7 @@ typedef struct OC_AUDIO_FILE_ {
   UINT32    Size;
 } OC_AUDIO_FILE;
 
-STATIC BOOLEAN ExitBSWait;
+STATIC BOOLEAN                    ExitBSWait;
 STATIC EFI_AUDIO_DECODE_PROTOCOL  *mAudioDecodeProtocol = NULL;
 
 STATIC


### PR DESCRIPTION
Useful when using longer audio files, previously this option was just set to wait always.