### PR TITLE
BuiltinPicker: Avoid responding to possibly multiple keys pressed before menu is read out, if using audio assist

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ OpenCore Changelog
 - Re-enabled AudioDxe failover to protocol GET mode for systems such as Acer E5 where it works when DisconnectHda doesn't
 - Added `FirmwareSettingsEntry.efi` driver which adds menu entry to reboot into UEFI firmware settings
 - Enabled use of picker shortcut keys which are read out in OpenCanopy when using `PickerAudioAssist`
+- Modified builtin picker audio assist to avoid responding to possibly multiple keys pressed before menu is read out
 
 #### v0.9.7
 - Updated recovery_urls.txt

--- a/Library/OcBootManagementLib/BuiltinPicker.c
+++ b/Library/OcBootManagementLib/BuiltinPicker.c
@@ -641,6 +641,11 @@ OcShowSimpleBootMenu (
         OC_VOICE_OVER_SILENCE_NORMAL_MS
         );
       PlayedOnce = TRUE;
+
+      //
+      // Avoid responding to possibly multiple keys pressed before menu is fully read out.
+      //
+      BootContext->PickerContext->HotKeyContext->FlushTypingBuffer (BootContext->PickerContext);
     }
 
     while (TRUE) {


### PR DESCRIPTION
Only just noticed that this happens, I would say it is a definite improvement to avoid this. Due to using a different approach to fetching key presses, Canopy already behaves like this.