### PR TITLE
OcBootManagementLib: Unify boot meta file loading code;

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,8 +3,9 @@ OpenCore Changelog
 #### v0.9.4
 - Fixed kext blocker `Exclude` strategy for prelinked on 32-bit versions of macOS
 - Fixed `ForceAquantiaEthernet` quirk on macOS 14 beta 2, thx @Shikumo
-- Added `InstanceIdentifier` and option to target `.contentVisibility` to specific instances (thx @dakanji)
+- Added `InstanceIdentifier` to OpenCore and option to target `.contentVisibility` to specific instances (thx @dakanji)
 - Improved `LapicKernelPanic` quirk on legacy versions of macOS
+- Allowed `.contentVisibility` in same boot FS root locations as `.VolumeIcon.icns`, in order to survive macOS updates
 
 #### v0.9.3
 - Added `--force-codec` option to AudioDxe, thx @xCuri0

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -3147,15 +3147,15 @@ The algorithm to determine boot options behaves as follows:
   \item For disk device paths (not specifying a bootloader), execute ``bless'' (may return > 1 entry).
   \item For file device paths, check for presence on the file system directly.
   % Just kill all \EFI\APPLE\ paths.
-  \item Exclude entries if there is a \texttt{.contentVisibility} file near the bootloader or
-  inside the boot directory with \texttt{Disabled} contents (ASCII) (and if the current
-  \texttt{InstanceIentifier} matches an \texttt{Instance-List} if present, see following).
+  \item Exclude entries if there is a \texttt{.contentVisibility} file at a relevant location (see below)
+  with \texttt{Disabled} contents (ASCII) (and if the current \texttt{InstanceIentifier} matches an \texttt{Instance-List}
+  if present, see below).
   \item Mark device handle as \textit{used} in the list of partition handles if any.
   % Each partition handle will basically have a list of boot option entries for later quick lookup.
   \item Register the resulting entries as primary options and determine their types. \\
   The option will become auxiliary for some types (e.g. Apple HFS recovery)
   or if its \texttt{.contentVisibility} file contains \texttt{Auxiliary} (and if the current
-  \texttt{InstanceIentifier} matches an \texttt{Instance-List} if present, see following).
+  \texttt{InstanceIentifier} matches an \texttt{Instance-List} if present, see below).
   \end{itemize}
 \item For each partition handle:
   \begin{itemize}
@@ -3173,6 +3173,25 @@ The algorithm to determine boot options behaves as follows:
 without any checks with respect to \texttt{Auxiliary}.
 \item System entries, such as \texttt{Reset NVRAM}, are added as primary auxiliary options.
 \end{enumerate}
+
+A \texttt{.contentVisibility} file may be placed next to the bootloader (such as \texttt{boot.efi}),
+or in the boot folder (for DMG folder based boot items). Example locations, as seen from within macOS, are:
+\begin{itemize}
+\tightlist
+\item \texttt{/System/Volumes/Preboot/\{GUID\}/System/Library/CoreServices/.contentVisibility}
+\item \texttt{/Volumes/\{ESP\}/EFI/BOOT/.contentVisibility}
+\end{itemize}
+In addition a \texttt{.contentVisibility} file may be placed in the instance-specific (for macOS) or absolute
+root folders related to a boot entry, for example:
+\begin{itemize}
+\tightlist
+\item \texttt{/System/Volumes/Preboot/\{GUID\}/.contentVisibility}
+\item \texttt{/System/Volumes/Preboot/.contentVisibility}
+\item \texttt{/Volumes/\{ESP\}/.contentVisibility} (\emph{not recommended})
+\end{itemize}
+These root folder locations are supported specifically for macOS, because non-Apple files next to the Apple bootloader
+are removed by macOS updates. It is supported but not recommended to place a \texttt{.contentVisibility} file in a
+non-macOS root location (such as the last location shown above), because it will hide all entries on the drive.
 
 The \texttt{.contentVisibility} file, when present, may optionally target only specific instances
 of OpenCore. Its contents are \texttt{[\{Instance-List\}:](Disabled|Auxiliary)}.

