### PR TITLE
Tweak GHA configs

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       JOB_TYPE: ANALYZE
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |
@@ -65,7 +65,7 @@ jobs:
     env:
       JOB_TYPE: ANALYZE
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |
@@ -77,7 +77,7 @@ jobs:
           python3 -m prospector . -P ./profile.yml | tee prospector_result.txt || exit 1
 
       - name: Upload prospector result to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Prospector Artifacts
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository_owner == 'acidanthera' && github.ref_name == 'master'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |
@@ -106,7 +106,7 @@ jobs:
       TOOLCHAINS: GCC
     if: github.repository_owner == 'acidanthera' && github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -62,7 +62,7 @@ jobs:
 
   analyze-python-scripts:
     name: Python Scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_TYPE: ANALYZE
     steps:
@@ -86,7 +86,7 @@ jobs:
 
   analyze-docs-linux:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'acidanthera' && github.ref_name == 'master'
     steps:
       - uses: actions/checkout@v4
@@ -101,7 +101,7 @@ jobs:
 
   analyze-coverity:
     name: Coverity
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JOB_TYPE: COVERITY
       TOOLCHAINS: GCC

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -62,7 +62,7 @@ jobs:
 
   analyze-python-scripts:
     name: Python Scripts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       JOB_TYPE: ANALYZE
     steps:
@@ -86,7 +86,7 @@ jobs:
 
   analyze-docs-linux:
     name: Documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'acidanthera' && github.ref_name == 'master'
     steps:
       - uses: actions/checkout@v4
@@ -101,7 +101,7 @@ jobs:
 
   analyze-coverity:
     name: Coverity
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       JOB_TYPE: COVERITY
       TOOLCHAINS: GCC

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-14
     env:
       JOB_TYPE: ANALYZE
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
       - uses: actions/checkout@v4
 
@@ -24,8 +25,6 @@ jobs:
         run: |
           brew install shellcheck
           python3 -m pip install pyyaml
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
 
       - name: CI Bootstrap
         run: |

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -13,7 +13,8 @@ env:
 jobs:
   analyze-shell-scripts:
     name: Shell Scripts
-    runs-on: macos-latest
+    # See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source
+    runs-on: macos-14
     env:
       JOB_TYPE: ANALYZE
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ env:
 jobs:
   build-macos:
     name: macOS XCODE5
-    runs-on: macos-13
+    # See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source
+    runs-on: macos-14
     env:
       JOB_TYPE: BUILD
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       JOB_TYPE: BUILD
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Add Linux Toolchain
         run: brew tap FiloSottile/homebrew-musl-cross
