### PR TITLE
OpenDuet: Debug updates

### DIFF
--- a/OpenDuetPkg.dsc
+++ b/OpenDuetPkg.dsc
@@ -112,9 +112,16 @@
   OcStringLib|OpenCorePkg/Library/OcStringLib/OcStringLib.inf
   #
   # To save size, use NULL library for DebugLib and ReportStatusCodeLib.
-  # If need status code output, do library instance overriden.
+  # If need status code output, do library instance override.
   #
+!if ($(TARGET) == NOOPT)
+  #
+  # NOOPT equivalent to DEBUG_ON_SERIAL_PORT in OvmfPkg.
+  #
+  DebugLib|OpenCorePkg/Library/OcDebugLibSerial/OcDebugLibSerial.inf
+!else
   DebugLib|OpenCorePkg/Library/OcDebugLibNull/OcDebugLibNull.inf
+!endif
   DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
 
@@ -256,9 +263,19 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize|0x10000
   gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize|0x10000
+!if ($(TARGET) == NOOPT)
+  # DEBUG_ASSERT_ENABLED | DEBUG_PRINT_ENABLED | DEBUG_CODE_ENABLED | CLEAR_MEMORY_ENABLED | ASSERT_DEADLOOP_ENABLED
+  ##gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x2f
+  # DEBUG_PRINT_ENABLED | DEBUG_CODE_ENABLED | CLEAR_MEMORY_ENABLED | ASSERT_DEADLOOP_ENABLED
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x2e
+  # DEBUG_ERROR | DEBUG_WARN | DEBUG_INFO
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000042
+  gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel|0x80000042
+!else
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x0
   gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel|0x0
+!endif
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x0
   gOpenCorePkgTokenSpaceGuid.PcdCanaryAllowRdtscFallback|TRUE
   gEfiMdePkgTokenSpaceGuid.PcdUefiImageFormatSupportFv|0x02
@@ -279,7 +296,7 @@
   MSFT:DEBUG_*_*_CC_FLAGS    = -D OC_TARGET_RELEASE=1 /FAcs -Dinline=__inline -DMDEPKG_NDEBUG /GS /kernel
   MSFT:RELEASE_*_*_CC_FLAGS  = -D OC_TARGET_RELEASE=1 /FAcs -Dinline=__inline -DMDEPKG_NDEBUG /GS /kernel
 
-  XCODE:NOOPT_*_*_CC_FLAGS   = -D OC_TARGET_RELEASE=1 -fno-unwind-tables -O0 -fstack-protector-strong -ftrivial-auto-var-init=pattern
+  XCODE:NOOPT_*_*_CC_FLAGS   = -D OC_TARGET_RELEASE=1 -fno-unwind-tables -flto -Os -fstack-protector-strong -ftrivial-auto-var-init=pattern
   XCODE:DEBUG_*_*_CC_FLAGS   = -D OC_TARGET_RELEASE=1 -fno-unwind-tables -flto -Os -DMDEPKG_NDEBUG -fstack-protector-strong -ftrivial-auto-var-init=pattern
   XCODE:RELEASE_*_*_CC_FLAGS = -D OC_TARGET_RELEASE=1 -fno-unwind-tables -flto -Os -DMDEPKG_NDEBUG -fstack-protector-strong -ftrivial-auto-var-init=pattern
 

--- a/OpenDuetPkgDefines.fdf.inc
+++ b/OpenDuetPkgDefines.fdf.inc
@@ -14,7 +14,11 @@
 ##
 
   BlockSize          = 0x10000
-  NumBlocks          = 22
+!if ($(TARGET) == NOOPT)
+  NumBlocks          = 0x24       #GenFv image size 0x240000
+!else
+  NumBlocks          = 0xd        #GenFv image size 0xd0000
+!endif
   FvAlignment        = 16         #FV alignment and FV attributes setting.
   ERASE_POLARITY     = 1
   MEMORY_MAPPED      = TRUE

--- a/build_duet.tool
+++ b/build_duet.tool
@@ -176,7 +176,7 @@ if [ "${INTREE}" != "" ]; then
   imgbuild "${TARGETARCH}"
 else
   if [ "$TARGETS" = "" ]; then
-    TARGETS=(DEBUG RELEASE)
+    TARGETS=(DEBUG RELEASE NOOPT)
     export TARGETS
   fi
   if [ "$ARCHS" = "" ]; then


### PR DESCRIPTION
For reasons currently unknown, unoptimized Duet will not start in qemu (continually restarts, before any debugging output). However it seems potentially extremely useful to have a version of Duet which can be run in qemu with all debug output streaming to serial, and with ASSERTs enabled, once they can be. It seams reasonable to make NOOPT Duet permanently like this?