### PR TITLE
OcPeCoffExtLib: Add support for FixupAppleEfiImages quirk

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ OpenCore Changelog
 - Fixed hang while generating boot entries on some systems
 - Added `efidebug.tool` support for 32-bit on 32-bit using GDB or LLDB
 - Fixed potential incorrect values in kernel image capabilities calculation
+- Added `FixupAppleEfiImages` quirk to allow booting Mac OS X 10.4 and 10.5 boot.efi images on modern secure image loaders
 
 #### v0.9.5
 - Fixed GUID formatting for legacy NVRAM saving

--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -1611,6 +1611,34 @@ To view their current state, use the \texttt{pmset -g} command in Terminal.
   Refer to the \texttt{OCABC: MAT support is 1/0} log entry to determine whether MAT is supported.
 
 \item
+  \texttt{FixupAppleEfiImages}\\
+  \textbf{Type}: \texttt{plist\ boolean}\\
+  \textbf{Failsafe}: \texttt{false}\\
+  \textbf{Description}: Fix errors in early Mac OS X boot.efi images.
+
+  Modern secure PE loaders will refuse to load \texttt{boot.efi} images from
+  Mac OS X 10.4 and 10.5 due to these files containing \texttt{W\^{}X} errors
+  and illegal overlapping sections.
+
+  This quirk detects these issues and pre-processes such images in memory,
+  so that a modern loader can accept them.
+
+  Pre-processing in memory is incompatible with secure boot, as the image loaded
+  is not the image on disk, so you cannot sign files which are loaded in this way
+  based on their original disk image contents.
+  Certain firmware will offer to register the hash of new, unknown images - this would
+  still work. On the other hand, it is not particularly realistic to want to
+  start such early, insecure images with secure boot anyway.
+
+  \emph{Note 1}: The quirk is only applied to Apple-specific `fat' (both 32-bit and 64-bit
+  versions in one image) \texttt{.efi} files, and is never applied during the Apple secure
+  boot path for newer macOS.
+
+  \emph{Note 2}: The quirk is only needed for loading Mac OS X 10.4 and 10.5, and even then
+  only if the firmware itself includes a modern, more secure PE COFF image loader. This includes
+  current builds of OpenDuet.
+
+\item
   \texttt{ForceBooterSignature}\\
   \textbf{Type}: \texttt{plist\ boolean}\\
   \textbf{Failsafe}: \texttt{false}\\

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -319,6 +319,8 @@
 			<true/>
 			<key>EnableWriteUnprotector</key>
 			<true/>
+			<key>FixupAppleEfiImages</key>
+			<false/>
 			<key>ForceBooterSignature</key>
 			<false/>
 			<key>ForceExitBootServices</key>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -319,6 +319,8 @@
 			<true/>
 			<key>EnableWriteUnprotector</key>
 			<true/>
+			<key>FixupAppleEfiImages</key>
+			<false/>
 			<key>ForceBooterSignature</key>
 			<false/>
 			<key>ForceExitBootServices</key>

--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -1814,7 +1814,8 @@ OcRegisterBootstrapBootOption (
 **/
 VOID
 OcImageLoaderInit (
-  IN     CONST BOOLEAN  ProtectUefiServices
+  IN     CONST BOOLEAN  ProtectUefiServices,
+  IN     CONST BOOLEAN  FixupAppleEfiImages
   );
 
 /**

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -142,6 +142,7 @@ OC_DECLARE (OC_BOOTER_PATCH_ARRAY)
   _(BOOLEAN                     , DiscardHibernateMap       ,     , FALSE  , ()) \
   _(BOOLEAN                     , EnableSafeModeSlide       ,     , FALSE  , ()) \
   _(BOOLEAN                     , EnableWriteUnprotector    ,     , FALSE  , ()) \
+  _(BOOLEAN                     , FixupAppleEfiImages       ,     , FALSE  , ()) \
   _(BOOLEAN                     , ForceBooterSignature      ,     , FALSE  , ()) \
   _(BOOLEAN                     , ForceExitBootServices     ,     , FALSE  , ()) \
   _(BOOLEAN                     , ProtectMemoryRegions      ,     , FALSE  , ()) \

--- a/Include/Acidanthera/Library/OcPeCoffExtLib.h
+++ b/Include/Acidanthera/Library/OcPeCoffExtLib.h
@@ -43,4 +43,19 @@ PeCoffGetApfsDriverVersion (
   OUT APFS_DRIVER_VERSION  **DriverVersionPtr
   );
 
+/**
+  Detect and patch W^X and section overlap errors in legacy boot.efi.
+  Expected to make changes in 10.4 and 10.5 only.
+
+  @param[in]  DriverBuffer      Image buffer.
+  @param[in]  DriverSize        Size of the image.
+
+  @retval EFI_SUCCESS on success.
+**/
+EFI_STATUS
+OcPatchLegacyEfi (
+  IN  VOID    *DriverBuffer,
+  IN  UINT32  DriverSize
+  );
+
 #endif // OC_PE_COFF_EXT_LIB_H

--- a/Library/OcBootManagementLib/OcBootManagementLib.inf
+++ b/Library/OcBootManagementLib/OcBootManagementLib.inf
@@ -110,6 +110,7 @@
   OcFlexArrayLib
   OcMachoLib
   OcMiscLib
+  OcPeCoffExtLib
   OcRtcLib
   OcTypingLib
   OcVariableLib

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -189,6 +189,7 @@ OC_SCHEMA
   OC_SCHEMA_BOOLEAN_IN ("DiscardHibernateMap",    OC_GLOBAL_CONFIG, Booter.Quirks.DiscardHibernateMap),
   OC_SCHEMA_BOOLEAN_IN ("EnableSafeModeSlide",    OC_GLOBAL_CONFIG, Booter.Quirks.EnableSafeModeSlide),
   OC_SCHEMA_BOOLEAN_IN ("EnableWriteUnprotector", OC_GLOBAL_CONFIG, Booter.Quirks.EnableWriteUnprotector),
+  OC_SCHEMA_BOOLEAN_IN ("FixupAppleEfiImages",    OC_GLOBAL_CONFIG, Booter.Quirks.FixupAppleEfiImages),
   OC_SCHEMA_BOOLEAN_IN ("ForceBooterSignature",   OC_GLOBAL_CONFIG, Booter.Quirks.ForceBooterSignature),
   OC_SCHEMA_BOOLEAN_IN ("ForceExitBootServices",  OC_GLOBAL_CONFIG, Booter.Quirks.ForceExitBootServices),
   OC_SCHEMA_BOOLEAN_IN ("ProtectMemoryRegions",   OC_GLOBAL_CONFIG, Booter.Quirks.ProtectMemoryRegions),

--- a/Library/OcMainLib/OpenCoreUefi.c
+++ b/Library/OcMainLib/OpenCoreUefi.c
@@ -899,7 +899,7 @@ OcLoadUefiSupport (
 
   OcReinstallProtocols (Config);
 
-  OcImageLoaderInit (Config->Booter.Quirks.ProtectUefiServices);
+  OcImageLoaderInit (Config->Booter.Quirks.ProtectUefiServices, Config->Booter.Quirks.FixupAppleEfiImages);
 
   OcLoadAppleSecureBoot (Config, CpuInfo);
 

--- a/Library/OcPeCoffExtLib/BasePeCoffLib2Internals.h
+++ b/Library/OcPeCoffExtLib/BasePeCoffLib2Internals.h
@@ -1,0 +1,55 @@
+/** @file
+  Provides shared private definitions across this library.
+
+  Copyright (c) 2020 - 2021, Marvin Häuser. All rights reserved.<BR>
+  Copyright (c) 2020, Vitaly Cheptsov. All rights reserved.<BR>
+  Copyright (c) 2020, ISP RAS. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-3-Clause
+**/
+
+#ifndef BASE_PE_COFF_LIB2_INTERNALS_H_
+#define BASE_PE_COFF_LIB2_INTERNALS_H_
+
+//
+// PcdImageLoaderRelocTypePolicy bits.
+//
+
+///
+/// If set, ARM Thumb Image relocations are supported.
+///
+#define PCD_RELOC_TYPE_POLICY_ARM  BIT0
+
+///
+/// Denotes the alignment requirement for Image certificate sizes.
+///
+#define IMAGE_CERTIFICATE_ALIGN  8U
+
+//
+// The PE/COFF specification guarantees an 8 Byte alignment for certificate
+// sizes. This is larger than the alignment requirement for WIN_CERTIFICATE
+// implied by the UEFI ABI. ASSERT this holds.
+//
+STATIC_ASSERT (
+  ALIGNOF (WIN_CERTIFICATE) <= IMAGE_CERTIFICATE_ALIGN,
+  "The PE/COFF specification guarantee does not suffice."
+  );
+
+//
+// The 4 Byte alignment guaranteed by the PE/COFF specification has been
+// replaced with ALIGNOF (EFI_IMAGE_BASE_RELOCATION_BLOCK) for proof simplicity.
+// This obviously was the original intention of the specification. ASSERT in
+// case the equality is not given.
+//
+STATIC_ASSERT (
+  sizeof (UINT32) == ALIGNOF (EFI_IMAGE_BASE_RELOCATION_BLOCK),
+  "The current model violates the PE/COFF specification"
+  );
+
+// FIXME:
+RETURN_STATUS
+PeCoffLoadImageInplaceNoBase (
+  IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *Context
+  );
+
+#endif // BASE_PE_COFF_LIB_INTERNALS_H_

--- a/Library/OcPeCoffExtLib/OcPeCoffExtInternal.h
+++ b/Library/OcPeCoffExtLib/OcPeCoffExtInternal.h
@@ -29,4 +29,31 @@ typedef struct APPLE_SIGNATURE_CONTEXT_ {
   UINT8                Signature[256];
 } APPLE_SIGNATURE_CONTEXT;
 
+/**
+  Fix W^X and section overlap issues in loaded TE, PE32, or PE32+ Image in
+  memory while initialising Context.
+
+  Closely based on PeCoffInitializeContext from PeCoffLib2.
+
+  The approach of modifying the image in memory is basically incompatible
+  with secure boot, athough:
+    a) Certain firmware may allow optionally registering the hash of any
+       image which does not load, which would still work.
+    b) It is fairly crazy anyway to want to apply secure boot to the old,
+       insecure .efi files which need these fixups.
+
+  @param[out] Context     The context describing the Image.
+  @param[in]  FileBuffer  The file data to parse as PE Image.
+  @param[in]  FileSize    The size, in Bytes, of FileBuffer.
+
+  @retval RETURN_SUCCESS  The Image context has been initialised successfully.
+  @retval other           The file data is malformed.
+**/
+RETURN_STATUS
+InternalPeCoffFixup (
+  OUT PE_COFF_LOADER_IMAGE_CONTEXT  *Context,
+  IN  CONST VOID                    *FileBuffer,
+  IN  UINT32                        FileSize
+  );
+
 #endif // OC_PE_COFF_EXT_INTERNAL_H

--- a/Library/OcPeCoffExtLib/OcPeCoffExtLib.c
+++ b/Library/OcPeCoffExtLib/OcPeCoffExtLib.c
@@ -33,6 +33,7 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include <Library/UefiLib.h>
 #include <Library/OcCryptoLib.h>
 #include <Library/OcAppleKeysLib.h>
+#include <Library/OcStringLib.h>
 #include <Guid/AppleCertificate.h>
 
 #include "OcPeCoffExtInternal.h"
@@ -493,7 +494,7 @@ PeCoffGetApfsDriverVersion (
      || (ImageContext.ImageType != PeCoffLoaderTypePe32Plus)
      || (ImageContext.Subsystem != EFI_IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER))
   {
-    DEBUG ((DEBUG_INFO, "OCPE: PeCoff unsupported image\n"));
+    DEBUG ((DEBUG_INFO, "OCPE: PeCoff apfs unsupported image\n"));
     return EFI_UNSUPPORTED;
   }
 
@@ -539,5 +540,27 @@ PeCoffGetApfsDriverVersion (
   }
 
   *DriverVersionPtr = DriverVersion;
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+OcPatchLegacyEfi (
+  IN  VOID    *DriverBuffer,
+  IN  UINT32  DriverSize
+  )
+{
+  EFI_STATUS                    ImageStatus;
+  PE_COFF_LOADER_IMAGE_CONTEXT  ImageContext;
+
+  ImageStatus = InternalPeCoffFixup (
+                  &ImageContext,
+                  DriverBuffer,
+                  DriverSize
+                  );
+  if (EFI_ERROR (ImageStatus)) {
+    DEBUG ((DEBUG_WARN, "OCPE: PeCoff legacy patch failure - %r\n", ImageStatus));
+    return EFI_UNSUPPORTED;
+  }
+
   return EFI_SUCCESS;
 }

--- a/Library/OcPeCoffExtLib/OcPeCoffExtLib.inf
+++ b/Library/OcPeCoffExtLib/OcPeCoffExtLib.inf
@@ -25,12 +25,13 @@
 
 
 #
-#  VALID_ARCHITECTURES           = X64
+#  VALID_ARCHITECTURES           = IA32 X64
 #
 
 [Sources]
   OcPeCoffExtInternal.h
   OcPeCoffExtLib.c
+  OcPeCoffFixup.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -48,7 +49,13 @@
   DebugLib
   OcAppleKeysLib
   OcCryptoLib
+  OcStringLib
 
 [Guids]
   gAppleEfiCertificateGuid
   gEfiCertTypeRsa2048Sha256Guid
+
+[FixedPcd]
+  gEfiMdePkgTokenSpaceGuid.PcdImageLoaderAlignmentPolicy
+  gEfiMdePkgTokenSpaceGuid.PcdImageLoaderAllowMisalignedOffset
+  gEfiMdePkgTokenSpaceGuid.PcdDebugRaisePropertyMask

--- a/Library/OcPeCoffExtLib/OcPeCoffFixup.c
+++ b/Library/OcPeCoffExtLib/OcPeCoffFixup.c
@@ -1,0 +1,720 @@
+/** @file
+  Implements APIs to verify PE/COFF Images for further processing.
+
+  Copyright (c) 2020 - 2021, Marvin Häuser. All rights reserved.<BR>
+  Copyright (c) 2020, Vitaly Cheptsov. All rights reserved.<BR>
+  Copyright (c) 2020, ISP RAS. All rights reserved.<BR>
+  Portions copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+  Portions copyright (c) 2008 - 2010, Apple Inc. All rights reserved.<BR>
+  Portions copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-3-Clause
+**/
+
+#include <Base.h>
+#include <Uefi/UefiBaseType.h>
+
+#include <IndustryStandard/PeImage2.h>
+
+#include <Guid/WinCertificate.h>
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseOverflowLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/PeCoffLib2.h>
+
+#include "BasePeCoffLib2Internals.h"
+
+//
+// FIXME: Provide an API to destruct the context?
+//
+
+/**
+  Verify the Image section Headers and initialise the Image memory space size.
+
+  The first Image section must be the beginning of the memory space, or be
+  contiguous to the aligned Image Headers.
+  Sections must be disjoint and, depending on the policy, contiguous in the
+  memory space space.
+  The section data must be in bounds bounds of the file buffer.
+
+  @param[in,out] Context       The context describing the Image. Must have been
+                               initialised by PeCoffInitializeContext().
+  @param[in]     FileSize      The size, in Bytes, of Context->FileBuffer.
+  @param[out]    StartAddress  On output, the RVA of the first Image section.
+
+  @retval RETURN_SUCCESS  The Image section Headers are well-formed.
+  @retval other           The Image section Headers are malformed.
+**/
+STATIC
+RETURN_STATUS
+InternalVerifySections (
+  IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *Context,
+  IN     UINT32                        FileSize,
+  OUT    UINT32                        *StartAddress
+  )
+{
+  BOOLEAN                        Overflow;
+  UINT32                         NextSectRva;
+  UINT32                         SectRawEnd;
+  UINT16                         SectionIndex;
+  CONST EFI_IMAGE_SECTION_HEADER *Sections;
+
+  ASSERT (Context != NULL);
+  ASSERT (IS_POW2 (Context->SectionAlignment));
+  ASSERT (StartAddress != NULL);
+  //
+  // Images without Sections have no usable data, disallow them.
+  //
+  if (Context->NumberOfSections == 0) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+
+  Sections = (CONST EFI_IMAGE_SECTION_HEADER *) (CONST VOID *) (
+               (CONST CHAR8 *) Context->FileBuffer + Context->SectionsOffset
+               );
+  //
+  // The first Image section must begin the Image memory space, or it must be
+  // adjacent to the Image Headers.
+  //
+  if (Sections[0].VirtualAddress == 0) {
+    // FIXME: Add PCD to disallow.
+    NextSectRva = 0;
+  } else {
+    //
+    // Choose the raw or aligned Image Headers size depending on whether loading
+    // unaligned Sections is allowed.
+    //
+    if ((PcdGet32 (PcdImageLoaderAlignmentPolicy) & PCD_ALIGNMENT_POLICY_CONTIGUOUS_SECTIONS) == 0) {
+      Overflow = BaseOverflowAlignUpU32 (
+                   Context->SizeOfHeaders,
+                   Context->SectionAlignment,
+                   &NextSectRva
+                   );
+      if (Overflow) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+    } else {
+      NextSectRva = Context->SizeOfHeaders;
+    }
+  }
+
+  *StartAddress = NextSectRva;
+  //
+  // Verify all Image sections are valid.
+  //
+  for (SectionIndex = 0; SectionIndex < Context->NumberOfSections; ++SectionIndex) {
+    //
+    // Verify the Image section adheres to the W^X principle, if the policy
+    // demands it.
+    //
+    if (PcdGetBool (PcdImageLoaderWXorX) && !PcdGetBool (PcdImageLoaderRemoveXForWX)) {
+      if ((Sections[SectionIndex].Characteristics & (EFI_IMAGE_SCN_MEM_EXECUTE | EFI_IMAGE_SCN_MEM_WRITE)) == (EFI_IMAGE_SCN_MEM_EXECUTE | EFI_IMAGE_SCN_MEM_WRITE)) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+    }
+    //
+    // Verify the Image sections are disjoint (relaxed) or adjacent (strict)
+    // depending on whether unaligned Image sections may be loaded or not.
+    // Unaligned Image sections have been observed with iPXE Option ROMs and old
+    // Apple Mac OS X bootloaders.
+    //
+    if ((PcdGet32 (PcdImageLoaderAlignmentPolicy) & PCD_ALIGNMENT_POLICY_CONTIGUOUS_SECTIONS) == 0) {
+      if (Sections[SectionIndex].VirtualAddress != NextSectRva) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+    } else {
+      if (Sections[SectionIndex].VirtualAddress < NextSectRva) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+      //
+      // If the Image section address is not aligned by the Image section
+      // alignment, fall back to important architecture-specific page sizes if
+      // possible, to ensure the Image can have memory protection applied.
+      // Otherwise, report no alignment for the Image.
+      //
+      if (!IS_ALIGNED (Sections[SectionIndex].VirtualAddress, Context->SectionAlignment)) {
+        STATIC_ASSERT (
+          DEFAULT_PAGE_ALLOCATION_GRANULARITY <= RUNTIME_PAGE_ALLOCATION_GRANULARITY,
+          "This code must be adapted to consider the reversed order."
+          );
+
+        if (IS_ALIGNED (Sections[SectionIndex].VirtualAddress, RUNTIME_PAGE_ALLOCATION_GRANULARITY)) {
+          Context->SectionAlignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
+        } else if (DEFAULT_PAGE_ALLOCATION_GRANULARITY < RUNTIME_PAGE_ALLOCATION_GRANULARITY
+         && IS_ALIGNED (Sections[SectionIndex].VirtualAddress, DEFAULT_PAGE_ALLOCATION_GRANULARITY)) {
+          Context->SectionAlignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
+        } else {
+          Context->SectionAlignment = 1;
+        }
+      }
+    }
+    //
+    // Verify the Image sections with data are in bounds of the file buffer.
+    //
+    if (Sections[SectionIndex].SizeOfRawData > 0) {
+      Overflow = BaseOverflowAddU32 (
+                   Sections[SectionIndex].PointerToRawData,
+                   Sections[SectionIndex].SizeOfRawData,
+                   &SectRawEnd
+                   );
+      if (Overflow) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+
+      if (SectRawEnd > FileSize) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+    }
+    //
+    // Determine the end of the current Image section.
+    //
+    Overflow = BaseOverflowAddU32 (
+                 Sections[SectionIndex].VirtualAddress,
+                 Sections[SectionIndex].VirtualSize,
+                 &NextSectRva
+                 );
+    if (Overflow) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+    //
+    // VirtualSize does not need to be aligned, so align the result if needed.
+    //
+    if ((PcdGet32 (PcdImageLoaderAlignmentPolicy) & PCD_ALIGNMENT_POLICY_CONTIGUOUS_SECTIONS) == 0) {
+      Overflow = BaseOverflowAlignUpU32 (
+                   NextSectRva,
+                   Context->SectionAlignment,
+                   &NextSectRva
+                   );
+      if (Overflow) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+    }
+  }
+  //
+  // Set SizeOfImage to the aligned end address of the last ImageSection.
+  //
+  if ((PcdGet32 (PcdImageLoaderAlignmentPolicy) & PCD_ALIGNMENT_POLICY_CONTIGUOUS_SECTIONS) == 0) {
+    Context->SizeOfImage = NextSectRva;
+  } else {
+    //
+    // Because VirtualAddress is aligned by SectionAlignment for all Image
+    // sections, and they are disjoint and ordered by VirtualAddress,
+    // VirtualAddress + VirtualSize must be safe to align by SectionAlignment for
+    // all but the last Image section.
+    // Determine the strictest common alignment that the last section's end is
+    // safe to align to.
+    //
+    Overflow = BaseOverflowAlignUpU32 (
+                NextSectRva,
+                Context->SectionAlignment,
+                &Context->SizeOfImage
+                );
+    if (Overflow) {
+      Context->SectionAlignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
+      Overflow = BaseOverflowAlignUpU32 (
+                  NextSectRva,
+                  Context->SectionAlignment,
+                  &Context->SizeOfImage
+                  );
+      if (DEFAULT_PAGE_ALLOCATION_GRANULARITY < RUNTIME_PAGE_ALLOCATION_GRANULARITY
+      && Overflow) {
+        Context->SectionAlignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
+        Overflow = BaseOverflowAlignUpU32 (
+                    NextSectRva,
+                    Context->SectionAlignment,
+                    &Context->SizeOfImage
+                    );
+      }
+
+      if (Overflow) {
+        Context->SectionAlignment = 1;
+      }
+    }
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Verify the basic Image Relocation information.
+
+  The preferred Image load address must be aligned by the section alignment.
+  The Relocation Directory must be contained within the Image section memory.
+  The Relocation Directory must be sufficiently aligned in memory.
+
+  @param[in] Context       The context describing the Image. Must have been
+                           initialised by PeCoffInitializeContext().
+  @param[in] StartAddress  The RVA of the first Image section.
+
+  @retval RETURN_SUCCESS  The basic Image Relocation information is well-formed.
+  @retval other           The basic Image Relocation information is malformed.
+**/
+STATIC
+RETURN_STATUS
+InternalValidateRelocInfo (
+  IN CONST PE_COFF_LOADER_IMAGE_CONTEXT  *Context,
+  IN UINT32                              StartAddress
+  )
+{
+  BOOLEAN Overflow;
+  UINT32  SectRvaEnd;
+
+  ASSERT (Context != NULL);
+  ASSERT (!Context->RelocsStripped || Context->RelocDirSize == 0);
+  //
+  // If the Base Relocations have not been stripped, verify their Directory.
+  //
+  if (Context->RelocDirSize != 0) {
+    //
+    // Verify the Relocation Directory is not empty.
+    //
+    if (sizeof (EFI_IMAGE_BASE_RELOCATION_BLOCK) > Context->RelocDirSize) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+    //
+    // Verify the Relocation Directory does not overlap with the Image Headers.
+    //
+    if (StartAddress > Context->RelocDirRva) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+    //
+    // Verify the Relocation Directory is contained in the Image memory space.
+    //
+    Overflow = BaseOverflowAddU32 (
+                 Context->RelocDirRva,
+                 Context->RelocDirSize,
+                 &SectRvaEnd
+                 );
+    if (Overflow || SectRvaEnd > Context->SizeOfImage) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+    //
+    // Verify the Relocation Directory start is sufficiently aligned.
+    //
+    if (!IS_ALIGNED (Context->RelocDirRva, ALIGNOF (EFI_IMAGE_BASE_RELOCATION_BLOCK))) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+  }
+  //
+  // Verify the preferred Image load address is sufficiently aligned.
+  //
+  // FIXME: Only with force-aligned sections? What to do with XIP?
+  if (!IS_ALIGNED (Context->ImageBase, (UINT64) Context->SectionAlignment)) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Verify the PE32 or PE32+ Image and initialise Context.
+
+  Used offsets and ranges must be aligned and in the bounds of the raw file.
+  Image section Headers and basic Relocation information must be Well-formed.
+
+  @param[in,out] Context   The context describing the Image. Must have been
+                           initialised by PeCoffInitializeContext().
+  @param[in]     FileSize  The size, in Bytes, of Context->FileBuffer.
+
+  @retval RETURN_SUCCESS  The PE Image is Well-formed.
+  @retval other           The PE Image is malformed.
+**/
+STATIC
+RETURN_STATUS
+InternalInitializePe (
+  IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *Context,
+  IN     UINT32                        FileSize
+  )
+{
+  BOOLEAN                               Overflow;
+  CONST EFI_IMAGE_NT_HEADERS_COMMON_HDR *PeCommon;
+  CONST EFI_IMAGE_NT_HEADERS32          *Pe32;
+  CONST EFI_IMAGE_NT_HEADERS64          *Pe32Plus;
+  CONST CHAR8                           *OptHdrPtr;
+  UINT32                                HdrSizeWithoutDataDir;
+  UINT32                                MinSizeOfOptionalHeader;
+  UINT32                                MinSizeOfHeaders;
+  CONST EFI_IMAGE_DATA_DIRECTORY        *RelocDir;
+  CONST EFI_IMAGE_DATA_DIRECTORY        *SecDir;
+  UINT32                                SecDirEnd;
+  UINT32                                NumberOfRvaAndSizes;
+  RETURN_STATUS                         Status;
+  UINT32                                StartAddress;
+
+  ASSERT (Context != NULL);
+  ASSERT (sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR) + sizeof (UINT16) <= FileSize - Context->ExeHdrOffset);
+  if (!PcdGetBool (PcdImageLoaderAllowMisalignedOffset)) {
+    ASSERT (IS_ALIGNED (Context->ExeHdrOffset, ALIGNOF (EFI_IMAGE_NT_HEADERS_COMMON_HDR)));
+  }
+  //
+  // Locate the PE Optional Header.
+  //
+  OptHdrPtr = (CONST CHAR8 *) Context->FileBuffer + Context->ExeHdrOffset;
+  OptHdrPtr += sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR);
+
+  STATIC_ASSERT (
+    IS_ALIGNED (ALIGNOF (EFI_IMAGE_NT_HEADERS_COMMON_HDR), ALIGNOF (UINT16))
+   && IS_ALIGNED (sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR), ALIGNOF (UINT16)),
+    "The following operation might be an unaligned access."
+    );
+  //
+  // Determine the type of and retrieve data from the PE Optional Header.
+  // Do not retrieve SizeOfImage as the value usually does not follow the
+  // specification. Even if the value is large enough to hold the last Image
+  // section, it may not be aligned, or it may be too large. No data can
+  // possibly be loaded past the last Image section anyway.
+  //
+  switch (*(CONST UINT16 *) (CONST VOID *) OptHdrPtr) {
+    case EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC:
+      //
+      // Verify the PE32 header is in bounds of the file buffer.
+      //
+      if (sizeof (*Pe32) > FileSize - Context->ExeHdrOffset) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+      //
+      // The PE32 header offset is always sufficiently aligned.
+      //
+      STATIC_ASSERT (
+        ALIGNOF (EFI_IMAGE_NT_HEADERS32) <= ALIGNOF (EFI_IMAGE_NT_HEADERS_COMMON_HDR),
+        "The following operations may be unaligned."
+        );
+      //
+      // Populate the common data with information from the Optional Header.
+      //
+      Pe32 = (CONST EFI_IMAGE_NT_HEADERS32 *) (CONST VOID *) (
+               (CONST CHAR8 *) Context->FileBuffer + Context->ExeHdrOffset
+               );
+
+      Context->ImageType           = PeCoffLoaderTypePe32;
+      Context->Subsystem           = Pe32->Subsystem;
+      Context->SizeOfHeaders       = Pe32->SizeOfHeaders;
+      Context->ImageBase           = Pe32->ImageBase;
+      Context->AddressOfEntryPoint = Pe32->AddressOfEntryPoint;
+      Context->SectionAlignment    = Pe32->SectionAlignment;
+
+      RelocDir = Pe32->DataDirectory + EFI_IMAGE_DIRECTORY_ENTRY_BASERELOC;
+      SecDir   = Pe32->DataDirectory + EFI_IMAGE_DIRECTORY_ENTRY_SECURITY;
+
+      PeCommon              = &Pe32->CommonHeader;
+      NumberOfRvaAndSizes   = Pe32->NumberOfRvaAndSizes;
+      HdrSizeWithoutDataDir = sizeof (EFI_IMAGE_NT_HEADERS32) - sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR);
+
+      break;
+
+    case EFI_IMAGE_NT_OPTIONAL_HDR64_MAGIC:
+      //
+      // Verify the PE32+ header is in bounds of the file buffer.
+      //
+      if (sizeof (*Pe32Plus) > FileSize - Context->ExeHdrOffset) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+      //
+      // Verify the PE32+ header offset is sufficiently aligned.
+      //
+      if (!PcdGetBool (PcdImageLoaderAllowMisalignedOffset)
+        && !IS_ALIGNED (Context->ExeHdrOffset, ALIGNOF (EFI_IMAGE_NT_HEADERS64))) {
+        DEBUG_RAISE ();
+        return RETURN_VOLUME_CORRUPTED;
+      }
+      //
+      // Populate the common data with information from the Optional Header.
+      //
+      Pe32Plus = (CONST EFI_IMAGE_NT_HEADERS64 *) (CONST VOID *) (
+                   (CONST CHAR8 *) Context->FileBuffer + Context->ExeHdrOffset
+                   );
+
+      Context->ImageType           = PeCoffLoaderTypePe32Plus;
+      Context->Subsystem           = Pe32Plus->Subsystem;
+      Context->SizeOfHeaders       = Pe32Plus->SizeOfHeaders;
+      Context->ImageBase           = Pe32Plus->ImageBase;
+      Context->AddressOfEntryPoint = Pe32Plus->AddressOfEntryPoint;
+      Context->SectionAlignment    = Pe32Plus->SectionAlignment;
+
+      RelocDir = Pe32Plus->DataDirectory + EFI_IMAGE_DIRECTORY_ENTRY_BASERELOC;
+      SecDir   = Pe32Plus->DataDirectory + EFI_IMAGE_DIRECTORY_ENTRY_SECURITY;
+
+      PeCommon              = &Pe32Plus->CommonHeader;
+      NumberOfRvaAndSizes   = Pe32Plus->NumberOfRvaAndSizes;
+      HdrSizeWithoutDataDir = sizeof (EFI_IMAGE_NT_HEADERS64) - sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR);
+
+      break;
+
+    default:
+      //
+      // Disallow Images with unknown PE Optional Header signatures.
+      //
+      DEBUG_RAISE ();
+      return RETURN_UNSUPPORTED;
+  }
+  //
+  // Disallow Images with unknown directories.
+  //
+  if (NumberOfRvaAndSizes > EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+  //
+  // Verify the Image alignment is a power of 2.
+  //
+  if (!IS_POW2 (Context->SectionAlignment)) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+
+  STATIC_ASSERT (
+    sizeof (EFI_IMAGE_DATA_DIRECTORY) <= MAX_UINT32 / EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES,
+    "The following arithmetic may overflow."
+    );
+  //
+  // Calculate the offset of the Image sections.
+  //
+  // Context->ExeHdrOffset + sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR) cannot overflow because
+  //   * ExeFileSize > sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR) and
+  //   * Context->ExeHdrOffset + ExeFileSize = FileSize
+  //
+  Overflow = BaseOverflowAddU32 (
+               Context->ExeHdrOffset + sizeof (*PeCommon),
+               PeCommon->FileHeader.SizeOfOptionalHeader,
+               &Context->SectionsOffset
+               );
+  if (Overflow) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+  //
+  // Verify the Section Headers offset is sufficiently aligned.
+  //
+  if (!PcdGetBool (PcdImageLoaderAllowMisalignedOffset)
+    && !IS_ALIGNED (Context->SectionsOffset, ALIGNOF (EFI_IMAGE_SECTION_HEADER))) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+  //
+  // This arithmetic cannot overflow because all values are sufficiently
+  // bounded.
+  //
+  MinSizeOfOptionalHeader = HdrSizeWithoutDataDir +
+                              NumberOfRvaAndSizes * sizeof (EFI_IMAGE_DATA_DIRECTORY);
+
+  ASSERT (MinSizeOfOptionalHeader >= HdrSizeWithoutDataDir);
+
+  STATIC_ASSERT (
+    sizeof (EFI_IMAGE_SECTION_HEADER) <= (MAX_UINT32 + 1ULL) / (MAX_UINT16 + 1ULL),
+    "The following arithmetic may overflow."
+    );
+  //
+  // Calculate the minimum size of the Image Headers.
+  //
+  Overflow = BaseOverflowAddU32 (
+               Context->SectionsOffset,
+               (UINT32) PeCommon->FileHeader.NumberOfSections * sizeof (EFI_IMAGE_SECTION_HEADER),
+               &MinSizeOfHeaders
+               );
+  if (Overflow) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+  //
+  // Verify the Image Header sizes are sane. SizeOfHeaders contains all header
+  // components (DOS, PE Common and Optional Header).
+  //
+  if (MinSizeOfOptionalHeader > PeCommon->FileHeader.SizeOfOptionalHeader) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+
+  if (MinSizeOfHeaders > Context->SizeOfHeaders) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+  //
+  // Verify the Image Headers are in bounds of the file buffer.
+  //
+  if (Context->SizeOfHeaders > FileSize) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+  //
+  // Populate the Image context with information from the Common Header.
+  //
+  Context->NumberOfSections = PeCommon->FileHeader.NumberOfSections;
+  Context->Machine          = PeCommon->FileHeader.Machine;
+  Context->RelocsStripped   =
+    (
+      PeCommon->FileHeader.Characteristics & EFI_IMAGE_FILE_RELOCS_STRIPPED
+    ) != 0;
+
+  if (EFI_IMAGE_DIRECTORY_ENTRY_BASERELOC < NumberOfRvaAndSizes) {
+    Context->RelocDirRva  = RelocDir->VirtualAddress;
+    Context->RelocDirSize = RelocDir->Size;
+
+    if (Context->RelocsStripped && Context->RelocDirSize != 0) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+  } else {
+    ASSERT (Context->RelocDirRva == 0);
+    ASSERT (Context->RelocDirSize == 0);
+  }
+
+  if (EFI_IMAGE_DIRECTORY_ENTRY_SECURITY < NumberOfRvaAndSizes) {
+    Context->SecDirOffset = SecDir->VirtualAddress;
+    Context->SecDirSize   = SecDir->Size;
+    //
+    // Verify the Security Directory is in bounds of the Image buffer.
+    //
+    Overflow = BaseOverflowAddU32 (
+                 Context->SecDirOffset,
+                 Context->SecDirSize,
+                 &SecDirEnd
+                 );
+    if (Overflow || SecDirEnd > FileSize) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+    //
+    // Verify the Security Directory is sufficiently aligned.
+    //
+    if (!IS_ALIGNED (Context->SecDirOffset, IMAGE_CERTIFICATE_ALIGN)) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+    //
+    // Verify the Security Directory size is sufficiently aligned, and that if
+    // it is not empty, it can fit at least one certificate.
+    //
+    if (Context->SecDirSize != 0
+     && (!IS_ALIGNED (Context->SecDirSize, IMAGE_CERTIFICATE_ALIGN)
+      || Context->SecDirSize < sizeof (WIN_CERTIFICATE))) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+  } else {
+    //
+    // The Image context is zero'd on allocation.
+    //
+    ASSERT (Context->SecDirOffset == 0);
+    ASSERT (Context->SecDirSize == 0);
+  }
+  //
+  // Verify the Image sections are Well-formed.
+  //
+  Status = InternalVerifySections (
+             Context,
+             FileSize,
+             &StartAddress
+             );
+  if (Status != RETURN_SUCCESS) {
+    DEBUG_RAISE ();
+    return Status;
+  }
+  //
+  // Verify the entry point is in bounds of the Image buffer.
+  //
+  if (Context->AddressOfEntryPoint >= Context->SizeOfImage) {
+    DEBUG_RAISE ();
+    return RETURN_VOLUME_CORRUPTED;
+  }
+  //
+  // Verify the basic Relocation information is well-formed.
+  //
+  Status = InternalValidateRelocInfo (Context, StartAddress);
+  if (Status != RETURN_SUCCESS) {
+    DEBUG_RAISE ();
+  }
+
+  return Status;
+}
+
+RETURN_STATUS
+PeCoffInitializeContext (
+  OUT PE_COFF_LOADER_IMAGE_CONTEXT  *Context,
+  IN  CONST VOID                    *FileBuffer,
+  IN  UINT32                        FileSize
+  )
+{
+  RETURN_STATUS               Status;
+  CONST EFI_IMAGE_DOS_HEADER *DosHdr;
+
+  ASSERT (Context != NULL);
+  ASSERT (FileBuffer != NULL || FileSize == 0);
+  //
+  // Initialise the Image context with 0-values.
+  //
+  ZeroMem (Context, sizeof (*Context));
+
+  Context->FileBuffer = FileBuffer;
+  Context->FileSize   = FileSize;
+  //
+  // Check whether the DOS Image Header is present.
+  //
+  if (sizeof (*DosHdr) <= FileSize
+   && *(CONST UINT16 *) (CONST VOID *) FileBuffer == EFI_IMAGE_DOS_SIGNATURE) {
+    DosHdr = (CONST EFI_IMAGE_DOS_HEADER *) (CONST VOID *) (
+               (CONST CHAR8 *) FileBuffer
+               );
+    //
+    // Verify the DOS Image Header and the Executable Header are in bounds of
+    // the file buffer, and that they are disjoint.
+    //
+    if (sizeof (EFI_IMAGE_DOS_HEADER) > DosHdr->e_lfanew
+     || DosHdr->e_lfanew > FileSize) {
+      DEBUG_RAISE ();
+      return RETURN_VOLUME_CORRUPTED;
+    }
+
+    Context->ExeHdrOffset = DosHdr->e_lfanew;
+    //
+    // Verify the Execution Header offset is sufficiently aligned.
+    //
+    if (!PcdGetBool (PcdImageLoaderAllowMisalignedOffset)
+      && !IS_ALIGNED (Context->ExeHdrOffset, ALIGNOF (EFI_IMAGE_NT_HEADERS_COMMON_HDR))) {
+      return RETURN_UNSUPPORTED;
+    }
+  }
+  //
+  // Verify the file buffer can hold a PE Common Header.
+  //
+  if (FileSize - Context->ExeHdrOffset < sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR) + sizeof (UINT16)) {
+    return RETURN_UNSUPPORTED;
+  }
+
+  STATIC_ASSERT (
+    ALIGNOF (UINT32) <= ALIGNOF (EFI_IMAGE_NT_HEADERS_COMMON_HDR),
+    "The following access may be performed unaligned"
+    );
+  //
+  // Verify the Image Executable Header has a PE signature.
+  //
+  if (*(CONST UINT32 *) (CONST VOID *) ((CONST CHAR8 *) FileBuffer + Context->ExeHdrOffset) != EFI_IMAGE_NT_SIGNATURE) {
+    return RETURN_UNSUPPORTED;
+  }
+  //
+  // Verify the PE Image Header is well-formed.
+  //
+  Status = InternalInitializePe (Context, FileSize);
+  if (Status != RETURN_SUCCESS) {
+    return Status;
+  }
+
+  return RETURN_SUCCESS;
+}

--- a/Library/OcPeCoffExtLib/OcPeCoffFixup.c
+++ b/Library/OcPeCoffExtLib/OcPeCoffFixup.c
@@ -61,14 +61,14 @@ InternalVerifySections (
   OUT    UINT32                        *StartAddress
   )
 {
-  BOOLEAN                        Overflow;
-  UINT32                         NextSectRva;
-  UINT32                         FixupOffset;
-  UINT32                         FixupVirtualSize;
-  CHAR8                          SectionName[EFI_IMAGE_SIZEOF_SHORT_NAME + 1];
-  UINT32                         SectRawEnd;
-  UINT16                         SectionIndex;
-  EFI_IMAGE_SECTION_HEADER       *Sections;
+  BOOLEAN                   Overflow;
+  UINT32                    NextSectRva;
+  UINT32                    FixupOffset;
+  UINT32                    FixupVirtualSize;
+  CHAR8                     SectionName[EFI_IMAGE_SIZEOF_SHORT_NAME + 1];
+  UINT32                    SectRawEnd;
+  UINT16                    SectionIndex;
+  EFI_IMAGE_SECTION_HEADER  *Sections;
 
   ASSERT (Context != NULL);
   ASSERT (IS_POW2 (Context->SectionAlignment));
@@ -81,9 +81,9 @@ InternalVerifySections (
     return RETURN_VOLUME_CORRUPTED;
   }
 
-  Sections = (EFI_IMAGE_SECTION_HEADER *) (VOID *) (
-               (CHAR8 *) Context->FileBuffer + Context->SectionsOffset
-               );
+  Sections = (EFI_IMAGE_SECTION_HEADER *)(VOID *)(
+                                                  (CHAR8 *)Context->FileBuffer + Context->SectionsOffset
+                                                  );
   //
   // The first Image section must begin the Image memory space, or it must be
   // adjacent to the Image Headers.
@@ -112,7 +112,7 @@ InternalVerifySections (
   }
 
   SectionName[L_STR_LEN (SectionName)] = '\0';
-  *StartAddress = NextSectRva;
+  *StartAddress                        = NextSectRva;
   //
   // Verify all Image sections are valid.
   //
@@ -125,6 +125,7 @@ InternalVerifySections (
       Sections[SectionIndex].Characteristics &= ~EFI_IMAGE_SCN_MEM_EXECUTE;
       DEBUG ((DEBUG_INFO, "OCPE: Fixup W^X for %a\n", SectionName));
     }
+
     //
     // Verify the Image sections are disjoint (relaxed) or adjacent (strict)
     // depending on whether unaligned Image sections may be loaded or not.
@@ -145,16 +146,18 @@ InternalVerifySections (
           DEBUG_RAISE ();
           return RETURN_VOLUME_CORRUPTED;
         }
+
         //
         // Fix up section overlap errors in memory.
         //
-        FixupOffset = NextSectRva - Sections[SectionIndex].VirtualAddress;
+        FixupOffset      = NextSectRva - Sections[SectionIndex].VirtualAddress;
         FixupVirtualSize = Sections[SectionIndex].VirtualSize;
         if (FixupOffset > Sections[SectionIndex].VirtualSize) {
           Sections[SectionIndex].VirtualSize = 0;
         } else {
           Sections[SectionIndex].VirtualSize -= FixupOffset;
         }
+
         DEBUG ((
           DEBUG_INFO,
           "OCPE: Fixup section overlap for %a 0x%X(0x%X)->0x%X(0x%X)\n",
@@ -163,9 +166,10 @@ InternalVerifySections (
           FixupVirtualSize,
           NextSectRva,
           Sections[SectionIndex].VirtualSize
-        ));
+          ));
         Sections[SectionIndex].VirtualAddress = NextSectRva;
       }
+
       //
       // If the Image section address is not aligned by the Image section
       // alignment, fall back to important architecture-specific page sizes if
@@ -180,14 +184,16 @@ InternalVerifySections (
 
         if (IS_ALIGNED (Sections[SectionIndex].VirtualAddress, RUNTIME_PAGE_ALLOCATION_GRANULARITY)) {
           Context->SectionAlignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-        } else if (DEFAULT_PAGE_ALLOCATION_GRANULARITY < RUNTIME_PAGE_ALLOCATION_GRANULARITY
-         && IS_ALIGNED (Sections[SectionIndex].VirtualAddress, DEFAULT_PAGE_ALLOCATION_GRANULARITY)) {
+        } else if (  (DEFAULT_PAGE_ALLOCATION_GRANULARITY < RUNTIME_PAGE_ALLOCATION_GRANULARITY)
+                  && IS_ALIGNED (Sections[SectionIndex].VirtualAddress, DEFAULT_PAGE_ALLOCATION_GRANULARITY))
+        {
           Context->SectionAlignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
         } else {
           Context->SectionAlignment = 1;
         }
       }
     }
+
     //
     // Verify the Image sections with data are in bounds of the file buffer.
     //
@@ -207,6 +213,7 @@ InternalVerifySections (
         return RETURN_VOLUME_CORRUPTED;
       }
     }
+
     //
     // Determine the end of the current Image section.
     //
@@ -219,6 +226,7 @@ InternalVerifySections (
       DEBUG_RAISE ();
       return RETURN_VOLUME_CORRUPTED;
     }
+
     //
     // VirtualSize does not need to be aligned, so align the result if needed.
     //
@@ -234,6 +242,7 @@ InternalVerifySections (
       }
     }
   }
+
   //
   // Set SizeOfImage to the aligned end address of the last ImageSection.
   //
@@ -249,25 +258,26 @@ InternalVerifySections (
     // safe to align to.
     //
     Overflow = BaseOverflowAlignUpU32 (
-                NextSectRva,
-                Context->SectionAlignment,
-                &Context->SizeOfImage
-                );
+                 NextSectRva,
+                 Context->SectionAlignment,
+                 &Context->SizeOfImage
+                 );
     if (Overflow) {
       Context->SectionAlignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-      Overflow = BaseOverflowAlignUpU32 (
-                  NextSectRva,
-                  Context->SectionAlignment,
-                  &Context->SizeOfImage
-                  );
-      if (DEFAULT_PAGE_ALLOCATION_GRANULARITY < RUNTIME_PAGE_ALLOCATION_GRANULARITY
-      && Overflow) {
+      Overflow                  = BaseOverflowAlignUpU32 (
+                                    NextSectRva,
+                                    Context->SectionAlignment,
+                                    &Context->SizeOfImage
+                                    );
+      if (  (DEFAULT_PAGE_ALLOCATION_GRANULARITY < RUNTIME_PAGE_ALLOCATION_GRANULARITY)
+         && Overflow)
+      {
         Context->SectionAlignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-        Overflow = BaseOverflowAlignUpU32 (
-                    NextSectRva,
-                    Context->SectionAlignment,
-                    &Context->SizeOfImage
-                    );
+        Overflow                  = BaseOverflowAlignUpU32 (
+                                      NextSectRva,
+                                      Context->SectionAlignment,
+                                      &Context->SizeOfImage
+                                      );
       }
 
       if (Overflow) {
@@ -300,8 +310,8 @@ InternalValidateRelocInfo (
   IN UINT32                              StartAddress
   )
 {
-  BOOLEAN Overflow;
-  UINT32  SectRvaEnd;
+  BOOLEAN  Overflow;
+  UINT32   SectRvaEnd;
 
   ASSERT (Context != NULL);
   ASSERT (!Context->RelocsStripped || Context->RelocDirSize == 0);
@@ -316,6 +326,7 @@ InternalValidateRelocInfo (
       DEBUG_RAISE ();
       return RETURN_VOLUME_CORRUPTED;
     }
+
     //
     // Verify the Relocation Directory does not overlap with the Image Headers.
     //
@@ -323,6 +334,7 @@ InternalValidateRelocInfo (
       DEBUG_RAISE ();
       return RETURN_VOLUME_CORRUPTED;
     }
+
     //
     // Verify the Relocation Directory is contained in the Image memory space.
     //
@@ -331,10 +343,11 @@ InternalValidateRelocInfo (
                  Context->RelocDirSize,
                  &SectRvaEnd
                  );
-    if (Overflow || SectRvaEnd > Context->SizeOfImage) {
+    if (Overflow || (SectRvaEnd > Context->SizeOfImage)) {
       DEBUG_RAISE ();
       return RETURN_VOLUME_CORRUPTED;
     }
+
     //
     // Verify the Relocation Directory start is sufficiently aligned.
     //
@@ -343,11 +356,12 @@ InternalValidateRelocInfo (
       return RETURN_VOLUME_CORRUPTED;
     }
   }
+
   //
   // Verify the preferred Image load address is sufficiently aligned.
   //
   // FIXME: Only with force-aligned sections? What to do with XIP?
-  if (!IS_ALIGNED (Context->ImageBase, (UINT64) Context->SectionAlignment)) {
+  if (!IS_ALIGNED (Context->ImageBase, (UINT64)Context->SectionAlignment)) {
     DEBUG_RAISE ();
     return RETURN_VOLUME_CORRUPTED;
   }
@@ -375,35 +389,36 @@ InternalInitializePe (
   IN     UINT32                        FileSize
   )
 {
-  BOOLEAN                               Overflow;
-  CONST EFI_IMAGE_NT_HEADERS_COMMON_HDR *PeCommon;
-  CONST EFI_IMAGE_NT_HEADERS32          *Pe32;
-  CONST EFI_IMAGE_NT_HEADERS64          *Pe32Plus;
-  CONST CHAR8                           *OptHdrPtr;
-  UINT32                                HdrSizeWithoutDataDir;
-  UINT32                                MinSizeOfOptionalHeader;
-  UINT32                                MinSizeOfHeaders;
-  CONST EFI_IMAGE_DATA_DIRECTORY        *RelocDir;
-  CONST EFI_IMAGE_DATA_DIRECTORY        *SecDir;
-  UINT32                                SecDirEnd;
-  UINT32                                NumberOfRvaAndSizes;
-  RETURN_STATUS                         Status;
-  UINT32                                StartAddress;
+  BOOLEAN                                Overflow;
+  CONST EFI_IMAGE_NT_HEADERS_COMMON_HDR  *PeCommon;
+  CONST EFI_IMAGE_NT_HEADERS32           *Pe32;
+  CONST EFI_IMAGE_NT_HEADERS64           *Pe32Plus;
+  CONST CHAR8                            *OptHdrPtr;
+  UINT32                                 HdrSizeWithoutDataDir;
+  UINT32                                 MinSizeOfOptionalHeader;
+  UINT32                                 MinSizeOfHeaders;
+  CONST EFI_IMAGE_DATA_DIRECTORY         *RelocDir;
+  CONST EFI_IMAGE_DATA_DIRECTORY         *SecDir;
+  UINT32                                 SecDirEnd;
+  UINT32                                 NumberOfRvaAndSizes;
+  RETURN_STATUS                          Status;
+  UINT32                                 StartAddress;
 
   ASSERT (Context != NULL);
   ASSERT (sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR) + sizeof (UINT16) <= FileSize - Context->ExeHdrOffset);
   if (!PcdGetBool (PcdImageLoaderAllowMisalignedOffset)) {
     ASSERT (IS_ALIGNED (Context->ExeHdrOffset, ALIGNOF (EFI_IMAGE_NT_HEADERS_COMMON_HDR)));
   }
+
   //
   // Locate the PE Optional Header.
   //
-  OptHdrPtr = (CONST CHAR8 *) Context->FileBuffer + Context->ExeHdrOffset;
+  OptHdrPtr  = (CONST CHAR8 *)Context->FileBuffer + Context->ExeHdrOffset;
   OptHdrPtr += sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR);
 
   STATIC_ASSERT (
     IS_ALIGNED (ALIGNOF (EFI_IMAGE_NT_HEADERS_COMMON_HDR), ALIGNOF (UINT16))
-   && IS_ALIGNED (sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR), ALIGNOF (UINT16)),
+                && IS_ALIGNED (sizeof (EFI_IMAGE_NT_HEADERS_COMMON_HDR), ALIGNOF (UINT16)),
     "The following operation might be an unaligned access."
     );
   //
@@ -413,7 +428,7 @@ InternalInitializePe (
   // section, it may not be aligned, or it may be too large. No data can
   // possibly be loaded past the last Image section anyway.
   //
-  switch (*(CONST UINT16 *) (CONST VOID *) OptHdrPtr) {
+  switch (*(CONST UINT16 *)(CONST VOID *)OptHdrPtr) {
     case EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC:
       //
       // Verify the PE32 header is in bounds of the file buffer.
@@ -422,6 +437,7 @@ InternalInitializePe (
         DEBUG_RAISE ();
         return RETURN_VOLUME_CORRUPTED;
       }
+
       //
       // The PE32 header offset is always sufficiently aligned.
       //
@@ -432,9 +448,9 @@ InternalInitializePe (
       //
       // Populate the common data with information from the Optional Header.
       //
-      Pe32 = (CONST EFI_IMAGE_NT_HEADERS32 *) (CONST VOID *) (
-               (CONST CHAR8 *) Context->FileBuffer + Context->ExeHdrOffset
-               );
+      Pe32 = (CONST EFI_IMAGE_NT_HEADERS32 *)(CONST VOID *)(
+                                                            (CONST CHAR8 *)Context->FileBuffer + Context->ExeHdrOffset
+                                                            );
 
       Context->ImageType           = PeCoffLoaderTypePe32;
       Context->Subsystem           = Pe32->Subsystem;
@@ -460,20 +476,23 @@ InternalInitializePe (
         DEBUG_RAISE ();
         return RETURN_VOLUME_CORRUPTED;
       }
+
       //
       // Verify the PE32+ header offset is sufficiently aligned.
       //
-      if (!PcdGetBool (PcdImageLoaderAllowMisalignedOffset)
-        && !IS_ALIGNED (Context->ExeHdrOffset, ALIGNOF (EFI_IMAGE_NT_HEADERS64))) {
+      if (  !PcdGetBool (PcdImageLoaderAllowMisalignedOffset)
+         && !IS_ALIGNED (Context->ExeHdrOffset, ALIGNOF (EFI_IMAGE_NT_HEADERS64)))
+      {
         DEBUG_RAISE ();
         return RETURN_VOLUME_CORRUPTED;
       }
+
       //
       // Populate the common data with information from the Optional Header.
       //
-      Pe32Plus = (CONST EFI_IMAGE_NT_HEADERS64 *) (CONST VOID *) (
-                   (CONST CHAR8 *) Context->FileBuffer + Context->ExeHdrOffset
-                   );
+      Pe32Plus = (CONST EFI_IMAGE_NT_HEADERS64 *)(CONST VOID *)(
+                                                                (CONST CHAR8 *)Context->FileBuffer + Context->ExeHdrOffset
+                                                                );
 
       Context->ImageType           = PeCoffLoaderTypePe32Plus;
       Context->Subsystem           = Pe32Plus->Subsystem;
@@ -498,6 +517,7 @@ InternalInitializePe (
       DEBUG_RAISE ();
       return RETURN_UNSUPPORTED;
   }
+
   //
   // Disallow Images with unknown directories.
   //
@@ -505,6 +525,7 @@ InternalInitializePe (
     DEBUG_RAISE ();
     return RETURN_VOLUME_CORRUPTED;
   }
+
   //
   // Verify the Image alignment is a power of 2.
   //
@@ -533,20 +554,23 @@ InternalInitializePe (
     DEBUG_RAISE ();
     return RETURN_VOLUME_CORRUPTED;
   }
+
   //
   // Verify the Section Headers offset is sufficiently aligned.
   //
-  if (!PcdGetBool (PcdImageLoaderAllowMisalignedOffset)
-    && !IS_ALIGNED (Context->SectionsOffset, ALIGNOF (EFI_IMAGE_SECTION_HEADER))) {
+  if (  !PcdGetBool (PcdImageLoaderAllowMisalignedOffset)
+     && !IS_ALIGNED (Context->SectionsOffset, ALIGNOF (EFI_IMAGE_SECTION_HEADER)))
+  {
     DEBUG_RAISE ();
     return RETURN_VOLUME_CORRUPTED;
   }
+
   //
   // This arithmetic cannot overflow because all values are sufficiently
   // bounded.
   //
   MinSizeOfOptionalHeader = HdrSizeWithoutDataDir +
-                              NumberOfRvaAndSizes * sizeof (EFI_IMAGE_DATA_DIRECTORY);
+                            NumberOfRvaAndSizes * sizeof (EFI_IMAGE_DATA_DIRECTORY);
 
   ASSERT (MinSizeOfOptionalHeader >= HdrSizeWithoutDataDir);
 
@@ -559,13 +583,14 @@ InternalInitializePe (
   //
   Overflow = BaseOverflowAddU32 (
                Context->SectionsOffset,
-               (UINT32) PeCommon->FileHeader.NumberOfSections * sizeof (EFI_IMAGE_SECTION_HEADER),
+               (UINT32)PeCommon->FileHeader.NumberOfSections * sizeof (EFI_IMAGE_SECTION_HEADER),
                &MinSizeOfHeaders
                );
   if (Overflow) {
     DEBUG_RAISE ();
     return RETURN_VOLUME_CORRUPTED;
   }
+
   //
   // Verify the Image Header sizes are sane. SizeOfHeaders contains all header
   // components (DOS, PE Common and Optional Header).
@@ -579,6 +604,7 @@ InternalInitializePe (
     DEBUG_RAISE ();
     return RETURN_VOLUME_CORRUPTED;
   }
+
   //
   // Verify the Image Headers are in bounds of the file buffer.
   //
@@ -586,6 +612,7 @@ InternalInitializePe (
     DEBUG_RAISE ();
     return RETURN_VOLUME_CORRUPTED;
   }
+
   //
   // Populate the Image context with information from the Common Header.
   //
@@ -593,14 +620,14 @@ InternalInitializePe (
   Context->Machine          = PeCommon->FileHeader.Machine;
   Context->RelocsStripped   =
     (
-      PeCommon->FileHeader.Characteristics & EFI_IMAGE_FILE_RELOCS_STRIPPED
+     PeCommon->FileHeader.Characteristics & EFI_IMAGE_FILE_RELOCS_STRIPPED
     ) != 0;
 
   if (EFI_IMAGE_DIRECTORY_ENTRY_BASERELOC < NumberOfRvaAndSizes) {
     Context->RelocDirRva  = RelocDir->VirtualAddress;
     Context->RelocDirSize = RelocDir->Size;
 
-    if (Context->RelocsStripped && Context->RelocDirSize != 0) {
+    if (Context->RelocsStripped && (Context->RelocDirSize != 0)) {
       DEBUG_RAISE ();
       return RETURN_VOLUME_CORRUPTED;
     }
@@ -620,10 +647,11 @@ InternalInitializePe (
                  Context->SecDirSize,
                  &SecDirEnd
                  );
-    if (Overflow || SecDirEnd > FileSize) {
+    if (Overflow || (SecDirEnd > FileSize)) {
       DEBUG_RAISE ();
       return RETURN_VOLUME_CORRUPTED;
     }
+
     //
     // Verify the Security Directory is sufficiently aligned.
     //
@@ -631,13 +659,15 @@ InternalInitializePe (
       DEBUG_RAISE ();
       return RETURN_VOLUME_CORRUPTED;
     }
+
     //
     // Verify the Security Directory size is sufficiently aligned, and that if
     // it is not empty, it can fit at least one certificate.
     //
-    if (Context->SecDirSize != 0
-     && (!IS_ALIGNED (Context->SecDirSize, IMAGE_CERTIFICATE_ALIGN)
-      || Context->SecDirSize < sizeof (WIN_CERTIFICATE))) {
+    if (  (Context->SecDirSize != 0)
+       && (  !IS_ALIGNED (Context->SecDirSize, IMAGE_CERTIFICATE_ALIGN)
+          || (Context->SecDirSize < sizeof (WIN_CERTIFICATE))))
+    {
       DEBUG_RAISE ();
       return RETURN_VOLUME_CORRUPTED;
     }
@@ -648,6 +678,7 @@ InternalInitializePe (
     ASSERT (Context->SecDirOffset == 0);
     ASSERT (Context->SecDirSize == 0);
   }
+
   //
   // Verify the Image sections are Well-formed.
   //
@@ -660,6 +691,7 @@ InternalInitializePe (
     DEBUG_RAISE ();
     return Status;
   }
+
   //
   // Verify the entry point is in bounds of the Image buffer.
   //
@@ -667,6 +699,7 @@ InternalInitializePe (
     DEBUG_RAISE ();
     return RETURN_VOLUME_CORRUPTED;
   }
+
   //
   // Verify the basic Relocation information is well-formed.
   //
@@ -686,7 +719,7 @@ InternalPeCoffFixup (
   )
 {
   RETURN_STATUS               Status;
-  CONST EFI_IMAGE_DOS_HEADER *DosHdr;
+  CONST EFI_IMAGE_DOS_HEADER  *DosHdr;
 
   //
   // Failure of these asserts can be fixed if needed by not using the Pcd
@@ -697,6 +730,7 @@ InternalPeCoffFixup (
   if ((PcdGet32 (PcdImageLoaderAlignmentPolicy) & PCD_ALIGNMENT_POLICY_CONTIGUOUS_SECTIONS) == 0) {
     ASSERT (FALSE);
   }
+
   if (PcdGetBool (PcdImageLoaderAllowMisalignedOffset)) {
     ASSERT (FALSE);
   }
@@ -713,17 +747,19 @@ InternalPeCoffFixup (
   //
   // Check whether the DOS Image Header is present.
   //
-  if (sizeof (*DosHdr) <= FileSize
-   && *(CONST UINT16 *) (CONST VOID *) FileBuffer == EFI_IMAGE_DOS_SIGNATURE) {
-    DosHdr = (CONST EFI_IMAGE_DOS_HEADER *) (CONST VOID *) (
-               (CONST CHAR8 *) FileBuffer
-               );
+  if (  (sizeof (*DosHdr) <= FileSize)
+     && (*(CONST UINT16 *)(CONST VOID *)FileBuffer == EFI_IMAGE_DOS_SIGNATURE))
+  {
+    DosHdr = (CONST EFI_IMAGE_DOS_HEADER *)(CONST VOID *)(
+                                                          (CONST CHAR8 *)FileBuffer
+                                                          );
     //
     // Verify the DOS Image Header and the Executable Header are in bounds of
     // the file buffer, and that they are disjoint.
     //
-    if (sizeof (EFI_IMAGE_DOS_HEADER) > DosHdr->e_lfanew
-     || DosHdr->e_lfanew > FileSize) {
+    if (  (sizeof (EFI_IMAGE_DOS_HEADER) > DosHdr->e_lfanew)
+       || (DosHdr->e_lfanew > FileSize))
+    {
       DEBUG_RAISE ();
       return RETURN_VOLUME_CORRUPTED;
     }
@@ -732,11 +768,13 @@ InternalPeCoffFixup (
     //
     // Verify the Execution Header offset is sufficiently aligned.
     //
-    if (!PcdGetBool (PcdImageLoaderAllowMisalignedOffset)
-      && !IS_ALIGNED (Context->ExeHdrOffset, ALIGNOF (EFI_IMAGE_NT_HEADERS_COMMON_HDR))) {
+    if (  !PcdGetBool (PcdImageLoaderAllowMisalignedOffset)
+       && !IS_ALIGNED (Context->ExeHdrOffset, ALIGNOF (EFI_IMAGE_NT_HEADERS_COMMON_HDR)))
+    {
       return RETURN_UNSUPPORTED;
     }
   }
+
   //
   // Verify the file buffer can hold a PE Common Header.
   //
@@ -751,9 +789,10 @@ InternalPeCoffFixup (
   //
   // Verify the Image Executable Header has a PE signature.
   //
-  if (*(CONST UINT32 *) (CONST VOID *) ((CONST CHAR8 *) FileBuffer + Context->ExeHdrOffset) != EFI_IMAGE_NT_SIGNATURE) {
+  if (*(CONST UINT32 *)(CONST VOID *)((CONST CHAR8 *)FileBuffer + Context->ExeHdrOffset) != EFI_IMAGE_NT_SIGNATURE) {
     return RETURN_UNSUPPORTED;
   }
+
   //
   // Verify the PE Image Header is well-formed.
   //

--- a/Utilities/AppleEfiSignTool/Makefile
+++ b/Utilities/AppleEfiSignTool/Makefile
@@ -13,7 +13,8 @@ OBJS    = $(PROJECT).o \
 	PeCoffInit.o \
 	PeCoffLoad.o \
 	PeCoffRelocate.o \
-	OcPeCoffExtLib.o
+	OcPeCoffExtLib.o \
+	OcPeCoffFixup.o
 VPATH   = $(UDK_PATH)/MdePkg/Library/BasePeCoffLib2:$\
           ../../Library/OcPeCoffExtLib:$\
 


### PR DESCRIPTION
Fixes https://github.com/acidanthera/bugtracker/issues/2233

For the purposes of viewing the changes, I strongly recommend https://github.com/mikebeaton/OpenCorePkg/commit/b6d5baf1e5af61b1c4b0888cd133ea02b9ca6b9f (i.e. commit 2/3), since this makes it very clear how OcPeCoffFixup.c relates to PeCoffInit.c which it came from.
 - Commit 1/3 imports the two files from BasePeCoffLib2 with no changes (except renaming PeCoffInit.c -> OcPeCoffFixup.c)
  - Commit 2/3 all the actual changes, making it easy to see what changed between PeCoffInit.c -> OcPeCoffFixup.c
  - Commit 3/3 just the required uncrustify changes to OcPeCoffFixup.c

Since all three commits are valid builds of OpenCore (with only Uncrustify errors, only in one file, in 1/3 and 2/3), then I suggest it might be worth keeping this three-commit structure in the main branch (i.e. not accepting as a merge commit, but just pushing the tip of this branch to master to accept the changes and auto-close the PR), so that it keeps the reference commit where it's easy to see the changes made between PeCoffInit.c and OcPeCoffFixup.c.