### PR TITLE
Close file pointer before calling abort

### DIFF
--- a/User/Library/UserFile.c
+++ b/User/Library/UserFile.c
@@ -131,6 +131,7 @@ UserWriteFile (
   }
 
   if (fwrite (Data, Size, 1, FilePtr) != 1) {
+    fclose (FilePtr);
     abort ();
   }
 


### PR DESCRIPTION
Hi.
This is a nitpick, but before calling abort in `fwrite(...)`, the `UserWriteFile(...)` function doesn't close the file pointer, which will cause a memory leak. This PR adds `fclose(...)` before the abort.