### PR TITLE
ocvalidate: Prevent uint32 roll over if *FixedSize > OC_STORAGE_SAFE_PATH_MAX

### DIFF
--- a/Utilities/ocvalidate/ValidateKernel.c
+++ b/Utilities/ocvalidate/ValidateKernel.c
@@ -231,7 +231,7 @@ CheckKernelAdd (
         "Kernel->Add[%u]->ExecutablePath (length %u) is too long (should not exceed %u)!\n",
         Index,
         AsciiStrLen (ExecutablePath),
-        OC_STORAGE_SAFE_PATH_MAX - ExecutableFixedSize
+        ExecutableFixedSize > OC_STORAGE_SAFE_PATH_MAX ? 0 : OC_STORAGE_SAFE_PATH_MAX - ExecutableFixedSize
         ));
       ++ErrorCount;
     }
@@ -247,7 +247,7 @@ CheckKernelAdd (
         "Kernel->Add[%u]->PlistPath (length %u) is too long (should not exceed %u)!\n",
         Index,
         AsciiStrLen (PlistPath),
-        OC_STORAGE_SAFE_PATH_MAX - PlistFixedSize
+        PlistFixedSize > OC_STORAGE_SAFE_PATH_MAX ? 0 : OC_STORAGE_SAFE_PATH_MAX - PlistFixedSize
         ));
       ++ErrorCount;
     }


### PR DESCRIPTION
If the `BundlePath` is greater than `OC_STORAGE_SAFE_PATH_MAX`, then subtracting the `*FixedSize` will always result in a would-be negative number, which rolls the print statement's `should not exceed` value over to the uint32 max.

This commit uses `0` if `*FixedSize` is greater than `OC_STORAGE_SAFE_PATH_MAX`, or the difference of the two values.