### PR TITLE
OcBootManagementLib: Store ImageLoaderCaps in protocol.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ OpenCore Changelog
 - Updated `FixupAppleEfiImages` quirk to fix `W^X` errors in all non-Secure Boot Apple signed binaries
 - Updated builtin firmware versions for SMBIOS and the rest
 - Updated `AppleEfiSignTool` to work with new PE COFF loader
+- Fixed recovery failing to boot on some systems
 
 #### v0.9.6
 - Updated builtin firmware versions for SMBIOS and the rest

--- a/Library/OcBootManagementLib/BootEntryManagement.c
+++ b/Library/OcBootManagementLib/BootEntryManagement.c
@@ -2548,6 +2548,10 @@ OcLoadBootEntry (
       // Unload dmg if any.
       //
       InternalUnloadDmg (&DmgLoadContext);
+      //
+      // Unload image.
+      //
+      gBS->UnloadImage (EntryHandle);
     }
   } else {
     DEBUG ((DEBUG_WARN, "OCB: LoadImage failed - %r\n", Status));


### PR DESCRIPTION
The recently added "OCB: load/start unsupported ordering" error log message is unfortunately being hit on real macs when loading recovery.

This means the assumption of the original code (i.e. before the recent changes) that LoadImage and StartImage are nicely paired, at least in the cases we care about, never was being met. Storage of image caps, to transfer them between LoadImage and StartImage when needed, is now moved from a shared static variable to a protocol instance on the image handle.

Tested that it resolves the issue.

Additionally, UnloadImage was never being called when StartImage fails. Now added.