### PR TITLE
OpenCore: Switch from UefiDriverEntryPoint.h to UefiApplicationEntryPoint.h

### DIFF
--- a/Application/OpenCore/OpenCore.c
+++ b/Application/OpenCore/OpenCore.c
@@ -1,5 +1,5 @@
 /** @file
-  OpenCore driver.
+  OpenCore primary application.
 
 Copyright (c) 2019, vit9696. All rights reserved.<BR>
 This program and the accompanying materials
@@ -39,7 +39,7 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include <Library/PrintLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
-#include <Library/UefiDriverEntryPoint.h>
+#include <Library/UefiApplicationEntryPoint.h>
 #include <Library/UefiLib.h>
 
 STATIC


### PR DESCRIPTION
Since OpenCore is no longer a driver as of 2021, it must use UefiApplicationEntryPoint.h