### PR TITLE
Utilities: Silence additional zlib warning triggered by update to brew mingw-w64

### DIFF
--- a/User/SilenceZlibWarnings
+++ b/User/SilenceZlibWarnings
@@ -1,0 +1,15 @@
+## @file
+# Copyright (c) 2023-2025, PMheart, Mike Beaton. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+##
+
+#
+# Add additional flags to silence warnings for legacy code style in zlib.
+#
+ifeq ($(shell echo 'int a;' | "${CC}" -Wno-deprecated-non-prototype -x c -c - -o /dev/null 2>&1),)
+	CFLAGS += -Wno-deprecated-non-prototype
+endif
+
+ifeq ($(shell echo 'void foo(a) int a; {}' | "${CC}" -Wno-old-style-definition -x c -c - -o /dev/null 2>&1),)
+	CFLAGS += -Wno-old-style-definition
+endif

--- a/Utilities/TestDiskImage/Makefile
+++ b/Utilities/TestDiskImage/Makefile
@@ -28,10 +28,4 @@ VPATH   = ../../Library/OcAppleChunklistLib:$\
 	../../Library/OcAppleRamDiskLib:$\
 	../../Library/OcCompressionLib/zlib
 include ../../User/Makefile
-
-#
-# Silence zlib warning.
-#
-ifeq ($(shell echo 'int a;' | "${CC}" -Wno-deprecated-non-prototype -x c -c - -o /dev/null 2>&1),)
-	CFLAGS += -Wno-deprecated-non-prototype
-endif
+include ../../User/SilenceZlibWarnings

--- a/Utilities/TestKextInject/Makefile
+++ b/Utilities/TestKextInject/Makefile
@@ -36,10 +36,4 @@ VPATH   = ../../Library/OcAppleKernelLib:$\
 	../../Library/OcCompressionLib/lzvn:$\
 	../../Library/OcCompressionLib/zlib
 include ../../User/Makefile
-
-#
-# Silence zlib warning.
-#
-ifeq ($(shell echo 'int a;' | "${CC}" -Wno-deprecated-non-prototype -x c -c - -o /dev/null 2>&1),)
-	CFLAGS += -Wno-deprecated-non-prototype
-endif
+include ../../User/SilenceZlibWarnings

--- a/Utilities/TestProcessKernel/Makefile
+++ b/Utilities/TestProcessKernel/Makefile
@@ -49,10 +49,4 @@ VPATH   = ../../Library/OcConfigurationLib:$\
 	../../Library/OcCompressionLib/lzvn:$\
 	../../Library/OcCompressionLib/zlib
 include ../../User/Makefile
-
-#
-# Silence zlib warning.
-#
-ifeq ($(shell echo 'int a;' | "${CC}" -Wno-deprecated-non-prototype -x c -c - -o /dev/null 2>&1),)
-	CFLAGS += -Wno-deprecated-non-prototype
-endif
+include ../../User/SilenceZlibWarnings


### PR DESCRIPTION
Also refactor to remove some duplication in zlib warning code.

Silences the error here https://github.com/acidanthera/OpenCorePkg/actions/runs/14961547077/job/42024258301