### PR TITLE
Fix wrong definition for AMD_CPU_EXT_FAMILY_1AH

### DIFF
--- a/Include/Intel/IndustryStandard/ProcessorInfo.h
+++ b/Include/Intel/IndustryStandard/ProcessorInfo.h
@@ -258,7 +258,7 @@ typedef enum {
 #define AMD_CPU_EXT_FAMILY_16H  0x7
 #define AMD_CPU_EXT_FAMILY_17H  0x8
 #define AMD_CPU_EXT_FAMILY_19H  0xA
-#define AMD_CPU_EXT_FAMILY_1AH  0x1A
+#define AMD_CPU_EXT_FAMILY_1AH  0x0B
 
 // CPU_P_STATE_COORDINATION
 /// P-State Coordination

--- a/Include/Intel/IndustryStandard/ProcessorInfo.h
+++ b/Include/Intel/IndustryStandard/ProcessorInfo.h
@@ -258,7 +258,7 @@ typedef enum {
 #define AMD_CPU_EXT_FAMILY_16H  0x7
 #define AMD_CPU_EXT_FAMILY_17H  0x8
 #define AMD_CPU_EXT_FAMILY_19H  0xA
-#define AMD_CPU_EXT_FAMILY_1AH  0x0B
+#define AMD_CPU_EXT_FAMILY_1AH  0xB
 
 // CPU_P_STATE_COORDINATION
 /// P-State Coordination


### PR DESCRIPTION
Defined the CPU family wrong. This fixes it. 