### PR TITLE
OpenCanopy: Fixed intro animation getting stuck...

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ OpenCore Changelog
 - Fixed CPU frequency calculation on AMD 10h family
 - Swapped the position of Shutdown and Restart buttons to better match recent macOS
 - Added `OC_ATTR_USE_REVERSED_UI` to allow access to previous default Shutdown and Restart button arrangement
+- Fixed intro animation getting stuck in OpenCanopy if an entry which returns to menu is selected before animation ends
 
 #### v0.9.7
 - Updated recovery_urls.txt

--- a/Platform/OpenCanopy/OcBootstrap.c
+++ b/Platform/OpenCanopy/OcBootstrap.c
@@ -102,8 +102,14 @@ OcShowMenuByOc (
 
   *ChosenBootEntry = NULL;
   OcSetInitialCursorOffset ();
-  mGuiContext.BootEntry            = NULL;
-  mGuiContext.ReadyToBoot          = FALSE;
+  mGuiContext.BootEntry   = NULL;
+  mGuiContext.ReadyToBoot = FALSE;
+  //
+  // Re-run intro animation on each entry into menu, to avoid stuck animation
+  // which happens otherwise, if a menu item which returns to the menu is
+  // selected before the animation ends.
+  //
+  mGuiContext.DoneIntroAnimation   = FALSE;
   mGuiContext.HideAuxiliary        = BootContext->PickerContext->HideAuxiliary;
   mGuiContext.Refresh              = FALSE;
   mGuiContext.PickerContext        = BootContext->PickerContext;
@@ -116,7 +122,7 @@ OcShowMenuByOc (
 
   mDrawContext.TimeOutSeconds = BootContext->PickerContext->TimeoutSeconds;
   //
-  // Do not play intro animation for blind.
+  // Do not play intro animation for visually impaired users.
   //
   if (BootContext->PickerContext->PickerAudioAssist) {
     mGuiContext.DoneIntroAnimation = TRUE;
@@ -249,11 +255,11 @@ OcShowPasswordByOc (
   mDrawContext.TimeOutSeconds = 0;
 
   //
-  // Do not play intro animation for blind.
+  // FIXME: Ideally we disable password fade-in animation here for visually
+  // impaired users, i.e. when Context->PickerAudioAssist is TRUE, as we
+  // already do for menu ease-in animation. Probably needs separate bool in
+  // addition to mGuiContext.DoneIntroAnimation.
   //
-  if (Context->PickerAudioAssist) {
-    mGuiContext.DoneIntroAnimation = TRUE;
-  }
 
   Status = PasswordViewInitialize (
              &mDrawContext,

--- a/Platform/OpenCanopy/Views/BootPicker.c
+++ b/Platform/OpenCanopy/Views/BootPicker.c
@@ -1698,6 +1698,8 @@ InternalBootPickerAnimateImageList (
   return FALSE;
 }
 
+STATIC UINT32  mPrevSine;
+
 STATIC GUI_INTERPOLATION  mBpAnimInfoSinMove = {
   GuiInterpolTypeSmooth,
   0,
@@ -1718,6 +1720,8 @@ InitBpAnimIntro (
   //        mBootPickerContainer between animation initialisation and start.
   //
   mBootPickerContainer.Obj.OffsetX += 35 * DrawContext->Scale;
+
+  mPrevSine = 0;
 }
 
 BOOLEAN
@@ -1727,8 +1731,6 @@ InternalBootPickerAnimateIntro (
   IN     UINT64                   CurrentTime
   )
 {
-  STATIC UINT32  PrevSine = 0;
-
   UINT8   Opacity;
   UINT32  InterpolVal;
   UINT32  DeltaSine;
@@ -1773,9 +1775,9 @@ InternalBootPickerAnimateIntro (
   }
 
   InterpolVal                       = GuiGetInterpolatedValue (&mBpAnimInfoSinMove, CurrentTime);
-  DeltaSine                         = InterpolVal - PrevSine;
+  DeltaSine                         = InterpolVal - mPrevSine;
   mBootPickerContainer.Obj.OffsetX -= DeltaSine;
-  PrevSine                          = InterpolVal;
+  mPrevSine                         = InterpolVal;
   //
   // Draw the full dimension of the inner container to implicitly cover the
   // scroll buttons with the off-screen entries.


### PR DESCRIPTION
...in OpenCanopy if an entry which returns to the menu is selected before the animation ends.

When triggered, this:
 - Looks wrong
 - Disables ESC and SPACE
 - Can hide the menu completely (if triggered early)