### PR TITLE
OpenCanopy: Enable use of picker shortcut keys when these are being read out due to audio assist

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ OpenCore Changelog
 - Added kext blocker `Exclude` strategy for mkext
 - Re-enabled AudioDxe failover to protocol GET mode for systems such as Acer E5 where it works when DisconnectHda doesn't
 - Added `FirmwareSettingsEntry.efi` driver which adds menu entry to reboot into UEFI firmware settings
+- Enabled use of picker shortcut keys which are read out in OpenCanopy when using `PickerAudioAssist`
 
 #### v0.9.7
 - Updated recovery_urls.txt

--- a/Platform/OpenCanopy/Views/BootPicker.c
+++ b/Platform/OpenCanopy/Views/BootPicker.c
@@ -455,6 +455,22 @@ InternalBootPickerKeyEvent (
       GuiContext->ReadyToBoot            = TRUE;
       ASSERT (GuiContext->BootEntry == SelectedEntry->Context);
     }
+  } else if (  GuiContext->PickerContext->PickerAudioAssist
+            && (KeyEvent->OcKeyCode >= 0)
+            && ((UINTN)KeyEvent->OcKeyCode < mBootPicker.Hdr.Obj.NumChildren)
+               )
+  {
+    InternalBootPickerChangeEntry (
+      Picker,
+      DrawContext,
+      BaseX,
+      BaseY,
+      (UINT32)KeyEvent->OcKeyCode
+      );
+    SelectedEntry                      = InternalGetVolumeEntry (mBootPicker.SelectedIndex);
+    SelectedEntry->Context->SetDefault = (KeyEvent->OcModifiers & OC_MODIFIERS_SET_DEFAULT) != 0;
+    GuiContext->ReadyToBoot            = TRUE;
+    ASSERT (GuiContext->BootEntry == SelectedEntry->Context);
   } else if (mBootPickerContainer.Obj.Opacity != 0xFF) {
     //
     // FIXME: Other keys are not allowed when boot picker is partially transparent.


### PR DESCRIPTION
It seems reasonable (preferable?) to allow these keys in the case where these are being read out loud anyway by audio assist