### PR TITLE
Go back to macos-latest

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -13,8 +13,7 @@ env:
 jobs:
   analyze-shell-scripts:
     name: Shell Scripts
-    # See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source
-    runs-on: macos-14
+    runs-on: macos-latest
     env:
       JOB_TYPE: ANALYZE
       HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,7 @@ env:
 jobs:
   build-macos:
     name: macOS XCODE5
-    # See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source
-    runs-on: macos-14
+    runs-on: macos-latest
     env:
       JOB_TYPE: BUILD
       HOMEBREW_NO_INSTALL_CLEANUP: 1


### PR DESCRIPTION
Now macos-latest is moved to Arm64.

See https://github.com/actions/runner-images?tab=readme-ov-file#available-images.

Follow up #526.