### PR TITLE
OcBootManagementLib: Convert naming from External System Boot to Unmanaged Boot

### DIFF
--- a/Include/Acidanthera/Library/OcBootManagementLib.h
+++ b/Include/Acidanthera/Library/OcBootManagementLib.h
@@ -157,7 +157,7 @@ typedef UINT32 OC_BOOT_ENTRY_TYPE;
 #define OC_BOOT_EXTERNAL_OS         BIT6
 #define OC_BOOT_EXTERNAL_TOOL       BIT7
 #define OC_BOOT_SYSTEM              BIT8
-#define OC_BOOT_EXTERNAL_SYSTEM     BIT9
+#define OC_BOOT_UNMANAGED           BIT9
 
 /**
   Picker mode.
@@ -200,21 +200,21 @@ EFI_STATUS
   );
 
 /**
-  Action to perform as part of executing an external boot system boot entry.
+  Action to perform as part of executing an unmanaged boot entry.
 **/
 typedef
 EFI_STATUS
-(*OC_BOOT_EXTERNAL_SYSTEM_ACTION) (
+(*OC_BOOT_UNMANAGED_ACTION) (
   IN OUT  OC_PICKER_CONTEXT         *PickerContext,
   IN      EFI_DEVICE_PATH_PROTOCOL  *DevicePath
   );
 
 /**
-  Gets Device Path for external boot system boot entry.
+  Get Device Path for unmanaged boot entry.
 **/
 typedef
 EFI_STATUS
-(*OC_BOOT_EXTERNAL_SYSTEM_GET_DP) (
+(*OC_BOOT_UNMANAGED_GET_FINAL_DP) (
   IN OUT  OC_PICKER_CONTEXT         *PickerContext,
   IN OUT  EFI_DEVICE_PATH_PROTOCOL  **DevicePath
   );
@@ -238,13 +238,13 @@ typedef struct OC_BOOT_ENTRY_ {
   //
   OC_BOOT_SYSTEM_ACTION             SystemAction;
   //
-  // Action to perform on execution. Only valid for external boot system entries.
+  // Action to perform on execution. Only valid for unmanaged boot entries.
   //
-  OC_BOOT_EXTERNAL_SYSTEM_ACTION    ExternalSystemAction;
+  OC_BOOT_UNMANAGED_ACTION          UnmanagedBootAction;
   //
-  // Gets Device Path for external boot system boot entry. Only valid for external boot system entries.
+  // Get final Device Path for boot entry. Only valid for unmanaged boot entries.
   //
-  OC_BOOT_EXTERNAL_SYSTEM_GET_DP    ExternalSystemGetDevicePath;
+  OC_BOOT_UNMANAGED_GET_FINAL_DP    UnmanagedBootGetFinalDevicePath;
   //
   // Id under which to save entry as default.
   //
@@ -642,17 +642,17 @@ typedef struct {
   //
   CHAR8                             *AudioBaseType;
   //
-  // External boot system action. Boot Entry Protocol only. Optional.
+  // Unmanaged boot action. Boot Entry Protocol unmanaged boot entries only.
   //
-  OC_BOOT_EXTERNAL_SYSTEM_ACTION    ExternalSystemAction;
+  OC_BOOT_UNMANAGED_ACTION          UnmanagedBootAction;
   //
-  // Gets Device Path for external boot system boot entry. Boot Entry Protocol only. Optional.
+  // Get final Device Path for unmanaged boot entry. Boot Entry Protocol unmanaged boot entries only.
   //
-  OC_BOOT_EXTERNAL_SYSTEM_GET_DP    ExternalSystemGetDevicePath;
+  OC_BOOT_UNMANAGED_GET_FINAL_DP    UnmanagedBootGetFinalDevicePath;
   //
-  // External boot system Device Path. Boot Entry Protocol only. Optional.
+  // Unmanaged boot Device Path. Boot Entry Protocol unmanaged boot entries only.
   //
-  EFI_DEVICE_PATH_PROTOCOL          *ExternalSystemDevicePath;
+  EFI_DEVICE_PATH_PROTOCOL          *UnmanagedBootDevicePath;
   //
   // Whether this entry should be labeled as external to the system. Boot Entry Protocol only. Optional.
   //

--- a/Library/OcBootManagementLib/DefaultEntryChoice.c
+++ b/Library/OcBootManagementLib/DefaultEntryChoice.c
@@ -795,7 +795,7 @@ OcSetDefaultBootEntry (
   UINTN            BootChosenIndex;
   UINTN            Index;
   UINTN            DevicePathSize;
-  UINTN            ExtSystemDevPathSize;
+  UINTN            UnmanagedBootDevPathSize;
   UINTN            LoadOptionSize;
   UINTN            LoadOptionIdSize;
   UINTN            LoadOptionNameSize;
@@ -805,7 +805,7 @@ OcSetDefaultBootEntry (
 
   CONST OC_CUSTOM_BOOT_DEVICE_PATH     *CustomDevPath;
   CONST OC_ENTRY_PROTOCOL_DEVICE_PATH  *EntryProtocolDevPath;
-  EFI_DEVICE_PATH_PROTOCOL             *ExtSystemDevPath;
+  EFI_DEVICE_PATH_PROTOCOL             *UnmanagedBootDevPath;
   VENDOR_DEVICE_PATH                   *DestCustomDevPath;
   FILEPATH_DEVICE_PATH                 *DestCustomEntryName;
   EFI_DEVICE_PATH_PROTOCOL             *DestCustomEndNode;
@@ -825,16 +825,16 @@ OcSetDefaultBootEntry (
   }
 
   //
-  // Get final device path for external boot system entries.
+  // Get final device path for unmanaged boot entries.
   //
-  ExtSystemDevPath = NULL;
-  if ((Entry->Type == OC_BOOT_EXTERNAL_SYSTEM) && (Entry->ExternalSystemGetDevicePath != NULL)) {
-    ExtSystemDevPath = Entry->DevicePath;
-    Status           = Entry->ExternalSystemGetDevicePath (Context, &ExtSystemDevPath);
+  UnmanagedBootDevPath = NULL;
+  if ((Entry->Type == OC_BOOT_UNMANAGED) && (Entry->UnmanagedBootGetFinalDevicePath != NULL)) {
+    UnmanagedBootDevPath = Entry->DevicePath;
+    Status               = Entry->UnmanagedBootGetFinalDevicePath (Context, &UnmanagedBootDevPath);
     if (EFI_ERROR (Status)) {
-      ExtSystemDevPath = NULL;
+      UnmanagedBootDevPath = NULL;
     } else {
-      ExtSystemDevPathSize = GetDevicePathSize (ExtSystemDevPath);
+      UnmanagedBootDevPathSize = GetDevicePathSize (UnmanagedBootDevPath);
     }
   }
 
@@ -890,10 +890,10 @@ OcSetDefaultBootEntry (
       continue;
     }
 
-    if (ExtSystemDevPath != NULL) {
+    if (UnmanagedBootDevPath != NULL) {
       DevicePathSize = GetDevicePathSize (BootOptionDevicePath);
-      if (DevicePathSize >= ExtSystemDevPathSize) {
-        MatchedEntry = CompareMem (BootOptionDevicePath, ExtSystemDevPath, ExtSystemDevPathSize) == 0;
+      if (DevicePathSize >= UnmanagedBootDevPathSize) {
+        MatchedEntry = CompareMem (BootOptionDevicePath, UnmanagedBootDevPath, UnmanagedBootDevPathSize) == 0;
       }
     } else {
       BootOptionRemainingDevicePath = BootOptionDevicePath;
@@ -973,8 +973,8 @@ OcSetDefaultBootEntry (
       }
     }
 
-    if (ExtSystemDevPath != NULL) {
-      DevicePathSize = ExtSystemDevPathSize;
+    if (UnmanagedBootDevPath != NULL) {
+      DevicePathSize = UnmanagedBootDevPathSize;
     } else if (!Entry->IsCustom) {
       DevicePathSize = GetDevicePathSize (Entry->DevicePath);
     } else {
@@ -1021,8 +1021,8 @@ OcSetDefaultBootEntry (
       CopyMem (LoadOption + 1, LoadOptionName, LoadOptionNameSize);
     }
 
-    if (ExtSystemDevPath != NULL) {
-      CopyMem ((UINT8 *)(LoadOption + 1) + LoadOptionNameSize, ExtSystemDevPath, DevicePathSize);
+    if (UnmanagedBootDevPath != NULL) {
+      CopyMem ((UINT8 *)(LoadOption + 1) + LoadOptionNameSize, UnmanagedBootDevPath, DevicePathSize);
     } else if (!Entry->IsCustom) {
       CopyMem ((UINT8 *)(LoadOption + 1) + LoadOptionNameSize, Entry->DevicePath, DevicePathSize);
     } else {
@@ -1084,9 +1084,9 @@ OcSetDefaultBootEntry (
 
     FreePool (LoadOption);
 
-    if (ExtSystemDevPath != NULL) {
-      FreePool (ExtSystemDevPath);
-      ExtSystemDevPath = NULL;
+    if (UnmanagedBootDevPath != NULL) {
+      FreePool (UnmanagedBootDevPath);
+      UnmanagedBootDevPath = NULL;
     }
 
     if (EFI_ERROR (Status)) {
@@ -1547,7 +1547,7 @@ InternalLoadBootEntry (
   //
   // System entries are not loaded but called directly.
   //
-  ASSERT ((BootEntry->Type & OC_BOOT_EXTERNAL_SYSTEM) == 0);
+  ASSERT ((BootEntry->Type & OC_BOOT_UNMANAGED) == 0);
   ASSERT ((BootEntry->Type & OC_BOOT_SYSTEM) == 0);
   ASSERT (Context != NULL);
   ASSERT (DmgLoadContext != NULL);

--- a/Platform/OpenCanopy/Views/BootPicker.c
+++ b/Platform/OpenCanopy/Views/BootPicker.c
@@ -1495,7 +1495,7 @@ BootPickerEntriesSet (
         }
 
         break;
-      case OC_BOOT_EXTERNAL_SYSTEM:
+      case OC_BOOT_UNMANAGED:
         if (OcAsciiStriStr (Entry->Flavour, OC_FLAVOUR_WINDOWS) != NULL) {
           Status = CopyLabel (&VolumeEntry->Label, &GuiContext->Labels[LABEL_WINDOWS]);
         } else {

--- a/Platform/OpenLegacyBoot/OpenLegacyBoot.c
+++ b/Platform/OpenLegacyBoot/OpenLegacyBoot.c
@@ -110,7 +110,7 @@ FreePickerEntry (
 
 STATIC
 EFI_STATUS
-ExternalSystemActionDoLegacyBoot (
+UnmanagedBootActionDoLegacyBoot (
   IN OUT  OC_PICKER_CONTEXT         *PickerContext,
   IN      EFI_DEVICE_PATH_PROTOCOL  *DevicePath
   )
@@ -211,7 +211,7 @@ ExternalSystemActionDoLegacyBoot (
 
 STATIC
 EFI_STATUS
-ExternalSystemGetDevicePath (
+UnmanagedBootGetFinalDevicePath (
   IN OUT  OC_PICKER_CONTEXT         *PickerContext,
   IN OUT  EFI_DEVICE_PATH_PROTOCOL  **DevicePath
   )
@@ -416,17 +416,17 @@ OcGetLegacyBootEntries (
       PickerEntry->Name = GetLegacyEntryName (LegacyOsType);
     }
 
-    PickerEntry->Id                          = AsciiDevicePath;
-    PickerEntry->Path                        = NULL;
-    PickerEntry->Arguments                   = NULL;
-    PickerEntry->Flavour                     = GetLegacyEntryFlavour (LegacyOsType);
-    PickerEntry->Tool                        = FALSE;
-    PickerEntry->TextMode                    = FALSE;
-    PickerEntry->RealPath                    = FALSE;
-    PickerEntry->External                    = IsExternal;
-    PickerEntry->ExternalSystemAction        = ExternalSystemActionDoLegacyBoot;
-    PickerEntry->ExternalSystemGetDevicePath = ExternalSystemGetDevicePath;
-    PickerEntry->ExternalSystemDevicePath    = BlockDevicePath;
+    PickerEntry->Id                              = AsciiDevicePath;
+    PickerEntry->Path                            = NULL;
+    PickerEntry->Arguments                       = NULL;
+    PickerEntry->Flavour                         = GetLegacyEntryFlavour (LegacyOsType);
+    PickerEntry->Tool                            = FALSE;
+    PickerEntry->TextMode                        = FALSE;
+    PickerEntry->RealPath                        = FALSE;
+    PickerEntry->External                        = IsExternal;
+    PickerEntry->UnmanagedBootAction             = UnmanagedBootActionDoLegacyBoot;
+    PickerEntry->UnmanagedBootGetFinalDevicePath = UnmanagedBootGetFinalDevicePath;
+    PickerEntry->UnmanagedBootDevicePath         = BlockDevicePath;
 
     if ((PickerEntry->Name == NULL) || (PickerEntry->Flavour == NULL)) {
       OcFlexArrayFree (&FlexPickerEntries);


### PR DESCRIPTION
External is already used for:

 - External picker (as opposed to builtin)
 - External file system (as in, which icon to show in Canopy, or whether to mark entry “ (external)” in builtin picker)
 - External Tool (user defined tool)
 - External OS (user defined entry; it is also used for entries from boot entry protocol*)
 - External Boot System

This PR suggests changing the last one to Unmanaged Boot This is a PR split off from https://github.com/acidanthera/OpenCorePkg/pull/549. I found it easier to work on that after these changes, which is why it was included in there in the first place.

**EDIT**: See additional explanation in comment below.

(*I only spotted this starred point while separating out this PR. I wonder if these should really have been Other OS instead of External OS all along? Like non-macOS, non-Windows blessed entries?)