### PR TITLE
OpenDuet: Apply UE loader Pcds which are required to load current Linux EFI stubs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ OpenCore Changelog
 - Added `FirmwareSettingsEntry.efi` driver which adds menu entry to reboot into UEFI firmware settings
 - Enabled use of picker shortcut keys which are read out in OpenCanopy when using `PickerAudioAssist`
 - Modified builtin picker so as not to respond to keys queued while audio assist menu is being read out
+- Fixed Linux EFI stub loading error when using OpenDuet since 0.8.8
 
 #### v0.9.7
 - Updated recovery_urls.txt

--- a/OpenDuetPkg.dsc
+++ b/OpenDuetPkg.dsc
@@ -267,6 +267,12 @@
   # such as HfsPlusLegacy.efi.
   #
   gEfiMdePkgTokenSpaceGuid.PcdImageProtectionPolicy|0x00000003
+  #
+  # PcdDxeNxMemoryProtectionPolicy and PcdImageLoaderAllowMisalignedOffset
+  # settings for Linux EFI stub (same as OvmfPkg LINUX_LOADER settings).
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy|0xFFFFFFFFFFFFFF40
+  gEfiMdePkgTokenSpaceGuid.PcdImageLoaderAllowMisalignedOffset|TRUE
 
 [BuildOptions]
   MSFT:NOOPT_*_*_CC_FLAGS    = -D OC_TARGET_RELEASE=1 /FAcs -Dinline=__inline  /GS /kernel


### PR DESCRIPTION
Should address https://github.com/acidanthera/bugtracker/issues/2371