### PR TITLE
Add missing zero check for CPUFrequency on AMD CPUs

### DIFF
--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1696,7 +1696,14 @@ PatchProvideCurrentCpuInfo (
     busFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), busFreqValue, NULL);
     busFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), busFCvtt2nValue, NULL);
 
-    tscFreqValue    = CpuInfo->CPUFrequency;
+    tscFreqValue = CpuInfo->CPUFrequency;
+
+    // Handle case where CPUFrequency is zero, providing a fallback
+    if (tscFreqValue == 0) {
+      tscFreqValue = 1000000000; // Assume 1 GHz TSC as fallback
+      DEBUG ((DEBUG_WARN, "OCAK: CPUFrequency is zero, using fallback value: 1 GHz\n"));
+    }
+
     tscFCvtt2nValue = DivU64x64Remainder ((1000000000ULL << 32), tscFreqValue, NULL);
     tscFCvtn2tValue = DivU64x64Remainder ((1000000000ULL << 32), tscFCvtt2nValue, NULL);
   }


### PR DESCRIPTION
This would hopefully fully fix the ASSERT issue that is present in issue (2409) in the bugtracker.
Confirmed to work on a different user with the same ASSERT issue.