### PR TITLE
OcApfsLib: Always load JumpStart APFS directly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ OpenCore Changelog
 - Enabled use of picker shortcut keys which are read out in OpenCanopy when using `PickerAudioAssist`
 - Modified builtin picker so as not to respond to keys queued while audio assist menu is being read out
 - Fixed Linux EFI stub loading error when using OpenDuet since 0.8.8
+- Fixed APFS JumpStart with OpenDuet and `SecureBootModel` `Disabled`
 
 #### v0.9.7
 - Updated recovery_urls.txt


### PR DESCRIPTION
apfs.efi has W^X errors which require fixup for strict loaders, however we were only passing the post-sanitised image to OC-wrapped platform loader, therefore the wrapper in ImageLoader.c cannot detect that it is an Apple signed binary which should be fixed up.

Fixes issue reported here: https://github.com/acidanthera/bugtracker/issues/2363#issuecomment-1896210279