### PR TITLE
Add support for AMD_CPU_EXT_FAMILY_1AH

### DIFF
--- a/Include/Intel/IndustryStandard/ProcessorInfo.h
+++ b/Include/Intel/IndustryStandard/ProcessorInfo.h
@@ -258,6 +258,7 @@ typedef enum {
 #define AMD_CPU_EXT_FAMILY_16H  0x7
 #define AMD_CPU_EXT_FAMILY_17H  0x8
 #define AMD_CPU_EXT_FAMILY_19H  0xA
+#define AMD_CPU_EXT_FAMILY_1AH  0x1A
 
 // CPU_P_STATE_COORDINATION
 /// P-State Coordination

--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1651,8 +1651,7 @@ PatchProvideCurrentCpuInfo (
     busFreqValue = CpuInfo->FSBFrequency;
 
     // Handle case where FSBFrequency is zero, providing a fallback
-    if (busFreqValue == 0)
-    {
+    if (busFreqValue == 0) {
       busFreqValue = 100000000; // Assume 100 MHz FSB as fallback
       DEBUG ((DEBUG_WARN, "OCAK: FSBFrequency is zero, using fallback value: 100 MHz\n"));
     }
@@ -1660,7 +1659,7 @@ PatchProvideCurrentCpuInfo (
     busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
     busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
 
-    tscFreqValue = CpuInfo->CPUFrequency;
+    tscFreqValue    = CpuInfo->CPUFrequency;
     tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
     tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), tscFCvtt2nValue, NULL);
   }

--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1654,7 +1654,28 @@ PatchProvideCurrentCpuInfo (
 
     tscFreqValue    = CpuInfo->CPUFrequency;
     tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
-    tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL  << 32), tscFCvtt2nValue, NULL);
+    tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), tscFCvtt2nValue, NULL);
+
+  } else if (CpuInfo->ExtFamily == 0xB) {
+
+    // Family 1Ah has different handling: no divisor (DID)
+    busFreqValue = CpuInfo->FSBFrequency;
+
+    // Handle case where FSBFrequency is zero, providing a fallback
+    if (busFreqValue == 0) {
+      busFreqValue = 100000000; // Assume 100 MHz FSB as fallback
+      DEBUG ((DEBUG_WARN, "OCAK: FSBFrequency is zero, using fallback value: 100 MHz\n"));
+    }
+
+    // Calculate bus FCvtt2n and FCvtn2t values
+    busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
+    busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
+
+    // Get TSC frequency and calculate TSC FCvtt2n and FCvtn2t values
+    tscFreqValue = CpuInfo->CPUFrequency;
+
+    tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
+    tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), tscFCvtt2nValue, NULL);
   }
   // For all other processors
   else {

--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1646,34 +1646,21 @@ PatchProvideCurrentCpuInfo (
   // Perform TSC and FSB calculations. This is traditionally done in tsc.c in XNU.
   //
   // For AMD Processors
-  if ((CpuInfo->Family == 0xF) && ((CpuInfo->ExtFamily == 0x8) || (CpuInfo->ExtFamily == 0xA))) {
+  if ((CpuInfo->Family == 0xF) && ((CpuInfo->ExtFamily == 0x8) || (CpuInfo->ExtFamily == 0xA) || (CpuInfo->ExtFamily == 0xB))) {
     DEBUG ((DEBUG_INFO, "OCAK: Setting FSB and TSC for Family 0x%x and ExtFamily 0x%x\n", (UINT16)CpuInfo->Family, (UINT16)CpuInfo->ExtFamily));
-    busFreqValue    = CpuInfo->FSBFrequency;
-    busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
-    busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
-
-    tscFreqValue    = CpuInfo->CPUFrequency;
-    tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
-    tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), tscFCvtt2nValue, NULL);
-
-  } else if (CpuInfo->ExtFamily == 0xB) {
-
-    // Family 1Ah has different handling: no divisor (DID)
     busFreqValue = CpuInfo->FSBFrequency;
 
     // Handle case where FSBFrequency is zero, providing a fallback
-    if (busFreqValue == 0) {
+    if (busFreqValue == 0)
+    {
       busFreqValue = 100000000; // Assume 100 MHz FSB as fallback
       DEBUG ((DEBUG_WARN, "OCAK: FSBFrequency is zero, using fallback value: 100 MHz\n"));
     }
 
-    // Calculate bus FCvtt2n and FCvtn2t values
     busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
     busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
 
-    // Get TSC frequency and calculate TSC FCvtt2n and FCvtn2t values
     tscFreqValue = CpuInfo->CPUFrequency;
-
     tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
     tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), tscFCvtt2nValue, NULL);
   }

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -692,9 +692,9 @@ ScanAmdProcessor (
     switch (Cpu->ExtFamily) {
       case AMD_CPU_EXT_FAMILY_1AH:
         if (Cpu->CPUFrequencyFromVMT == 0) {
-          CofVid          = AsmReadMsr64(K10_PSTATE_STATUS);
-          CoreFrequencyID = (UINT16)BitFieldRead64(CofVid, 0, 11); // 12-bit field for FID
-          
+          CofVid          = AsmReadMsr64 (K10_PSTATE_STATUS);
+          CoreFrequencyID = (UINT16)BitFieldRead64 (CofVid, 0, 11); // 12-bit field for FID
+
           // On AMD Family 1Ah and later, if the Frequency ID (FID) exceeds 0x0f,
           // the core frequency is scaled by a factor of 5. This scaling behavior
           // is based on Linux kernel logic for handling higher frequency multipliers
@@ -703,19 +703,21 @@ ScanAmdProcessor (
           if (CoreFrequencyID > 0x0f) {
             CoreFrequencyID *= 5;
           }
+
           MaxBusRatio = (UINT8)(CoreFrequencyID);
         }
-        
+
         //
         // Get core count from CPUID
         //
         if (Cpu->MaxExtId >= 0x8000001E) {
-          AsmCpuid(0x8000001E, NULL, &CpuidEbx, NULL, NULL);
-          Cpu->CoreCount = (UINT16)DivU64x32(
-                                 Cpu->ThreadCount,
-                                 (BitFieldRead32(CpuidEbx, 8, 15) + 1)
-                               );
+          AsmCpuid (0x8000001E, NULL, &CpuidEbx, NULL, NULL);
+          Cpu->CoreCount = (UINT16)DivU64x32 (
+                                     Cpu->ThreadCount,
+                                     (BitFieldRead32 (CpuidEbx, 8, 15) + 1)
+                                     );
         }
+
         break;
       case AMD_CPU_EXT_FAMILY_17H:
       case AMD_CPU_EXT_FAMILY_19H:
@@ -815,9 +817,9 @@ ScanAmdProcessor (
       } else {
         // Special handling for Family 1Ah
         if (Cpu->ExtFamily == AMD_CPU_EXT_FAMILY_1AH) {
-          Cpu->FSBFrequency = DivU64x32(Cpu->CPUFrequency, CoreFrequencyID);  // No divisor for Family 1Ah
+          Cpu->FSBFrequency = DivU64x32 (Cpu->CPUFrequency, CoreFrequencyID);  // No divisor for Family 1Ah
         } else {
-          Cpu->FSBFrequency = DivU64x32(Cpu->CPUFrequency, MaxBusRatio);
+          Cpu->FSBFrequency = DivU64x32 (Cpu->CPUFrequency, MaxBusRatio);
         }
       }
     }

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -693,7 +693,7 @@ ScanAmdProcessor (
       case AMD_CPU_EXT_FAMILY_1AH:
         if (Cpu->CPUFrequencyFromVMT == 0) {
           CofVid          = AsmReadMsr64 (K10_PSTATE_STATUS);
-          CoreFrequencyID = (UINT16)BitFieldRead64 (CofVid, 0, 11); // 12-bit field for FID
+          CoreFrequencyID = (UINT8)BitFieldRead64 (CofVid, 0, 11); // 12-bit field for FID
 
           // On AMD Family 1Ah and later, if the Frequency ID (FID) exceeds 0x0f,
           // the core frequency is scaled by a factor of 5. This scaling behavior
@@ -814,13 +814,10 @@ ScanAmdProcessor (
       //
       if (MaxBusRatio == 0) {
         Cpu->FSBFrequency = 100000000; // 100 MHz like Intel part.
+      } else if (Cpu->ExtFamily == AMD_CPU_EXT_FAMILY_1AH) {
+        Cpu->FSBFrequency = DivU64x32 (Cpu->CPUFrequency, CoreFrequencyID);  // No divisor for Family 1Ah
       } else {
-        // Special handling for Family 1Ah
-        if (Cpu->ExtFamily == AMD_CPU_EXT_FAMILY_1AH) {
-          Cpu->FSBFrequency = DivU64x32 (Cpu->CPUFrequency, CoreFrequencyID);  // No divisor for Family 1Ah
-        } else {
-          Cpu->FSBFrequency = DivU64x32 (Cpu->CPUFrequency, MaxBusRatio);
-        }
+        Cpu->FSBFrequency = DivU64x32 (Cpu->CPUFrequency, MaxBusRatio);
       }
     }
   }

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -690,6 +690,32 @@ ScanAmdProcessor (
     MaxBusRatio     = 0;
 
     switch (Cpu->ExtFamily) {
+      case AMD_CPU_EXT_FAMILY_1AH:
+        if (Cpu->CPUFrequencyFromVMT == 0) {
+          CofVid = AsmReadMsr64(K10_PSTATE_STATUS);
+          CoreFrequencyID = (UINT16)BitFieldRead64(CofVid, 0, 11);  // 12-bit field for FID
+          // On AMD Family 1Ah and later, if the Frequency ID (FID) exceeds 0x0f,
+          // the core frequency is scaled by a factor of 5. This scaling behavior
+          // is based on Linux kernel logic for handling higher frequency multipliers
+          // in newer AMD CPUs, where the FID no longer directly correlates to the
+          // bus ratio.
+          if (CoreFrequencyID > 0x0f) {
+            CoreFrequencyID *= 5;
+          }
+          MaxBusRatio = (UINT8)(CoreFrequencyID);
+        }
+        
+        //
+        // Get core count from CPUID
+        //
+        if (Cpu->MaxExtId >= 0x8000001E) {
+          AsmCpuid(0x8000001E, NULL, &CpuidEbx, NULL, NULL);
+          Cpu->CoreCount = (UINT16)DivU64x32(
+                                 Cpu->ThreadCount,
+                                 (BitFieldRead32(CpuidEbx, 8, 15) + 1)
+                               );
+        }
+        break;
       case AMD_CPU_EXT_FAMILY_17H:
       case AMD_CPU_EXT_FAMILY_19H:
         if (Cpu->CPUFrequencyFromVMT == 0) {
@@ -784,9 +810,14 @@ ScanAmdProcessor (
       // Sometimes incorrect hypervisor configuration will lead to dividing by zero.
       //
       if (MaxBusRatio == 0) {
-        Cpu->FSBFrequency = 100000000; // 100 MHz like Intel part.
+        Cpu->FSBFrequency = 100000000; // Default to 100 MHz like Intel part.
       } else {
-        Cpu->FSBFrequency = DivU64x32 (Cpu->CPUFrequency, MaxBusRatio);
+        // Special handling for Family 1Ah
+        if (Cpu->ExtFamily == AMD_CPU_EXT_FAMILY_1AH) {
+          Cpu->FSBFrequency = DivU64x32(Cpu->CPUFrequency, CoreFrequencyID);  // No divisor for Family 1Ah
+        } else {
+          Cpu->FSBFrequency = DivU64x32(Cpu->CPUFrequency, MaxBusRatio);
+        }
       }
     }
   }

--- a/Library/OcCpuLib/OcCpuLib.c
+++ b/Library/OcCpuLib/OcCpuLib.c
@@ -692,8 +692,9 @@ ScanAmdProcessor (
     switch (Cpu->ExtFamily) {
       case AMD_CPU_EXT_FAMILY_1AH:
         if (Cpu->CPUFrequencyFromVMT == 0) {
-          CofVid = AsmReadMsr64(K10_PSTATE_STATUS);
-          CoreFrequencyID = (UINT16)BitFieldRead64(CofVid, 0, 11);  // 12-bit field for FID
+          CofVid          = AsmReadMsr64(K10_PSTATE_STATUS);
+          CoreFrequencyID = (UINT16)BitFieldRead64(CofVid, 0, 11); // 12-bit field for FID
+          
           // On AMD Family 1Ah and later, if the Frequency ID (FID) exceeds 0x0f,
           // the core frequency is scaled by a factor of 5. This scaling behavior
           // is based on Linux kernel logic for handling higher frequency multipliers
@@ -810,7 +811,7 @@ ScanAmdProcessor (
       // Sometimes incorrect hypervisor configuration will lead to dividing by zero.
       //
       if (MaxBusRatio == 0) {
-        Cpu->FSBFrequency = 100000000; // Default to 100 MHz like Intel part.
+        Cpu->FSBFrequency = 100000000; // 100 MHz like Intel part.
       } else {
         // Special handling for Family 1Ah
         if (Cpu->ExtFamily == AMD_CPU_EXT_FAMILY_1AH) {


### PR DESCRIPTION
AMD 9000 Series CPUs have changed from Family 19h to 1Ah.

Tested and confirmed to boot.