### PR TITLE
Utilities: change order of download in macrecovery

### DIFF
--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -282,10 +282,10 @@ def action_download(args):
     if args.verbose:
         print(info)
     print(f'Downloading {info[INFO_PRODUCT]}...')
-    dmgname = '' if args.basename == '' else args.basename + '.dmg'
-    dmgpath = save_image(info[INFO_IMAGE_LINK], info[INFO_IMAGE_SESS], dmgname, args.outdir)
     cnkname = '' if args.basename == '' else args.basename + '.chunklist'
     cnkpath = save_image(info[INFO_SIGN_LINK], info[INFO_SIGN_SESS], cnkname, args.outdir)
+    dmgname = '' if args.basename == '' else args.basename + '.dmg'
+    dmgpath = save_image(info[INFO_IMAGE_LINK], info[INFO_IMAGE_SESS], dmgname, args.outdir)
     try:
         verify_image(dmgpath, cnkpath)
         return 0


### PR DESCRIPTION
Downloading the big file first (BaseSystem) and then the chunklist may result in a token timeout for people with slow internet connections, to work around this simply moving the order of download so that the chunklist downloads first solves this issue.