### PR TITLE
Fix: OSError in mintty terminal on Windows

### DIFF
--- a/Utilities/macrecovery/macrecovery.py
+++ b/Utilities/macrecovery/macrecovery.py
@@ -12,6 +12,7 @@ import json
 import linecache
 import os
 import random
+import shutil
 import struct
 import string
 import sys
@@ -225,7 +226,7 @@ def save_image(url, sess, filename='', directory=''):
                 break
             fh.write(chunk)
             size += len(chunk)
-            terminalsize = max(os.get_terminal_size().columns - TERMINAL_MARGIN, 0)
+            terminalsize = max(shutil.get_terminal_size().columns - TERMINAL_MARGIN, 0)
             if oldterminalsize != terminalsize:
                 print(f'\r{"":<{terminalsize}}', end='')
                 oldterminalsize = terminalsize
@@ -250,7 +251,7 @@ def verify_image(dmgpath, cnkpath):
 
     with open(dmgpath, 'rb') as dmgf:
         for cnkcount, (cnksize, cnkhash) in enumerate(verify_chunklist(cnkpath), 1):
-            terminalsize = max(os.get_terminal_size().columns - TERMINAL_MARGIN, 0)
+            terminalsize = max(shutil.get_terminal_size().columns - TERMINAL_MARGIN, 0)
             print(f'\r{f"Chunk {cnkcount} ({cnksize} bytes)":<{terminalsize}}', end='')
             sys.stdout.flush()
             cnk = dmgf.read(cnksize)


### PR DESCRIPTION
Hi! Thank you for maintaining tools in this repository.

I'm using Git Bash on Windows. Git Bash is a mintty terminal [^mintty-official-website]. The script "macrecovery.py" raised `OSError`. I have tried replacing `os.get_terminal_size()` with `shutil.get_terminal_size()` and it works! My tests are as follows:

[^mintty-official-website]: *... In Git-for-Windows, mintty is installed by default and invoked as "Git Bash"...* | https://mintty.github.io/

After applying this PR:

```console
$ ./Utilities/macrecovery/macrecovery.py download
Downloading 696-28424...
Saving .../RecoveryImage/BaseSystem.chunklist to com.apple.recovery.boot\BaseSystem.chunklist...
0.0/0.0 MB |==========================| 100.0% downloaded
Download complete!
Saving .../RecoveryImage/BaseSystem.dmg to com.apple.recovery.boot\BaseSystem.dmg...
56.0/843.4 MB |=                         | 6.6% downloaded

```

Before:

```console
$ ./Utilities/macrecovery/macrecovery.py download
Downloading 696-28424...
Saving .../RecoveryImage/BaseSystem.chunklist to com.apple.recovery.boot\BaseSystem.chunklist...
Traceback (most recent call last):
  File "...\OpenCorePkg\Utilities\macrecovery\macrecovery.py", line 516, in <module>
    sys.exit(main())
             ~~~~^^
  File "...\OpenCorePkg\Utilities\macrecovery\macrecovery.py", line 504, in main
    return action_download(args)
  File "...\OpenCorePkg\Utilities\macrecovery\macrecovery.py", line 300, in action_download
    cnkpath = save_image(info[INFO_SIGN_LINK], info[INFO_SIGN_SESS], cnkname, args.outdir)
  File "...\OpenCorePkg\Utilities\macrecovery\macrecovery.py", line 228, in save_image
    terminalsize = max(os.get_terminal_size().columns - TERMINAL_MARGIN, 0)
                       ~~~~~~~~~~~~~~~~~~~~^^
OSError: [WinError 6] The handle is invalid

```

Both `$COLUMNS` and `$LINES` are defined. The docs of `shutil.get_terminal_size` say that it uses these two environment variables [^shutil-docs]:

```console
$ echo "$COLUMNS, $LINES"
118, 30

```

The environment:

- Windows 11 23H2 (10.0.22631.4317)
- mintty 3.7.0 (x86_64-pc-msys) [Windows 22631]
- git version 2.44.0.windows.1

That script works fine in other terminals on my computer. Hope this PR won't break anything.

[^shutil-docs]: https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size