@@ -46,13 +46,13 @@ jobs:
       - run: ./build_oc.tool
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macOS XCODE5 Artifacts
           path: Binaries/*.zip
       - name: Upload to Release
         if: github.event_name == 'release'
-        uses: svenstaro/upload-release-action@e74ff71f7d8a4c4745b560a485cc5fdb9b5b999d
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: Binaries/*.zip
@@ -63,7 +63,7 @@ jobs:
     name: Linux CLANGPDB
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Docker in rootless mode.
         uses: ScribeMD/rootless-docker@0.2.2
@@ -79,7 +79,7 @@ jobs:
           TOOLCHAINS: CLANGPDB
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux CLANGPDB Artifacts
           path: Binaries/*.zip
@@ -88,7 +88,7 @@ jobs:
     name: Linux GCC
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Docker in rootless mode.
         uses: ScribeMD/rootless-docker@0.2.2
@@ -104,7 +104,7 @@ jobs:
           TOOLCHAINS: GCC
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux GCC Artifacts
           path: Binaries/*.zip
@@ -113,7 +113,7 @@ jobs:
     name: Linux CLANGDWARF
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Docker in rootless mode.
         uses: ScribeMD/rootless-docker@0.2.2
@@ -129,7 +129,7 @@ jobs:
           TOOLCHAINS: CLANGDWARF
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux CLANGDWARF Artifacts
           path: Binaries/*.zip
@@ -138,7 +138,7 @@ jobs:
     name: Linux Docs
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Docker in rootless mode.
         uses: ScribeMD/rootless-docker@0.2.2
@@ -156,7 +156,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |
@@ -170,7 +170,7 @@ jobs:
       - run: ./build_oc.tool
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Artifacts
           path: Binaries/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Add Linux Toolchain
-        run: brew tap FiloSottile/homebrew-musl-cross
-
       - name: Install Linux Toolchain
-        run: brew install musl-cross
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_AUTO_UPDATE: 1
+        run: |
+          brew tap FiloSottile/homebrew-musl-cross
+          brew install musl-cross
 
       - name: Install Dependencies
         run: brew install openssl mingw-w64
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-          HOMEBREW_NO_AUTO_UPDATE: 1
 
       - name: CI Bootstrap
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
 
   build-linux-clangpdb:
     name: Linux CLANGPDB
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -87,7 +87,7 @@ jobs:
 
   build-linux-gcc5:
     name: Linux GCC
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -112,7 +112,7 @@ jobs:
 
   build-linux-clangdwarf:
     name: Linux CLANGDWARF
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -137,7 +137,7 @@ jobs:
 
   build-linux-docs:
     name: Linux Docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           path: Binaries/*.zip
       - name: Upload to Release
         if: github.event_name == 'release'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2.9.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: Binaries/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
 
   build-linux-clangpdb:
     name: Linux CLANGPDB
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -83,7 +83,7 @@ jobs:
 
   build-linux-gcc5:
     name: Linux GCC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -108,7 +108,7 @@ jobs:
 
   build-linux-clangdwarf:
     name: Linux CLANGDWARF
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -133,7 +133,7 @@ jobs:
 
   build-linux-docs:
     name: Linux Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,12 @@ jobs:
     runs-on: macos-14
     env:
       JOB_TYPE: BUILD
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Linux Toolchain
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-          HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           brew tap FiloSottile/homebrew-musl-cross
           brew install musl-cross
@@ -59,6 +58,8 @@ jobs:
   build-linux-clangpdb:
     name: Linux CLANGPDB
     runs-on: ubuntu-22.04
+    env:
+      TOOLCHAINS: CLANGPDB
     steps:
       - uses: actions/checkout@v4
 
@@ -67,13 +68,9 @@ jobs:
 
       - name: ./build_duet.tool
         run: docker compose run build-duet
-        env:
-          TOOLCHAINS: CLANGPDB
 
       - name: ./build_oc.tool
         run: docker compose run build-oc
-        env:
-          TOOLCHAINS: CLANGPDB
 
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v4
@@ -84,6 +81,8 @@ jobs:
   build-linux-gcc5:
     name: Linux GCC
     runs-on: ubuntu-22.04
+    env:
+      TOOLCHAINS: GCC
     steps:
       - uses: actions/checkout@v4
 
@@ -92,13 +91,9 @@ jobs:
 
       - name: ./build_duet.tool
         run: docker compose run build-duet
-        env:
-          TOOLCHAINS: GCC
 
       - name: ./build_oc.tool
         run: docker compose run build-oc
-        env:
-          TOOLCHAINS: GCC
 
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v4
@@ -109,6 +104,8 @@ jobs:
   build-linux-clangdwarf:
     name: Linux CLANGDWARF
     runs-on: ubuntu-22.04
+    env:
+      TOOLCHAINS: CLANGDWARF
     steps:
       - uses: actions/checkout@v4
 
@@ -117,13 +114,9 @@ jobs:
 
       - name: ./build_duet.tool
         run: docker compose run build-duet
-        env:
-          TOOLCHAINS: CLANGDWARF
 
       - name: ./build_oc.tool
         run: docker compose run build-oc
-        env:
-          TOOLCHAINS: CLANGDWARF
 
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   analyze-uncrustify:
     name: Check Codestyle
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   analyze-uncrustify:
     name: Check Codestyle
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check Codestyle
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |
@@ -32,7 +32,7 @@ jobs:
           python3 -c "$(/usr/bin/curl https://raw.githubusercontent.com/acidanthera/ocbuild/master/uncstrap/uncstrap.py)" ./Uncrustify.yml || exit 1
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Uncrustify Artifacts


### PR DESCRIPTION
- Bump GH actions, old ones based on Node 16 are deprecated.
- Use Apple silicon images, this will speed up builds on Mac, see https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source
- Merge steps.
- ~~Switch back to ubuntu-latest, now it's `22.04`.~~
- Reuse env variables.