### PR TITLE
OcBootManagementLib: Add missing explicit initialisation of mImageLoaderCaps in OcImageLoaderLoad

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ OpenCore Changelog
 - Updated builtin firmware versions for SMBIOS and the rest
 - Fixed hang while generating boot entries on some systems
 - Added `efidebug.tool` support for 32-bit on 32-bit using GDB or LLDB
+- Fixed potential incorrect values in kernel image capabilities calculation
 
 #### v0.9.5
 - Fixed GUID formatting for legacy NVRAM saving

--- a/Library/OcBootManagementLib/ImageLoader.c
+++ b/Library/OcBootManagementLib/ImageLoader.c
@@ -270,6 +270,17 @@ OcImageLoaderLoad (
   OC_LOADED_IMAGE_PROTOCOL         *OcLoadedImage;
   EFI_LOADED_IMAGE_PROTOCOL        *LoadedImage;
 
+  //
+  // For OcImageLoaderLoad always assume target default.
+  //
+ #ifdef MDE_CPU_IA32
+  mImageLoaderCaps = OC_KERN_CAPABILITY_K32_U32 | OC_KERN_CAPABILITY_K32_U64;
+ #else
+  mImageLoaderCaps = OC_KERN_CAPABILITY_K64_U64;
+ #endif
+
+  mImageLoaderCapsHandle = NULL;
+
   ASSERT (SourceBuffer != NULL);
 
   //
@@ -410,6 +421,8 @@ OcImageLoaderLoad (
     FreeAlignedPages (DestinationBuffer, DestinationPages);
     return Status;
   }
+
+  mImageLoaderCapsHandle = *ImageHandle;
 
   DEBUG ((DEBUG_VERBOSE, "OCB: Loaded image at %p\n", *ImageHandle));
 


### PR DESCRIPTION
Fix mentioned in changelog incorporates this and the previous commit