### PR TITLE
macrecovery: Fix ValueError

### DIFF
--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -44,6 +44,8 @@ INFO_SIGN_HASH = 'CH'
 INFO_SIGN_SESS = 'CT'
 INFO_REQURED = [INFO_PRODUCT, INFO_IMAGE_LINK, INFO_IMAGE_HASH, INFO_IMAGE_SESS, INFO_SIGN_LINK, INFO_SIGN_HASH, INFO_SIGN_SESS]
 
+# Use -2 for better resize stability on Windows
+TERMINAL_MARGIN = 2
 
 def run_query(url, headers, post=None, raw=False):
     if post is not None:
@@ -223,10 +225,9 @@ def save_image(url, sess, filename='', directory=''):
                 break
             fh.write(chunk)
             size += len(chunk)
-            terminalsize = os.get_terminal_size().columns
+            terminalsize = max(os.get_terminal_size().columns - TERMINAL_MARGIN, 0)
             if oldterminalsize != terminalsize:
-                # Use -2 for better resize stability on Windows
-                print(f'\r{"":<{terminalsize - 2}}', end='')
+                print(f'\r{"":<{terminalsize}}', end='')
                 oldterminalsize = terminalsize
             if totalsize > 0:
                 progress = size / totalsize
@@ -249,9 +250,7 @@ def verify_image(dmgpath, cnkpath):
 
     with open(dmgpath, 'rb') as dmgf:
         for cnkcount, (cnksize, cnkhash) in enumerate(verify_chunklist(cnkpath), 1):
-            terminalsize = os.get_terminal_size().columns
-            if terminalsize >= 2:
-                terminalsize -= 2
+            terminalsize = max(os.get_terminal_size().columns - TERMINAL_MARGIN, 0)
             print(f'\r{f"Chunk {cnkcount} ({cnksize} bytes)":<{terminalsize}}', end='')
             sys.stdout.flush()
             cnk = dmgf.read(cnksize)


### PR DESCRIPTION
When running the script in a builder, I was getting the error that `Image verification failed. (Sign not allowed in string format specifier)`. If `os.get_terminal_size().columns` is less than 2 then the align left padding has a negative value, giving the error `ValueError: Sign not allowed in string format specifier`. I just added a check before the value's use to ensure that it isn't negative.