### PR TITLE
USB限制补丁

### DIFF
--- a/Staging/AudioDxe/HdaCodec/HdaCodec.c
+++ b/Staging/AudioDxe/HdaCodec/HdaCodec.c
@@ -937,11 +937,14 @@ HdaCodecParsePorts (
           (HDA_VERB_GET_CONFIGURATION_DEFAULT_ASSOCIATION (HdaWidget->DefaultConfiguration) == 0))
       {
         DEBUG ((
-          DEBUG_VERBOSE,
-          "HDA:  | Ignoring widget @ 0x%X\n",
-          HdaWidget->NodeId
+          DEBUG_INFO,
+          "HDA:  | Would ignore widget @ 0x%X %u|%u|%u\n",
+          HdaWidget->NodeId,
+          HdaWidget->Type != HDA_WIDGET_TYPE_PIN_COMPLEX,
+          HDA_VERB_GET_CONFIGURATION_DEFAULT_PORT_CONN (HdaWidget->DefaultConfiguration) == HDA_CONFIG_DEFAULT_PORT_CONN_NONE,
+          HDA_VERB_GET_CONFIGURATION_DEFAULT_ASSOCIATION (HdaWidget->DefaultConfiguration) == 0
           ));
-        continue;
+        // continue;
       }
 
       if (PcdGetBool (PcdAudioControllerUsePinCapsForOutputs)) {


### PR DESCRIPTION
MacOS11系统到12系统的USB限制补丁 XhciPortLimit 勾选上 然后所有的USB口都能使用，突破15个端口限制

USB restriction patches for MacOS11 to 12 systems, Check XhciPortLimit and then all USB ports can be used, breaking the limit of 15 ports