### PR TITLE
OcBootManagementLib: Revert changes to fat slice secure boot logic from 125d8e8df36bd7ca12085d9670dca9060cf49c76

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ OpenCore Changelog
 - Added support for manual build of i386/x64 10.6+ versions of userspace tools via `FATBIN32=1 make`
 - Disabled `XcpmExtraMsrs MSR_MISC_PWR_MGMT` patch on macOS 12+ due to non-existence
 - Fixed `ThirdPartyDrives` quirk on macOS 14.4 and above
+- Resolved issue booting recovery for OS X 10.8 and earlier since 0.9.7
 
 #### v1.0.0
 - Updated builtin firmware versions for SMBIOS and the rest

--- a/Library/OcBootManagementLib/ImageLoader.c
+++ b/Library/OcBootManagementLib/ImageLoader.c
@@ -969,7 +969,7 @@ InternalEfiLoadImage (
   // Load the image ourselves in secure boot mode.
   //
   if (SecureBootStatus == EFI_SUCCESS) {
-    if ((SourceBuffer != NULL) && (OcImageLoaderCaps == NULL)) {
+    if (SourceBuffer != NULL) {
       Status = OcImageLoaderLoad (
                  FALSE,
                  ParentImageHandle,
@@ -980,10 +980,16 @@ InternalEfiLoadImage (
                  );
     } else {
       //
-      // We verified the image, but contained garbage, or we are trying to secure boot a Fat slice.
-      // This should not happen.
+      // SecureBootStatus can be EFI_SUCCESS without a signature being
+      // verified, if SecureBootModel is Disabled and the boot file is from
+      // a DMG. This effectively just means: no more SB checks required, use
+      // our loader.
+      // SourceBuffer will be NULL if filtering for supported architecture
+      // failed.
+      // All this can't happen in a secure boot chain, and should not happen
+      // (with valid boot files) in a non-secure boot chain. But if it does,
+      // just abort.
       //
-      ASSERT (FALSE);
       Status = EFI_UNSUPPORTED;
     }
   } else {


### PR DESCRIPTION
Note: EFI_SUCCESS does not always mean a signature was found and verified (which cannot happen for a fat slice), but simply that no further verification of SB status is required and OC image loader should be used.

Resolves: https://github.com/acidanthera/bugtracker/issues/2414