### PR TITLE
OcConsoleLib: Normalize console font path

### DIFF
--- a/Library/OcConsoleLib/ConsoleFontLoader.c
+++ b/Library/OcConsoleLib/ConsoleFontLoader.c
@@ -167,7 +167,7 @@ OcLoadConsoleFont (
   Status = OcUnicodeSafeSPrint (
              Path,
              sizeof (Path),
-             OPEN_CORE_FONT_PATH L"\\%a.hex",
+             OPEN_CORE_FONT_PATH L"%a.hex",
              FontName
              );
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
OcLoadConsoleFont currently loads the specified console path from `Resources\Font\\`, which can cause vault failures if vault.plist doesn't include the duplicate path separator. Remove it to match other paths.