### PR TITLE
OcAppleKernelLib: prelink diagnostic + symbol-only dependent fallback

### DIFF
--- a/Library/OcAppleKernelLib/Link.c
+++ b/Library/OcAppleKernelLib/Link.c
@@ -552,9 +552,12 @@ InternalSolveSymbol (
   Instruction will be patched with the resulting address.
   Logically matches XNU's calculate_displacement_x86_64.
 
+  @param[in]     Source       The source address (link PC of the relocation).
   @param[in]     Target       The target address.
   @param[in]     Adjustment   Adjustment to be subtracted from the
                               displacement.
+  @param[in]     Identifier   Kext bundle identifier for diagnostic output;
+                              may be NULL.
   @param[in,out] Instruction  Pointer to the instruction to be patched.
 
   @retval  Returned is whether the target instruction has been patched.
@@ -563,13 +566,15 @@ InternalSolveSymbol (
 STATIC
 BOOLEAN
 InternalCalculateDisplacementIntel64 (
-  IN     UINT64  Target,
-  IN     UINT64  Adjustment,
-  IN OUT INT32   *Instruction
+  IN     UINT64       Source,
+  IN     UINT64       Target,
+  IN     UINT64       Adjustment,
+  IN     CONST CHAR8  *Identifier OPTIONAL,
+  IN OUT INT32        *Instruction
   )
 {
-  INT64  Displacement;
-  UINT64 Difference;
+  INT64   Displacement;
+  UINT64  Difference;
 
   ASSERT (Instruction != NULL);
 
@@ -577,6 +582,14 @@ InternalCalculateDisplacementIntel64 (
   Difference   = ABS (Displacement);
 
   if (Difference >= X86_64_RIP_RELATIVE_LIMIT) {
+    DEBUG ((
+      DEBUG_INFO,
+      "OCAK: RIP-relative overflow in %a: source=0x%Lx target=0x%Lx diff=0x%Lx\n",
+      Identifier != NULL ? Identifier : "(unknown)",
+      Source,
+      Target,
+      Difference
+      ));
     return FALSE;
   }
 
@@ -1032,8 +1045,10 @@ InternalRelocateRelocation (
 
       if (PcRelative) {
         Result = InternalCalculateDisplacementIntel64 (
+                   LinkPc,
                    Target,
                    Adjustment,
+                   Kext->Identifier,
                    &Instruction32
                    );
         if (!Result) {

--- a/Library/OcAppleKernelLib/PrelinkedKext.c
+++ b/Library/OcAppleKernelLib/PrelinkedKext.c
@@ -653,6 +653,13 @@ InternalInsertPrelinkedKextDependency (
 
   Status = InternalScanPrelinkedKext (DependencyKext, Context, TRUE);
   if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "OCAK: Dependency scan failed for %a (dep of %a) - %r\n",
+      DependencyKext->Identifier,
+      Kext->Identifier,
+      Status
+      ));
     return Status;
   }
 
@@ -739,7 +746,47 @@ InternalCachedPrelinkedKext (
   }
 
   if (NewKext == NULL) {
-    return NULL;
+    //
+    // On kernel-collection boots (macOS 11+), bundle identifiers that the
+    // injected kext lists in OSBundleLibraries may have no plist entry in
+    // the Boot KC because the providing module ships in a different KC or
+    // is plist-only. Returning NULL here silently breaks symbol-only
+    // dependents (weak references, build-time links): the caller skips
+    // the dependency entirely, then InternalSolveSymbol () later fails
+    // with "library kext ... not found".
+    //
+    // Materialise a minimal kernel-stub PRELINKED_KEXT aliasing the
+    // kernel's own inner Mach-O context. The stub carries no vtable
+    // source, so it cannot satisfy subclassing, but it lets the kernel's
+    // symbol table answer weak/test lookups so the link can complete.
+    // Boot-KC dependents that need real vtables still fail loudly during
+    // linking, exactly as before.
+    //
+    if (Prelinked->IsKernelCollection) {
+      NewKext = AllocateZeroPool (sizeof (*NewKext));
+      if (NewKext == NULL) {
+        return NULL;
+      }
+
+      NewKext->Signature       = PRELINKED_KEXT_SIGNATURE;
+      NewKext->Identifier      = Identifier;
+      NewKext->BundleLibraries = NULL;
+      CopyMem (
+        &NewKext->Context.MachContext,
+        &Prelinked->InnerMachContext,
+        sizeof (OC_MACHO_CONTEXT)
+        );
+      NewKext->Context.VirtualBase = 0;
+      NewKext->Context.VirtualKmod = 0;
+
+      DEBUG ((
+        DEBUG_INFO,
+        "OCAK: %a not in Boot KC, using kernel stub for symbol-only deps\n",
+        Identifier
+        ));
+    } else {
+      return NULL;
+    }
   }
 
   InsertTailList (&Prelinked->PrelinkedKexts, &NewKext->Link);


### PR DESCRIPTION
Per the discussion in #600 — vit9696 endorsed splitting "B" off as a
standalone cleanup with no SystemKC machinery. This PR is just that
piece. ~25 LOC, all in `OcAppleKernelLib`, no behaviour change for
non-KC boots.

Four changes:

1. `PrelinkedKext.c`, `InternalInsertPrelinkedKextDependency`: log the
   dependency-scan failure path that currently propagates a status code
   with no `OCAK:` line. Dependent + dependency + status are printed at
   `DEBUG_INFO`.

2. `PrelinkedKext.c`, `InternalCachedPrelinkedKext`: on
   `IsKernelCollection` boots, when a bundle id isn't in the Boot KC
   plist, materialise a minimal kernel-stub `PRELINKED_KEXT` aliasing
   `PRELINKED_CONTEXT::InnerMachContext` instead of returning `NULL`.
   Returning `NULL` silently breaks symbol-only dependents (weak refs,
   build-time links) — the caller skips the dependency and
   `InternalSolveSymbol` later fails with "library kext … not found".
   The stub carries no vtable source so subclassers still fail loudly
   during linking. Pre-Big Sur unchanged.

3. `Link.c`, `InternalCalculateDisplacementIntel64`: the
   `X86_64_RIP_RELATIVE_LIMIT` overflow path returns `FALSE` silently;
   the caller propagates that to `MAX_UINTN` and the link fails with
   no `OCAK:` trace. Add a `DEBUG_INFO` log carrying kext identifier,
   source link PC, target VA, and computed difference. The helper gains
   `Source` and `Identifier` parameters; one call site at line ~1034 is
   updated.

4. The originally proposed missing-include item turned out to be a
   non-issue on master (`PrelinkedInternal.h` already pulls
   `<IndustryStandard/AppleMachoImage.h>` transitively into
   `PrelinkedKext.c`). Dropped rather than invented.

**Testing:** `TestKextInject` and `TestProcessKernel` both build clean
with `WERROR=1 USE_SHARED_OBJS=1` against this tree (Xcode 16.4 /
clang 17, EDK2 stable202502).

A "C" path is queued behind this in #600's discussion (chained-fixup
helpers + a `TestProcessKernel` driver subcommand) and will be opened
as a follow-up branch. SystemKC loading itself remains in #600 pending
your read.