### PR TITLE
fix: add Windows-friendly macrecovery invocation

### DIFF
--- a/Utilities/macrecovery/README.md
+++ b/Utilities/macrecovery/README.md
@@ -4,5 +4,7 @@ macrecovery is a tool that helps to automate recovery interaction. It can be use
 
 Requires python3 to run. Run with `-h` argument to see all available arguments.
 
+On Windows, you can run `macrecovery.bat` from Command Prompt or PowerShell. It will automatically use `py -3` or `python` from `PATH`.
+
 To create a disk image for a virtual machine installation use `build-image.sh`.
 

--- a/Utilities/macrecovery/macrecovery.bat
+++ b/Utilities/macrecovery/macrecovery.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+
+where py >nul 2>nul
+if %ERRORLEVEL% EQU 0 (
+  py -3 "%SCRIPT_DIR%macrecovery.py" %*
+  exit /b %ERRORLEVEL%
+)
+
+where python >nul 2>nul
+if %ERRORLEVEL% EQU 0 (
+  python "%SCRIPT_DIR%macrecovery.py" %*
+  exit /b %ERRORLEVEL%
+)
+
+echo Python launcher 'py' or 'python' was not found in PATH. 1>&2
+echo Install Python 3 from https://www.python.org/downloads/windows/ and try again. 1>&2
+exit /b 1

--- a/Utilities/macrecovery/recovery_urls.txt
+++ b/Utilities/macrecovery/recovery_urls.txt
@@ -1,3 +1,7 @@
+Usage note:
+- macOS/Linux shells: run commands exactly as listed.
+- Windows Command Prompt/PowerShell: replace `./macrecovery.py` with `macrecovery.bat` (or `py macrecovery.py`).
+
 Lion
 ./macrecovery.py -b Mac-2E6FAB96566FE58C -m 00000000000F25Y00 download
 ./macrecovery.py -b Mac-C3EC7CD22292981F -m 00000000000F0HM00 download


### PR DESCRIPTION
## Summary
- add a macrecovery.bat wrapper for Windows users
- document the Windows invocation in README.md
- clarify in ecovery_urls.txt that ./macrecovery.py is shell syntax and should be replaced on Windows

## Why
The release zip currently includes ecovery_urls.txt examples like ./macrecovery.py ..., which work in Unix-like shells but fail in Command Prompt with:

`	ext
'.' is not recognized as an internal or external command,
operable program or batch file.
`

This keeps the existing Unix workflow intact while giving Windows users a zero-guess wrapper that works from Command Prompt and PowerShell.

## Validation
- ran Utilities\\macrecovery\\macrecovery.bat -h on Windows successfully
