### PR TITLE
OcCpuLib: Fix cpu-type detection on Raptor Lake

### DIFF
--- a/Include/Apple/IndustryStandard/AppleSmBios.h
+++ b/Include/Apple/IndustryStandard/AppleSmBios.h
@@ -216,7 +216,7 @@ enum {
 
   AppleProcessorTypeCorei9Type1 = 0x1001,     // may not be used
   AppleProcessorTypeCorei9Type5 = 0x1005,     // SKL-X i9, most likely to be invalid!
-  AppleProcessorTypeCorei9Type9 = 0x1009      // ideal value for Coffee Lake i9, need confirmation
+  AppleProcessorTypeCorei9Type9 = 0x1009      // i9 9980HK (MacBookPro16,1)
 };
 
 // APPLE_PROCESSOR_TYPE_CLASS

--- a/Include/Intel/IndustryStandard/ProcessorInfo.h
+++ b/Include/Intel/IndustryStandard/ProcessorInfo.h
@@ -241,13 +241,15 @@ typedef enum {
 #define CPU_MODEL_COFFEELAKE_DT   0x9E
 #define CPU_MODEL_ICELAKE_Y       0x7D
 #define CPU_MODEL_ICELAKE_U       0x7E
-#define CPU_MODEL_ICELAKE_SP      0x9F /* Some variation of Ice Lake */
-#define CPU_MODEL_COMETLAKE_S     0xA5 /* desktop CometLake */
-#define CPU_MODEL_COMETLAKE_Y     0xA5 /* aka 10th generation Amber Lake Y */
+#define CPU_MODEL_ICELAKE_SP      0x9F ///< Some variation of Ice Lake
+#define CPU_MODEL_COMETLAKE_S     0xA5 ///< desktop CometLake
+#define CPU_MODEL_COMETLAKE_Y     0xA5 ///< aka 10th generation Amber Lake Y
 #define CPU_MODEL_COMETLAKE_U     0xA6
-#define CPU_MODEL_ROCKETLAKE_S    0xA7/* desktop RocketLake */
+#define CPU_MODEL_ROCKETLAKE_S    0xA7 ///< desktop RocketLake
 #define CPU_MODEL_TIGERLAKE_U     0x8C
 #define CPU_MODEL_ALDERLAKE_S     0x97
+#define CPU_MODEL_RAPTORLAKE_S    0xB7 ///< Raptor Lake B0 stepping
+#define CPU_MODEL_RAPTORLAKE_HX   0xBF ///< Raptor Lake C0 stepping
 
 #define AMD_CPU_FAMILY          0xF
 #define AMD_CPU_EXT_FAMILY_10H  0x1

--- a/Library/OcCpuLib/AppleCpuSupport.c
+++ b/Library/OcCpuLib/AppleCpuSupport.c
@@ -611,6 +611,8 @@ InternalDetectAppleProcessorType (
     case CPU_MODEL_ICELAKE_SP:     // 0x9F FIXME - unknown, for now
     case CPU_MODEL_TIGERLAKE_U:    // 0x8C FIXME - unknown, for now
     case CPU_MODEL_ALDERLAKE_S:    // 0x97 FIXME - unknown, for now
+    case CPU_MODEL_RAPTORLAKE_S:   // 0xB7 FIXME - unknown, for now
+    case CPU_MODEL_RAPTORLAKE_HX:  // 0xBF FIXME - unknown, for now
       if (AppleMajorType == AppleProcessorMajorM3) {
         // MB101 (m3 7Y32)
         return AppleProcessorTypeCoreM3Type7; // 0x0C07
@@ -648,6 +650,7 @@ InternalDetectAppleProcessorType (
       if (AppleMajorType == AppleProcessorMajorI9) {
         // FIXME: find a dump from MBP151 with i9-8950HK,
         // for now using an ideal value (0x1009), comparing to 0x0709 (used on MBP151, i7-8850H and MM81, i7-8700B)
+        // MBP161 (i9-9980HK)
         return AppleProcessorTypeCorei9Type9; // 0x1009
       }
 


### PR DESCRIPTION
Partially addresses https://github.com/acidanthera/bugtracker/issues/2366. System Information still reports an Unknown processor, presumably due to the core count exceeding the expected values for the Skylake families. But this matches the existing behavior for Alder Lake.