### PR TITLE
OcAfterBootCompatLib: Add `FixupAppleEfiImages`‎ quirk to debug output. Also fixed alphabetical order.

### DIFF
--- a/Include/Acidanthera/Library/OcAfterBootCompatLib.h
+++ b/Include/Acidanthera/Library/OcAfterBootCompatLib.h
@@ -184,6 +184,10 @@ typedef struct OC_ABC_SETTINGS_ {
   ///
   BOOLEAN                 ResizeUsePciRbIo;
   ///
+  /// Fix errors in early Mac OS X boot.efi images.
+  ///
+  BOOLEAN                 FixupAppleEfiImages;
+  ///
   /// Reduce GPU BARs for macOS to maximum supported version.
   ///
   INT8                    ResizeAppleGpuBars;

--- a/Library/OcAfterBootCompatLib/OcAfterBootCompatLib.c
+++ b/Library/OcAfterBootCompatLib/OcAfterBootCompatLib.c
@@ -112,33 +112,34 @@ OcAbcInitialize (
 
   DEBUG ((
     DEBUG_INFO,
-    "OCABC: ALRBL %d RTDFRG %d DEVMMIO %d NOSU %d NOVRWR %d NOSB %d FBSIG %d NOHBMAP %d SMSLIDE %d WRUNPROT %d\n",
+    "OCABC: ALRBL %d RTDFRG %d DEVMMIO %d NOSU %d NOVRWR %d NOHBMAP %d SMSLIDE %d WRUNPROT %d FXAPPLIMG %d FBSIG %d FEXITBS %d\n",
     Settings->AllowRelocationBlock,
     Settings->AvoidRuntimeDefrag,
     Settings->DevirtualiseMmio,
     Settings->DisableSingleUser,
     Settings->DisableVariableWrite,
-    Settings->ProtectSecureBoot,
-    Settings->ForceBooterSignature,
     Settings->DiscardHibernateMap,
     Settings->EnableSafeModeSlide,
-    Settings->EnableWriteUnprotector
+    Settings->EnableWriteUnprotector,
+    Settings->FixupAppleEfiImages,
+    Settings->ForceBooterSignature,
+    Settings->ForceExitBootServices
     ));
 
   DEBUG ((
     DEBUG_INFO,
-    "OCABC: FEXITBS %d PRMRG %d CSLIDE %d MSLIDE %d PRSRV %d RBMAP %d VMAP %d APPLOS %d RTPERMS %d ARBAR %d RBIO %d\n",
-    Settings->ForceExitBootServices,
+    "OCABC: PRMRG %d NOSB %d PRSRV %d CSLIDE %d MSLIDE %d RBMAP %d ARBAR %d RBIO %d VMAP %d APPLOS %d RTPERMS %d\n",
     Settings->ProtectMemoryRegions,
+    Settings->ProtectSecureBoot,
+    Settings->ProtectUefiServices,
     Settings->ProvideCustomSlide,
     Settings->ProvideMaxSlide,
-    Settings->ProtectUefiServices,
     Settings->RebuildAppleMemoryMap,
+    Settings->ResizeAppleGpuBars,
+    Settings->ResizeUsePciRbIo,
     Settings->SetupVirtualMap,
     Settings->SignalAppleOS,
-    Settings->SyncRuntimePermissions,
-    Settings->ResizeAppleGpuBars,
-    Settings->ResizeUsePciRbIo
+    Settings->SyncRuntimePermissions
     ));
 
   DEBUG_CODE_BEGIN ();

--- a/Library/OcMainLib/OpenCoreUefi.c
+++ b/Library/OcMainLib/OpenCoreUefi.c
@@ -697,6 +697,7 @@ OcLoadBooterUefiSupport (
   AbcSettings.AllowRelocationBlock   = Config->Booter.Quirks.AllowRelocationBlock;
   AbcSettings.EnableSafeModeSlide    = Config->Booter.Quirks.EnableSafeModeSlide;
   AbcSettings.EnableWriteUnprotector = Config->Booter.Quirks.EnableWriteUnprotector;
+  AbcSettings.FixupAppleEfiImages    = Config->Booter.Quirks.FixupAppleEfiImages;
   AbcSettings.ForceExitBootServices  = Config->Booter.Quirks.ForceExitBootServices;
   AbcSettings.ForceBooterSignature   = Config->Booter.Quirks.ForceBooterSignature;
   CopyMem (AbcSettings.BooterSignature, Signature, sizeof (AbcSettings.BooterSignature));


### PR DESCRIPTION
When I was reading the OC debug file I found `FixupAppleEfiImages` quirk was missing. Then, I fixed the alphabetical order of some entries, to follow the Sample.plist file.

[opencore-2024-05-15-082116.txt](https://github.com/acidanthera/OpenCorePkg/files/15319718/opencore-2024-05-15-082116.txt)
