### PR TITLE
OcBootManagementLib: Add Apple DP expansion for virtio blk

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ OpenCore Changelog
 - Enabled `XcpmExtraMsrs MSR_MISC_PWR_MGMT` patch back on macOS 12+
 - Fixed `XcpmExtraMsrs MSR_MISC_PWR_MGMT` patch on macOS 15
 - Added `UEFI` `Unload` option to unload existing firmware drivers
+- Fixed boot device selection with VirtIO disk drives used for macOS installations
 
 #### v1.0.1
 - Updated code and added progress bar to macrecovery, thx @soyeonswife63

--- a/Include/Acidanthera/Library/OcDevicePathLib.h
+++ b/Include/Acidanthera/Library/OcDevicePathLib.h
@@ -303,6 +303,8 @@ typedef struct {
                                  restore DevicePathNode's original content in
                                  the case of failure.
                                  On success, data may need to be freed.
+  @param[in]     ValidDevice     A device handle pointing to previous valid
+                                 device path if any.
 
   @retval -1  DevicePathNode could not be fixed.
   @retval 0   DevicePathNode was not modified and may be valid.
@@ -313,7 +315,8 @@ INTN
 OcFixAppleBootDevicePathNode (
   IN OUT EFI_DEVICE_PATH_PROTOCOL     **DevicePath,
   IN OUT EFI_DEVICE_PATH_PROTOCOL     **DevicePathNode,
-  OUT    APPLE_BOOT_DP_PATCH_CONTEXT  *RestoreContext OPTIONAL
+  OUT    APPLE_BOOT_DP_PATCH_CONTEXT  *RestoreContext OPTIONAL,
+  IN     EFI_HANDLE                   ValidDevice OPTIONAL
   );
 
 /**

--- a/Library/OcBootManagementLib/BootEntryManagement.c
+++ b/Library/OcBootManagementLib/BootEntryManagement.c
@@ -1459,6 +1459,7 @@ AddBootEntryFromBootOption (
       NumPatchedNodes = OcFixAppleBootDevicePathNode (
                           &DevicePath,
                           &RemainingDevicePath,
+                          NULL,
                           NULL
                           );
     } while (NumPatchedNodes > 0);


### PR DESCRIPTION
Apparently macOS strips down HD nodes from virtio blk devices leaving them "infix" shortened, i.e. PCI/APFS instead of PCI/HD/APFS.