--- a/Include/Acidanthera/Library/OcAppleBootPolicyLib.h
+++ b/Include/Acidanthera/Library/OcAppleBootPolicyLib.h
@@ -101,22 +101,24 @@ OcBootPolicyGetBootFileEx (
   );
 
 /**
-  Retrieves information about DevicePath.
+  Retrieves folder and file system associated with DevicePath.
 
   @param[in]  DevicePath          The device path to describe.
   @param[out] BootPathName        A pointer into which the folder portion of
-                                  DevicePath is returned.
-  @param[out] Device              A pointer into which the device handle of
-                                  DevicePath is returned.
+                                  DevicePath is returned. When EFI_SUCCESS is
+                                  returned, caller is responsible for freeing
+                                  this pool memory.
+  @param[out] FileSystem          A pointer into which the simple file system
+                                  for the folder is returned.
 
   @retval EFI_SUCCESS  The operation has been completed successfully.
   @retval other        DevicePath is not a valid file path.
 **/
 EFI_STATUS
 OcBootPolicyDevicePathToDirPath (
-  IN  EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
-  OUT CHAR16                    **BootPathName,
-  OUT EFI_HANDLE                *Device
+  IN  EFI_DEVICE_PATH_PROTOCOL         *DevicePath,
+  OUT CHAR16                           **BootPathName,
+  OUT EFI_SIMPLE_FILE_SYSTEM_PROTOCOL  **FileSystem
   );
 
 /**

--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -2114,4 +2114,68 @@ OcLaunchAppleBootPicker (
   VOID
   );
 
+/**
+  Read boot entry meta-data file from boot entry device path.
+  May be used before before OC_BOOT_ENTRY struct is created.
+
+  @param[in]  DevicePath          Boot entry device path.
+  @param[in]  FileName            File name to search for.
+  @param[in]  DebugFileType       Brief description of file for use in debug messages.
+  @param[in]  MaxFileSize         Maximum allowed file size (inclusive).
+  @param[in]  MinFileSize         Minimum allowed file size (inclusive).
+  @param[out] FileData            Returned file data.
+  @param[out] DataLength          Returned data length.
+  @param[in]  SearchAtLeaf        Search next to boot file (or in boot folder) first.
+  @param[in]  SearchAtRoot        After SearchAtLeaf, if specific, search at OC-specific
+                                  GUID sub-folder location, followed by FS root.
+
+  @retval EFI_SUCCESS   File was located, validated against allowed length, and returned.
+  @retval other         File could not be located, or had invalid length.
+**/
+EFI_STATUS
+EFIAPI
+OcGetBootEntryFileFromDevicePath (
+  IN  EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
+  IN  CONST CHAR16              *FileName,
+  IN  CONST CHAR8               *DebugFileType,
+  IN  UINT32                    MaxFileSize,
+  IN  UINT32                    MinFileSize,
+  OUT VOID                      **FileData,
+  OUT UINT32                    *DataLength,
+  IN  BOOLEAN                   SearchAtLeaf,
+  IN  BOOLEAN                   SearchAtRoot
+  );
+
+/**
+  Read boot entry meta-data file.
+  Validates that boot entry is external tool or OS type.
+
+  @param[in]  BootEntry           Boot entry.
+  @param[in]  FileName            File name to search for.
+  @param[in]  DebugFileType       Brief description of file for use in debug messages.
+  @param[in]  MaxFileSize         Maximum allowed file size (inclusive).
+  @param[in]  MinFileSize         Minimum allowed file size (inclusive).
+  @param[out] FileData            Returned file data.
+  @param[out] DataLength          Returned data length.
+  @param[in]  SearchAtLeaf        Search next to boot file (or in boot folder) first.
+  @param[in]  SearchAtRoot        After SearchAtLeaf, if specific, search at OC-specific
+                                  GUID sub-folder location, followed by FS root.
+
+  @retval EFI_SUCCESS   Boot entry was correct type, file was located, validated against allowed length, and returned.
+  @retval other         Boot entry was incorrect type, or file could not be located, or had invalid length.
+**/
+EFI_STATUS
+EFIAPI
+OcGetBootEntryFile (
+  IN  OC_BOOT_ENTRY  *BootEntry,
+  IN  CONST CHAR16   *FileName,
+  IN  CONST CHAR8    *DebugFileType,
+  IN  UINT32         MaxFileSize,
+  IN  UINT32         MinFileSize,
+  OUT VOID           **FileData,
+  OUT UINT32         *DataLength,
+  IN  BOOLEAN        SearchAtLeaf,
+  IN  BOOLEAN        SearchAtRoot
+  );
+
 #endif // OC_BOOT_MANAGEMENT_LIB_H

--- a/Include/Acidanthera/Library/OcDevicePathLib.h
+++ b/Include/Acidanthera/Library/OcDevicePathLib.h
@@ -202,8 +202,8 @@ OcFileDevicePathFullNameSize (
 
   @param[out] PathName      On output, the full file path of FilePath.
   @param[in]  FilePath      The File Device Path to inspect.
-  @param[in]  PathNameSize  The size, in bytes, of PathnName.  Must equal the
-                            actual fill file path size.
+  @param[in]  PathNameSize  The size, in bytes, of PathName.  Must equal the
+                            actual full file path size.
 
 **/
 VOID

--- a/Library/OcBootManagementLib/BootManagementInternal.h
+++ b/Library/OcBootManagementLib/BootManagementInternal.h
@@ -152,8 +152,7 @@ InternalGetAppleDiskLabel (
 CHAR8 *
 InternalGetContentFlavour (
   IN  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL  *FileSystem,
-  IN  CONST CHAR16                     *BootDirectoryName,
-  IN  CONST CHAR16                     *FlavourFilename
+  IN  CONST CHAR16                     *BootDirectoryName
   );
 
 EFI_STATUS

--- a/Library/OcDevicePathLib/OcDevicePathLib.c
+++ b/Library/OcDevicePathLib/OcDevicePathLib.c
@@ -1145,8 +1145,8 @@ OcFileDevicePathFullNameSize (
 
   @param[out] PathName      On output, the full file path of FilePath.
   @param[in]  FilePath      The File Device Path to inspect.
-  @param[in]  PathNameSize  The size, in bytes, of PathnName.  Must equal the
-                            actual fill file path size.
+  @param[in]  PathNameSize  The size, in bytes, of PathName.  Must equal the
+                            actual full file path size.
 
 **/
 VOID


### PR DESCRIPTION
Optionally allow .contentVisibility in the boot fs root locations that are currently searched for .VolumeIcon.icns, since file next to boot.efi is deleted on macOS update.