### PR TITLE
CrScreenshotDxe: Work around TPL-related ASSERT within firmware compiled to assert

### DIFF
--- a/Platform/CrScreenshotDxe/CrScreenshotDxe.c
+++ b/Platform/CrScreenshotDxe/CrScreenshotDxe.c
@@ -166,6 +166,16 @@ TakeScreenshot (
   UINTN                          Index;
   UINT8                          Temp;
 
+  //
+  // This is required to avoid assert (only noticeable on firmware compiled to
+  // assert) from gBS->RaiseTPL(TPL_CALLBACK) within the file system accesses
+  // below. Makes explicit what was happening anyway, which is that we're
+  // effectively lowering the TPL for a long running task, during a keyboard
+  // interrupt.
+  // REF: https://github.com/acidanthera/audk/blob/bcdcc4160d7460c46c08c9395aae81be44ef23a9/FatPkg/EnhancedFatDxe/Misc.c#L399
+  //
+  gBS->RestoreTPL (TPL_CALLBACK);
+
   Status = OcFindWritableOcFileSystem (&Fs);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "OCSCR: Can't find writable FS - %r\n", Status));


### PR DESCRIPTION
(such as recently updated DEBUG version of OpenDuet)