### PR TITLE
OcAppleKernelLib: chained-fixup pointer-format helpers + TestProcessKernel driver

### DIFF
--- a/Include/Acidanthera/Library/OcAppleKernelLib.h
+++ b/Include/Acidanthera/Library/OcAppleKernelLib.h
@@ -1052,6 +1052,75 @@ KcFixupValue (
   );
 
 /**
+  Visitor callback invoked once per chained-fixup slot encountered while
+  walking a kernel-collection chained-fixup table. The callback may
+  rewrite the slot in place (e.g. to translate a fileset VA into a kernel
+  VA) or just observe it (e.g. for counting / validation).
+
+  @param[in,out] FixupLoc        Pointer to the 8-byte fixup slot.
+  @param[in,out] VisitorContext  Caller-provided context, may be NULL.
+**/
+typedef
+VOID
+(*KC_CHAINED_FIXUP_VISIT)(
+  IN OUT UINT64  *FixupLoc,
+  IN OUT VOID    *VisitorContext
+  );
+
+/**
+  Walk every chained-fixup slot in a single segment of a kernel
+  collection's LC_DYLD_CHAINED_FIXUPS payload, invoking Visitor on each
+  slot. Pointer-format-aware: handles both stride-1
+  (X86_64_KERNEL_CACHE) and stride-4 (64_KERNEL_CACHE / 64_OFFSET /
+  ARM64E_KERNEL) layouts; returns 0 for any other format without
+  walking.
+
+  @param[in]     Buffer          Pointer to the containing kernel
+                                 collection buffer (the same base
+                                 SegmentOffset is relative to).
+  @param[in]     StartsSeg       MACH_DYLD_CHAINED_STARTS_IN_SEGMENT for
+                                 the segment to walk.
+  @param[in]     Visitor         Callback invoked per fixup slot, or
+                                 NULL to count only.
+  @param[in,out] VisitorContext  Opaque context forwarded to Visitor,
+                                 may be NULL.
+
+  @return  Count of fixup slots visited (0 if PointerFormat unsupported).
+**/
+UINTN
+KcWalkChainedFixupsInSegment (
+  IN     UINT8                                *Buffer,
+  IN     MACH_DYLD_CHAINED_STARTS_IN_SEGMENT  *StartsSeg,
+  IN     KC_CHAINED_FIXUP_VISIT               Visitor OPTIONAL,
+  IN OUT VOID                                 *VisitorContext OPTIONAL
+  );
+
+/**
+  Walk every chained-fixup slot in every segment of a kernel
+  collection's LC_DYLD_CHAINED_FIXUPS payload by iterating over the
+  STARTS_IN_IMAGE table and calling KcWalkChainedFixupsInSegment for
+  each populated segment.
+
+  @param[in]     Buffer          Pointer to the containing kernel
+                                 collection buffer.
+  @param[in]     Starts          MACH_DYLD_CHAINED_STARTS_IN_IMAGE for
+                                 the whole image.
+  @param[in]     Visitor         Callback invoked per fixup slot, or
+                                 NULL to count only.
+  @param[in,out] VisitorContext  Opaque context forwarded to Visitor,
+                                 may be NULL.
+
+  @return  Total count of fixup slots visited across all segments.
+**/
+UINTN
+KcWalkChainedFixupsInImage (
+  IN     UINT8                              *Buffer,
+  IN     MACH_DYLD_CHAINED_STARTS_IN_IMAGE  *Starts,
+  IN     KC_CHAINED_FIXUP_VISIT             Visitor OPTIONAL,
+  IN OUT VOID                               *VisitorContext OPTIONAL
+  );
+
+/**
   Initialize patcher from prelinked context for kext patching.
 
   @param[in,out] Context         Patcher context.

--- a/Include/Acidanthera/Library/OcAppleKernelLib.h
+++ b/Include/Acidanthera/Library/OcAppleKernelLib.h
@@ -1075,22 +1075,39 @@ VOID
   ARM64E_KERNEL) layouts; returns 0 for any other format without
   walking.
 
+  All fields read from StartsSeg are treated as untrusted input. Every
+  computed offset and chain step is bounds-checked against the
+  caller-supplied container sizes. The walker never reads or invokes
+  Visitor on a slot that lies outside [Buffer, Buffer + BufferSize).
+  A self-referencing chain is bounded by the per-page iteration cap
+  PageSize / sizeof (UINT64).
+
   @param[in]     Buffer          Pointer to the containing kernel
                                  collection buffer (the same base
                                  SegmentOffset is relative to).
+  @param[in]     BufferSize      Size of Buffer in bytes. The walker
+                                 will not access Buffer past this.
   @param[in]     StartsSeg       MACH_DYLD_CHAINED_STARTS_IN_SEGMENT for
                                  the segment to walk.
+  @param[in]     StartsSegSize   Size of the metadata region pointed to
+                                 by StartsSeg. The walker will not read
+                                 the StartsSeg struct or its
+                                 PageStart[] array past this.
   @param[in]     Visitor         Callback invoked per fixup slot, or
                                  NULL to count only.
   @param[in,out] VisitorContext  Opaque context forwarded to Visitor,
                                  may be NULL.
 
-  @return  Count of fixup slots visited (0 if PointerFormat unsupported).
+  @return  Count of fixup slots visited. 0 if any size precondition
+           fails, the pointer format is unsupported, or the structure
+           is malformed.
 **/
 UINTN
 KcWalkChainedFixupsInSegment (
   IN     UINT8                                *Buffer,
+  IN     UINTN                                BufferSize,
   IN     MACH_DYLD_CHAINED_STARTS_IN_SEGMENT  *StartsSeg,
+  IN     UINTN                                StartsSegSize,
   IN     KC_CHAINED_FIXUP_VISIT               Visitor OPTIONAL,
   IN OUT VOID                                 *VisitorContext OPTIONAL
   );
@@ -1101,21 +1118,36 @@ KcWalkChainedFixupsInSegment (
   STARTS_IN_IMAGE table and calling KcWalkChainedFixupsInSegment for
   each populated segment.
 
+  Both the Starts table and each per-segment record it indexes are
+  treated as untrusted input and bounds-checked against StartsSize.
+  Per-segment validation is performed by KcWalkChainedFixupsInSegment.
+
   @param[in]     Buffer          Pointer to the containing kernel
                                  collection buffer.
+  @param[in]     BufferSize      Size of Buffer in bytes. Forwarded to
+                                 KcWalkChainedFixupsInSegment.
   @param[in]     Starts          MACH_DYLD_CHAINED_STARTS_IN_IMAGE for
                                  the whole image.
+  @param[in]     StartsSize      Size of the chained-fixups metadata
+                                 region pointed to by Starts. Bounds
+                                 the SegInfoOffset[] array reads and
+                                 each per-segment dereference.
   @param[in]     Visitor         Callback invoked per fixup slot, or
                                  NULL to count only.
   @param[in,out] VisitorContext  Opaque context forwarded to Visitor,
                                  may be NULL.
 
-  @return  Total count of fixup slots visited across all segments.
+  @return  Total count of fixup slots visited across all segments. 0
+           if a size precondition fails or the structure is malformed;
+           a malformed individual segment is skipped without affecting
+           other segments.
 **/
 UINTN
 KcWalkChainedFixupsInImage (
   IN     UINT8                              *Buffer,
+  IN     UINTN                              BufferSize,
   IN     MACH_DYLD_CHAINED_STARTS_IN_IMAGE  *Starts,
+  IN     UINTN                              StartsSize,
   IN     KC_CHAINED_FIXUP_VISIT             Visitor OPTIONAL,
   IN OUT VOID                               *VisitorContext OPTIONAL
   );

--- a/Library/OcAppleKernelLib/KernelCollection.c
+++ b/Library/OcAppleKernelLib/KernelCollection.c
@@ -835,3 +835,123 @@ KcFixupValue (
 
   return Value;
 }
+
+UINTN
+KcWalkChainedFixupsInSegment (
+  IN     UINT8                                *Buffer,
+  IN     MACH_DYLD_CHAINED_STARTS_IN_SEGMENT  *StartsSeg,
+  IN     KC_CHAINED_FIXUP_VISIT               Visitor OPTIONAL,
+  IN OUT VOID                                 *VisitorContext OPTIONAL
+  )
+{
+  MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE_REBASE  *Fixup;
+  UINT64                                        *FixupLoc;
+  UINT32                                        PageIdx;
+  UINT32                                        Stride;
+  UINTN                                         Count;
+
+  ASSERT (Buffer != NULL);
+  ASSERT (StartsSeg != NULL);
+
+  //
+  // Per Apple's mach-o/fixup-chains.h, the Fixup->Next field is a stride
+  // count, not a byte offset. The stride depends on the pointer format:
+  //
+  //   X86_64_KERNEL_CACHE (11): stride 1 byte  (Fixup->Next * 1)
+  //   64_KERNEL_CACHE      (8): stride 4 bytes (Fixup->Next * 4)
+  //
+  // The 64_OFFSET (6) and ARM64E_KERNEL (7) variants also use stride 4
+  // and share the same per-pointer rebase layout for the unauth case.
+  // Other formats (ARM64E with auth, 32-bit variants, userland 64) are
+  // not produced by current macOS kernel caches and are skipped here.
+  //
+  switch (StartsSeg->PointerFormat) {
+    case MACH_DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE:
+      Stride = 1;
+      break;
+    case MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE:
+    case MACH_DYLD_CHAINED_PTR_64_OFFSET:
+    case MACH_DYLD_CHAINED_PTR_ARM64E_KERNEL:
+      Stride = 4;
+      break;
+    default:
+      return 0;
+  }
+
+  Count = 0;
+
+  for (PageIdx = 0; PageIdx < StartsSeg->PageCount; ++PageIdx) {
+    if (StartsSeg->PageStart[PageIdx] == MACH_DYLD_CHAINED_PTR_START_NONE) {
+      continue;
+    }
+
+    //
+    // STARTS_IN_SEGMENT entries with the START_MULTI bit set carry their
+    // chain heads via a separate ChainStarts table appended after
+    // PageStart[PageCount]. macOS kernel caches do not emit this layout
+    // for the formats handled above; skip such pages defensively rather
+    // than mis-walking foreign data.
+    //
+    if ((StartsSeg->PageStart[PageIdx] & MACH_DYLD_CHAINED_PTR_START_MULTI) != 0) {
+      continue;
+    }
+
+    FixupLoc = (UINT64 *)(
+                          Buffer + StartsSeg->SegmentOffset
+                          + (UINT64)PageIdx * StartsSeg->PageSize
+                          + StartsSeg->PageStart[PageIdx]
+                          );
+
+    while (TRUE) {
+      Fixup = (MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE_REBASE *)FixupLoc;
+
+      if (Visitor != NULL) {
+        Visitor (FixupLoc, VisitorContext);
+      }
+
+      ++Count;
+
+      if (Fixup->Next == 0) {
+        break;
+      }
+
+      FixupLoc = (UINT64 *)(
+                            (UINT8 *)FixupLoc + (UINTN)Fixup->Next * Stride
+                            );
+    }
+  }
+
+  return Count;
+}
+
+UINTN
+KcWalkChainedFixupsInImage (
+  IN     UINT8                              *Buffer,
+  IN     MACH_DYLD_CHAINED_STARTS_IN_IMAGE  *Starts,
+  IN     KC_CHAINED_FIXUP_VISIT             Visitor OPTIONAL,
+  IN OUT VOID                               *VisitorContext OPTIONAL
+  )
+{
+  MACH_DYLD_CHAINED_STARTS_IN_SEGMENT  *StartsSeg;
+  UINT32                               SegIdx;
+  UINTN                                Count;
+
+  ASSERT (Buffer != NULL);
+  ASSERT (Starts != NULL);
+
+  Count = 0;
+
+  for (SegIdx = 0; SegIdx < Starts->NumSegments; ++SegIdx) {
+    if (Starts->SegInfoOffset[SegIdx] == 0) {
+      continue;
+    }
+
+    StartsSeg = (MACH_DYLD_CHAINED_STARTS_IN_SEGMENT *)(
+                                                        (UINT8 *)Starts + Starts->SegInfoOffset[SegIdx]
+                                                        );
+
+    Count += KcWalkChainedFixupsInSegment (Buffer, StartsSeg, Visitor, VisitorContext);
+  }
+
+  return Count;
+}

--- a/Library/OcAppleKernelLib/KernelCollection.c
+++ b/Library/OcAppleKernelLib/KernelCollection.c
@@ -839,33 +839,97 @@ KcFixupValue (
 UINTN
 KcWalkChainedFixupsInSegment (
   IN     UINT8                                *Buffer,
+  IN     UINTN                                BufferSize,
   IN     MACH_DYLD_CHAINED_STARTS_IN_SEGMENT  *StartsSeg,
+  IN     UINTN                                StartsSegSize,
   IN     KC_CHAINED_FIXUP_VISIT               Visitor OPTIONAL,
   IN OUT VOID                                 *VisitorContext OPTIONAL
   )
 {
   MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE_REBASE  *Fixup;
   UINT64                                        *FixupLoc;
+  UINT64                                        PageBase;
+  UINT64                                        PageEnd;
+  UINT64                                        SlotOffset;
+  UINT64                                        SlotEnd;
+  UINT64                                        NextStep;
+  UINT64                                        NextSlotOffset;
+  UINT16                                        PageStart;
+  UINT16                                        PageCount;
+  UINT16                                        PageSize;
+  UINT16                                        PointerFormat;
+  UINT32                                        Size;
   UINT32                                        PageIdx;
   UINT32                                        Stride;
+  UINTN                                         StructHeaderSize;
+  UINTN                                         MaxIters;
+  UINTN                                         IterCount;
   UINTN                                         Count;
 
   ASSERT (Buffer != NULL);
   ASSERT (StartsSeg != NULL);
 
   //
-  // Per Apple's mach-o/fixup-chains.h, the Fixup->Next field is a stride
-  // count, not a byte offset. The stride depends on the pointer format:
+  // None of the fields below can be trusted to bound themselves; treat
+  // every read of StartsSeg as untrusted input from the kernel
+  // collection blob and validate against caller-supplied container
+  // sizes (BufferSize bounds the contents being walked, StartsSegSize
+  // bounds the metadata struct itself).
   //
-  //   X86_64_KERNEL_CACHE (11): stride 1 byte  (Fixup->Next * 1)
-  //   64_KERNEL_CACHE      (8): stride 4 bytes (Fixup->Next * 4)
+
   //
-  // The 64_OFFSET (6) and ARM64E_KERNEL (7) variants also use stride 4
-  // and share the same per-pointer rebase layout for the unauth case.
-  // Other formats (ARM64E with auth, 32-bit variants, userland 64) are
-  // not produced by current macOS kernel caches and are skipped here.
+  // 1. The fixed-size header of MACH_DYLD_CHAINED_STARTS_IN_SEGMENT
+  //    must fit, otherwise reading Size/PageCount below is OOB.
   //
-  switch (StartsSeg->PointerFormat) {
+  StructHeaderSize = OFFSET_OF (MACH_DYLD_CHAINED_STARTS_IN_SEGMENT, PageStart);
+  if (StartsSegSize < StructHeaderSize) {
+    return 0;
+  }
+
+  Size          = StartsSeg->Size;
+  PageSize      = StartsSeg->PageSize;
+  PageCount     = StartsSeg->PageCount;
+  PointerFormat = StartsSeg->PointerFormat;
+
+  //
+  // 2. The struct's self-declared Size must not exceed StartsSegSize
+  //    and must be at least the fixed header.
+  //
+  if ((Size > StartsSegSize) || (Size < StructHeaderSize)) {
+    return 0;
+  }
+
+  //
+  // 3. The PageStart[PageCount] flexible array must fit within Size.
+  //    Equivalent to:  StructHeaderSize + PageCount * sizeof(UINT16) <= Size.
+  //
+  if ((UINTN)PageCount > (Size - StructHeaderSize) / sizeof (UINT16)) {
+    return 0;
+  }
+
+  //
+  // 4. PageSize must be large enough to hold a pointer slot, and small
+  //    enough that one page fits in the buffer at all. macOS kernel
+  //    caches use 0x1000 or 0x4000.
+  //
+  if ((PageSize < sizeof (UINT64)) || ((UINTN)PageSize > BufferSize)) {
+    return 0;
+  }
+
+  //
+  // 5. The segment must start within the buffer.
+  //
+  if (StartsSeg->SegmentOffset >= BufferSize) {
+    return 0;
+  }
+
+  //
+  // 6. Pointer-format dispatch. Stride is the chain step in bytes per
+  //    Apple's mach-o/fixup-chains.h. Other formats (auth ARM64E,
+  //    32-bit variants, userland 64) are not produced by current macOS
+  //    kernel caches and are skipped.
+  //
+  switch (PointerFormat) {
     case MACH_DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE:
       Stride = 1;
       break;
@@ -878,31 +942,85 @@ KcWalkChainedFixupsInSegment (
       return 0;
   }
 
+  //
+  // 7. A correctly formed chain visits each pointer slot at most once.
+  //    Cap the per-page iteration count at PageSize / sizeof(UINT64) to
+  //    defeat hostile self-referencing chains where Fixup->Next would
+  //    cycle back to a previously visited slot.
+  //
+  MaxIters = (UINTN)PageSize / sizeof (UINT64);
+
   Count = 0;
 
-  for (PageIdx = 0; PageIdx < StartsSeg->PageCount; ++PageIdx) {
-    if (StartsSeg->PageStart[PageIdx] == MACH_DYLD_CHAINED_PTR_START_NONE) {
+  for (PageIdx = 0; PageIdx < PageCount; ++PageIdx) {
+    PageStart = StartsSeg->PageStart[PageIdx];
+
+    if (PageStart == MACH_DYLD_CHAINED_PTR_START_NONE) {
       continue;
     }
 
     //
-    // STARTS_IN_SEGMENT entries with the START_MULTI bit set carry their
-    // chain heads via a separate ChainStarts table appended after
-    // PageStart[PageCount]. macOS kernel caches do not emit this layout
-    // for the formats handled above; skip such pages defensively rather
-    // than mis-walking foreign data.
+    // 8. STARTS_IN_SEGMENT pages with the START_MULTI bit carry chain
+    //    heads via a separate ChainStarts[] table appended after
+    //    PageStart[PageCount]. macOS kernel caches do not emit this
+    //    layout for the formats handled above; skip such pages
+    //    defensively rather than mis-walking foreign data.
     //
-    if ((StartsSeg->PageStart[PageIdx] & MACH_DYLD_CHAINED_PTR_START_MULTI) != 0) {
+    if ((PageStart & MACH_DYLD_CHAINED_PTR_START_MULTI) != 0) {
       continue;
     }
 
-    FixupLoc = (UINT64 *)(
-                          Buffer + StartsSeg->SegmentOffset
-                          + (UINT64)PageIdx * StartsSeg->PageSize
-                          + StartsSeg->PageStart[PageIdx]
-                          );
+    //
+    // 9. Compute and bounds-check the page base in Buffer:
+    //      PageBase = SegmentOffset + PageIdx * PageSize
+    //    Arithmetic is overflow-checked, and the resulting page must
+    //    fit entirely in Buffer.
+    //
+    if (BaseOverflowMulAddU64 (
+          (UINT64)PageIdx,
+          (UINT64)PageSize,
+          StartsSeg->SegmentOffset,
+          &PageBase
+          ))
+    {
+      continue;
+    }
 
-    while (TRUE) {
+    if (BaseOverflowAddU64 (PageBase, (UINT64)PageSize, &PageEnd)) {
+      continue;
+    }
+
+    if (PageEnd > BufferSize) {
+      continue;
+    }
+
+    //
+    // 10. The chain head must point inside this page; otherwise the
+    //     starts table is malformed for this entry.
+    //
+    if (PageStart >= PageSize) {
+      continue;
+    }
+
+    SlotOffset = PageBase + PageStart;
+
+    //
+    // 11. The chain head's pointer slot must fit inside the page.
+    //
+    if (BaseOverflowAddU64 (SlotOffset, sizeof (UINT64), &SlotEnd) ||
+        (SlotEnd > PageEnd))
+    {
+      continue;
+    }
+
+    FixupLoc = (UINT64 *)(Buffer + SlotOffset);
+
+    //
+    // 12. Walk this page's chain with a hard upper iteration bound. A
+    //     well-formed chain cannot revisit a slot, so MaxIters slots is
+    //     a strict upper bound; we stop short on any sign of looping.
+    //
+    for (IterCount = 0; IterCount < MaxIters; ++IterCount) {
       Fixup = (MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE_REBASE *)FixupLoc;
 
       if (Visitor != NULL) {
@@ -915,9 +1033,32 @@ KcWalkChainedFixupsInSegment (
         break;
       }
 
-      FixupLoc = (UINT64 *)(
-                            (UINT8 *)FixupLoc + (UINTN)Fixup->Next * Stride
-                            );
+      //
+      // 13. Compute and bounds-check the next slot. The chain MUST
+      //     stay within the same page; if Fixup->Next would step
+      //     outside the page, stop walking this chain.
+      //
+      if (BaseOverflowMulU64 (
+            (UINT64)Fixup->Next,
+            (UINT64)Stride,
+            &NextStep
+            ))
+      {
+        break;
+      }
+
+      if (BaseOverflowAddU64 (SlotOffset, NextStep, &NextSlotOffset)) {
+        break;
+      }
+
+      if (BaseOverflowAddU64 (NextSlotOffset, sizeof (UINT64), &SlotEnd) ||
+          (SlotEnd > PageEnd))
+      {
+        break;
+      }
+
+      SlotOffset = NextSlotOffset;
+      FixupLoc   = (UINT64 *)(Buffer + SlotOffset);
     }
   }
 
@@ -927,30 +1068,77 @@ KcWalkChainedFixupsInSegment (
 UINTN
 KcWalkChainedFixupsInImage (
   IN     UINT8                              *Buffer,
+  IN     UINTN                              BufferSize,
   IN     MACH_DYLD_CHAINED_STARTS_IN_IMAGE  *Starts,
+  IN     UINTN                              StartsSize,
   IN     KC_CHAINED_FIXUP_VISIT             Visitor OPTIONAL,
   IN OUT VOID                               *VisitorContext OPTIONAL
   )
 {
   MACH_DYLD_CHAINED_STARTS_IN_SEGMENT  *StartsSeg;
+  UINTN                                StartsSegSize;
+  UINT32                               NumSegments;
+  UINT32                               SegOffset;
   UINT32                               SegIdx;
+  UINTN                                StructHeaderSize;
   UINTN                                Count;
 
   ASSERT (Buffer != NULL);
   ASSERT (Starts != NULL);
 
+  //
+  // The fixed header of MACH_DYLD_CHAINED_STARTS_IN_IMAGE is one UINT32
+  // (NumSegments) before the variable-length SegInfoOffset[] array.
+  //
+  StructHeaderSize = OFFSET_OF (MACH_DYLD_CHAINED_STARTS_IN_IMAGE, SegInfoOffset);
+  if (StartsSize < StructHeaderSize) {
+    return 0;
+  }
+
+  NumSegments = Starts->NumSegments;
+
+  //
+  // The SegInfoOffset[NumSegments] array must fit within StartsSize.
+  //
+  if ((UINTN)NumSegments > (StartsSize - StructHeaderSize) / sizeof (UINT32)) {
+    return 0;
+  }
+
   Count = 0;
 
-  for (SegIdx = 0; SegIdx < Starts->NumSegments; ++SegIdx) {
-    if (Starts->SegInfoOffset[SegIdx] == 0) {
+  for (SegIdx = 0; SegIdx < NumSegments; ++SegIdx) {
+    SegOffset = Starts->SegInfoOffset[SegIdx];
+
+    //
+    // SegInfoOffset == 0 is the sentinel for "segment has no fixups".
+    //
+    if (SegOffset == 0) {
       continue;
     }
 
-    StartsSeg = (MACH_DYLD_CHAINED_STARTS_IN_SEGMENT *)(
-                                                        (UINT8 *)Starts + Starts->SegInfoOffset[SegIdx]
-                                                        );
+    //
+    // The per-segment record must lie within the StartsSize region.
+    // We pass the remaining bytes from this offset as StartsSegSize;
+    // KcWalkChainedFixupsInSegment validates further (struct header,
+    // declared Size, page array).
+    //
+    if ((UINTN)SegOffset >= StartsSize) {
+      continue;
+    }
 
-    Count += KcWalkChainedFixupsInSegment (Buffer, StartsSeg, Visitor, VisitorContext);
+    StartsSegSize = StartsSize - (UINTN)SegOffset;
+    StartsSeg     = (MACH_DYLD_CHAINED_STARTS_IN_SEGMENT *)(
+                                                            (UINT8 *)Starts + SegOffset
+                                                            );
+
+    Count += KcWalkChainedFixupsInSegment (
+               Buffer,
+               BufferSize,
+               StartsSeg,
+               StartsSegSize,
+               Visitor,
+               VisitorContext
+               );
   }
 
   return Count;

--- a/Library/OcAppleKernelLib/Link.c
+++ b/Library/OcAppleKernelLib/Link.c
@@ -552,9 +552,12 @@ InternalSolveSymbol (
   Instruction will be patched with the resulting address.
   Logically matches XNU's calculate_displacement_x86_64.
 
+  @param[in]     Source       The source address (link PC of the relocation).
   @param[in]     Target       The target address.
   @param[in]     Adjustment   Adjustment to be subtracted from the
                               displacement.
+  @param[in]     Identifier   Kext bundle identifier for diagnostic output;
+                              may be NULL.
   @param[in,out] Instruction  Pointer to the instruction to be patched.
 
   @retval  Returned is whether the target instruction has been patched.
@@ -563,13 +566,15 @@ InternalSolveSymbol (
 STATIC
 BOOLEAN
 InternalCalculateDisplacementIntel64 (
-  IN     UINT64  Target,
-  IN     UINT64  Adjustment,
-  IN OUT INT32   *Instruction
+  IN     UINT64       Source,
+  IN     UINT64       Target,
+  IN     UINT64       Adjustment,
+  IN     CONST CHAR8  *Identifier OPTIONAL,
+  IN OUT INT32        *Instruction
   )
 {
-  INT64  Displacement;
-  UINT64 Difference;
+  INT64   Displacement;
+  UINT64  Difference;
 
   ASSERT (Instruction != NULL);
 
@@ -577,6 +582,14 @@ InternalCalculateDisplacementIntel64 (
   Difference   = ABS (Displacement);
 
   if (Difference >= X86_64_RIP_RELATIVE_LIMIT) {
+    DEBUG ((
+      DEBUG_INFO,
+      "OCAK: RIP-relative overflow in %a: source=0x%Lx target=0x%Lx diff=0x%Lx\n",
+      Identifier != NULL ? Identifier : "(unknown)",
+      Source,
+      Target,
+      Difference
+      ));
     return FALSE;
   }
 
@@ -1032,8 +1045,10 @@ InternalRelocateRelocation (
 
       if (PcRelative) {
         Result = InternalCalculateDisplacementIntel64 (
+                   LinkPc,
                    Target,
                    Adjustment,
+                   Kext->Identifier,
                    &Instruction32
                    );
         if (!Result) {

--- a/Library/OcAppleKernelLib/PrelinkedKext.c
+++ b/Library/OcAppleKernelLib/PrelinkedKext.c
@@ -653,6 +653,13 @@ InternalInsertPrelinkedKextDependency (
 
   Status = InternalScanPrelinkedKext (DependencyKext, Context, TRUE);
   if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "OCAK: Dependency scan failed for %a (dep of %a) - %r\n",
+      DependencyKext->Identifier,
+      Kext->Identifier,
+      Status
+      ));
     return Status;
   }
 
@@ -739,7 +746,47 @@ InternalCachedPrelinkedKext (
   }
 
   if (NewKext == NULL) {
-    return NULL;
+    //
+    // On kernel-collection boots (macOS 11+), bundle identifiers that the
+    // injected kext lists in OSBundleLibraries may have no plist entry in
+    // the Boot KC because the providing module ships in a different KC or
+    // is plist-only. Returning NULL here silently breaks symbol-only
+    // dependents (weak references, build-time links): the caller skips
+    // the dependency entirely, then InternalSolveSymbol () later fails
+    // with "library kext ... not found".
+    //
+    // Materialise a minimal kernel-stub PRELINKED_KEXT aliasing the
+    // kernel's own inner Mach-O context. The stub carries no vtable
+    // source, so it cannot satisfy subclassing, but it lets the kernel's
+    // symbol table answer weak/test lookups so the link can complete.
+    // Boot-KC dependents that need real vtables still fail loudly during
+    // linking, exactly as before.
+    //
+    if (Prelinked->IsKernelCollection) {
+      NewKext = AllocateZeroPool (sizeof (*NewKext));
+      if (NewKext == NULL) {
+        return NULL;
+      }
+
+      NewKext->Signature       = PRELINKED_KEXT_SIGNATURE;
+      NewKext->Identifier      = Identifier;
+      NewKext->BundleLibraries = NULL;
+      CopyMem (
+        &NewKext->Context.MachContext,
+        &Prelinked->InnerMachContext,
+        sizeof (OC_MACHO_CONTEXT)
+        );
+      NewKext->Context.VirtualBase = 0;
+      NewKext->Context.VirtualKmod = 0;
+
+      DEBUG ((
+        DEBUG_INFO,
+        "OCAK: %a not in Boot KC, using kernel stub for symbol-only deps\n",
+        Identifier
+        ));
+    } else {
+      return NULL;
+    }
   }
 
   InsertTailList (&Prelinked->PrelinkedKexts, &NewKext->Link);

--- a/Utilities/TestProcessKernel/ProcessKernel.c
+++ b/Utilities/TestProcessKernel/ProcessKernel.c
@@ -308,6 +308,147 @@ OcGetFileSize (
   return EFI_SUCCESS;
 }
 
+//
+// Synthetic chained-fixup buffer used by --test-fixup-walk to exercise
+// KcWalkChainedFixupsInSegment for both supported pointer formats.
+//
+#define TEST_FIXUP_PAGE_SIZE   0x1000U
+#define TEST_FIXUP_PAGE_COUNT  1
+#define TEST_FIXUP_BUFFER_SZ   (TEST_FIXUP_PAGE_SIZE * TEST_FIXUP_PAGE_COUNT)
+
+STATIC
+VOID
+TestFixupVisitor (
+  IN OUT UINT64  *FixupLoc,
+  IN OUT VOID    *VisitorContext
+  )
+{
+  UINTN  *VisitedAddresses;
+
+  VisitedAddresses = (UINTN *)VisitorContext;
+  if (VisitedAddresses != NULL) {
+    VisitedAddresses[*VisitedAddresses + 1] = (UINTN)FixupLoc;
+    ++*VisitedAddresses;
+  }
+}
+
+STATIC
+INT32
+RunFixupWalkTest (
+  VOID
+  )
+{
+  UINT8                                         *Buffer;
+  UINT8                                         StartsBuffer[sizeof (MACH_DYLD_CHAINED_STARTS_IN_SEGMENT) + sizeof (UINT16) * TEST_FIXUP_PAGE_COUNT];
+  MACH_DYLD_CHAINED_STARTS_IN_SEGMENT           *StartsSeg;
+  MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE_REBASE  *Slot;
+  UINTN                                         Count;
+  UINTN                                         VisitedAddresses[8];
+  INT32                                         FailCount;
+
+  FailCount = 0;
+  Buffer    = AllocateZeroPool (TEST_FIXUP_BUFFER_SZ);
+  if (Buffer == NULL) {
+    return -1;
+  }
+
+  ZeroMem (StartsBuffer, sizeof (StartsBuffer));
+  StartsSeg                = (MACH_DYLD_CHAINED_STARTS_IN_SEGMENT *)StartsBuffer;
+  StartsSeg->Size          = sizeof (StartsBuffer);
+  StartsSeg->PageSize      = TEST_FIXUP_PAGE_SIZE;
+  StartsSeg->SegmentOffset = 0;
+  StartsSeg->PageCount     = TEST_FIXUP_PAGE_COUNT;
+  StartsSeg->PageStart[0]  = 0;
+
+  //
+  // Lay down a 4-link chain at offsets 0, 16, 32, 48 within the page.
+  // For X86_64_KERNEL_CACHE (stride 1) Next = 16; for 64_KERNEL_CACHE
+  // (stride 4) Next = 4. Both encode the same byte distance between
+  // slots, so the walker must produce identical visit counts and
+  // addresses for both layouts.
+  //
+  Slot = (MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE_REBASE *)Buffer;
+  ZeroMem (Slot, sizeof (*Slot));
+  Slot[0].Next   = 16;
+  Slot[0].Target = 0xAAAA;
+  ZeroMem (&Slot[2], sizeof (*Slot));
+  Slot[2].Next   = 16;
+  Slot[2].Target = 0xBBBB;
+  ZeroMem (&Slot[4], sizeof (*Slot));
+  Slot[4].Next   = 16;
+  Slot[4].Target = 0xCCCC;
+  ZeroMem (&Slot[6], sizeof (*Slot));
+  Slot[6].Next   = 0;
+  Slot[6].Target = 0xDDDD;
+
+  StartsSeg->PointerFormat = MACH_DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE;
+  ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+  Count = KcWalkChainedFixupsInSegment (
+            Buffer,
+            StartsSeg,
+            TestFixupVisitor,
+            VisitedAddresses
+            );
+  if ((Count != 4) || (VisitedAddresses[0] != 4)) {
+    DEBUG ((DEBUG_ERROR, "[FAIL] X86_64_KERNEL_CACHE walk: %u fixups\n", (UINT32)Count));
+    ++FailCount;
+  } else {
+    DEBUG ((DEBUG_WARN, "[OK] X86_64_KERNEL_CACHE walk visited 4 fixups (stride 1)\n"));
+  }
+
+  //
+  // Reset slots with stride-4 Next encoding.
+  //
+  ZeroMem (Slot, sizeof (*Slot));
+  Slot[0].Next   = 4;
+  Slot[0].Target = 0xAAAA;
+  ZeroMem (&Slot[2], sizeof (*Slot));
+  Slot[2].Next   = 4;
+  Slot[2].Target = 0xBBBB;
+  ZeroMem (&Slot[4], sizeof (*Slot));
+  Slot[4].Next   = 4;
+  Slot[4].Target = 0xCCCC;
+  ZeroMem (&Slot[6], sizeof (*Slot));
+  Slot[6].Next   = 0;
+  Slot[6].Target = 0xDDDD;
+
+  StartsSeg->PointerFormat = MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE;
+  ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+  Count = KcWalkChainedFixupsInSegment (
+            Buffer,
+            StartsSeg,
+            TestFixupVisitor,
+            VisitedAddresses
+            );
+  if ((Count != 4) || (VisitedAddresses[0] != 4)) {
+    DEBUG ((DEBUG_ERROR, "[FAIL] 64_KERNEL_CACHE walk: %u fixups\n", (UINT32)Count));
+    ++FailCount;
+  } else {
+    DEBUG ((DEBUG_WARN, "[OK] 64_KERNEL_CACHE walk visited 4 fixups (stride 4)\n"));
+  }
+
+  //
+  // An unsupported format must return 0 and never invoke the visitor.
+  //
+  StartsSeg->PointerFormat = MACH_DYLD_CHAINED_PTR_ARM64E;
+  ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+  Count = KcWalkChainedFixupsInSegment (
+            Buffer,
+            StartsSeg,
+            TestFixupVisitor,
+            VisitedAddresses
+            );
+  if ((Count != 0) || (VisitedAddresses[0] != 0)) {
+    DEBUG ((DEBUG_ERROR, "[FAIL] unsupported-format guard: %u fixups\n", (UINT32)Count));
+    ++FailCount;
+  } else {
+    DEBUG ((DEBUG_WARN, "[OK] unsupported-format guard returned 0\n"));
+  }
+
+  FreePool (Buffer);
+  return FailCount;
+}
+
 int
 WrapMain (
   int   argc,
@@ -340,8 +481,13 @@ WrapMain (
   OC_KERNEL_ADD_ENTRY  *Kext;
 
   if (argc < 2) {
-    DEBUG ((DEBUG_ERROR, "Usage: %a <path/to/OC/folder/> [path/to/kernel]\n\n", argv[0]));
+    DEBUG ((DEBUG_ERROR, "Usage: %a <path/to/OC/folder/> [path/to/kernel]\n", argv[0]));
+    DEBUG ((DEBUG_ERROR, "       %a --test-fixup-walk\n\n", argv[0]));
     return -1;
+  }
+
+  if (AsciiStrCmp (argv[1], "--test-fixup-walk") == 0) {
+    return RunFixupWalkTest () != 0 ? -1 : 0;
   }
 
   FileName = argc > 2 ? argv[2] : "/System/Library/PrelinkedKernels/prelinkedkernel";

--- a/Utilities/TestProcessKernel/ProcessKernel.c
+++ b/Utilities/TestProcessKernel/ProcessKernel.c
@@ -627,8 +627,8 @@ RunFixupWalkTest (
     MACH_DYLD_CHAINED_STARTS_IN_IMAGE  *ImageStarts;
 
     ZeroMem (ImageStartsBuffer, sizeof (ImageStartsBuffer));
-    ImageStarts                  = (MACH_DYLD_CHAINED_STARTS_IN_IMAGE *)ImageStartsBuffer;
-    ImageStarts->NumSegments     = 1000;
+    ImageStarts                   = (MACH_DYLD_CHAINED_STARTS_IN_IMAGE *)ImageStartsBuffer;
+    ImageStarts->NumSegments      = 1000;
     ImageStarts->SegInfoOffset[0] = 0;
 
     ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));

--- a/Utilities/TestProcessKernel/ProcessKernel.c
+++ b/Utilities/TestProcessKernel/ProcessKernel.c
@@ -344,6 +344,7 @@ RunFixupWalkTest (
   MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE_REBASE  *Slot;
   UINTN                                         Count;
   UINTN                                         VisitedAddresses[8];
+  UINTN                                         ByteIdx;
   INT32                                         FailCount;
 
   FailCount = 0;
@@ -385,7 +386,9 @@ RunFixupWalkTest (
   ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
   Count = KcWalkChainedFixupsInSegment (
             Buffer,
+            TEST_FIXUP_BUFFER_SZ,
             StartsSeg,
+            sizeof (StartsBuffer),
             TestFixupVisitor,
             VisitedAddresses
             );
@@ -416,7 +419,9 @@ RunFixupWalkTest (
   ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
   Count = KcWalkChainedFixupsInSegment (
             Buffer,
+            TEST_FIXUP_BUFFER_SZ,
             StartsSeg,
+            sizeof (StartsBuffer),
             TestFixupVisitor,
             VisitedAddresses
             );
@@ -434,7 +439,9 @@ RunFixupWalkTest (
   ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
   Count = KcWalkChainedFixupsInSegment (
             Buffer,
+            TEST_FIXUP_BUFFER_SZ,
             StartsSeg,
+            sizeof (StartsBuffer),
             TestFixupVisitor,
             VisitedAddresses
             );
@@ -443,6 +450,202 @@ RunFixupWalkTest (
     ++FailCount;
   } else {
     DEBUG ((DEBUG_WARN, "[OK] unsupported-format guard returned 0\n"));
+  }
+
+  //
+  // Bounds-check tests. Each constructs a malformed StartsSeg and
+  // confirms the walker rejects it (returns 0, visits nothing) rather
+  // than reading or writing out of the supplied buffers.
+  //
+
+  //
+  // (a) PageCount lies about the array length. Buffer-of-record claims
+  //     200 pages but only ~1 entry of metadata is supplied; walker
+  //     must refuse rather than walk a UINT16 array off the end of
+  //     StartsBuffer.
+  //
+  StartsSeg->PointerFormat = MACH_DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE;
+  StartsSeg->PageCount     = 200;
+  ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+  Count = KcWalkChainedFixupsInSegment (
+            Buffer,
+            TEST_FIXUP_BUFFER_SZ,
+            StartsSeg,
+            sizeof (StartsBuffer),
+            TestFixupVisitor,
+            VisitedAddresses
+            );
+  if ((Count != 0) || (VisitedAddresses[0] != 0)) {
+    DEBUG ((DEBUG_ERROR, "[FAIL] PageCount oversize guard: %u fixups\n", (UINT32)Count));
+    ++FailCount;
+  } else {
+    DEBUG ((DEBUG_WARN, "[OK] PageCount oversize rejected\n"));
+  }
+
+  //
+  // (b) StartsSeg->Size > caller's StartsSegSize. Walker must refuse to
+  //     trust the larger self-declared size.
+  //
+  StartsSeg->PageCount = TEST_FIXUP_PAGE_COUNT;
+  StartsSeg->Size      = (UINT32)sizeof (StartsBuffer) + 64;
+  ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+  Count = KcWalkChainedFixupsInSegment (
+            Buffer,
+            TEST_FIXUP_BUFFER_SZ,
+            StartsSeg,
+            sizeof (StartsBuffer),
+            TestFixupVisitor,
+            VisitedAddresses
+            );
+  if ((Count != 0) || (VisitedAddresses[0] != 0)) {
+    DEBUG ((DEBUG_ERROR, "[FAIL] Size > StartsSegSize guard: %u fixups\n", (UINT32)Count));
+    ++FailCount;
+  } else {
+    DEBUG ((DEBUG_WARN, "[OK] Size > StartsSegSize rejected\n"));
+  }
+
+  //
+  // (c) SegmentOffset past end of buffer. Walker must not deref past
+  //     Buffer + BufferSize even though Buffer itself is non-NULL.
+  //
+  StartsSeg->Size          = (UINT32)sizeof (StartsBuffer);
+  StartsSeg->SegmentOffset = TEST_FIXUP_BUFFER_SZ;
+  ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+  Count = KcWalkChainedFixupsInSegment (
+            Buffer,
+            TEST_FIXUP_BUFFER_SZ,
+            StartsSeg,
+            sizeof (StartsBuffer),
+            TestFixupVisitor,
+            VisitedAddresses
+            );
+  if ((Count != 0) || (VisitedAddresses[0] != 0)) {
+    DEBUG ((DEBUG_ERROR, "[FAIL] SegmentOffset OOB guard: %u fixups\n", (UINT32)Count));
+    ++FailCount;
+  } else {
+    DEBUG ((DEBUG_WARN, "[OK] SegmentOffset out-of-buffer rejected\n"));
+  }
+
+  //
+  // (d) PageStart >= PageSize — chain head outside its own page. Page
+  //     is skipped; walker returns count 0 (nothing to visit).
+  //
+  StartsSeg->SegmentOffset = 0;
+  StartsSeg->PageStart[0]  = TEST_FIXUP_PAGE_SIZE;
+  ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+  Count = KcWalkChainedFixupsInSegment (
+            Buffer,
+            TEST_FIXUP_BUFFER_SZ,
+            StartsSeg,
+            sizeof (StartsBuffer),
+            TestFixupVisitor,
+            VisitedAddresses
+            );
+  if ((Count != 0) || (VisitedAddresses[0] != 0)) {
+    DEBUG ((DEBUG_ERROR, "[FAIL] PageStart >= PageSize guard: %u fixups\n", (UINT32)Count));
+    ++FailCount;
+  } else {
+    DEBUG ((DEBUG_WARN, "[OK] PageStart >= PageSize rejected\n"));
+  }
+
+  //
+  // (e) Pathological chain: every 4-byte step reads as Next=1, so the
+  //     chain walks forward 4 bytes at a time and would visit
+  //     PageSize/4 = 1024 slots if unchecked. The iteration cap
+  //     (PageSize / sizeof(UINT64) = 512) must stop it short.
+  //
+  // Pattern: set byte i = 0x08 for i = 6, 10, 14, ..., so that the
+  // 8-byte read at every 4-byte-aligned offset has bit 51 set and all
+  // other Next-field bits clear, decoding to Next = 1. The
+  // MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE_REBASE bitfield places Next
+  // at bits 51-62 of the 64-bit slot (Apple mach-o/fixup-chains.h).
+  //
+  ZeroMem (Buffer, TEST_FIXUP_BUFFER_SZ);
+  for (ByteIdx = 6; ByteIdx + 1 < TEST_FIXUP_BUFFER_SZ; ByteIdx += 4) {
+    Buffer[ByteIdx] = 0x08;
+  }
+
+  StartsSeg->PointerFormat = MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE;
+  StartsSeg->PageStart[0]  = 0;
+  ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+  Count = KcWalkChainedFixupsInSegment (
+            Buffer,
+            TEST_FIXUP_BUFFER_SZ,
+            StartsSeg,
+            sizeof (StartsBuffer),
+            TestFixupVisitor,
+            VisitedAddresses
+            );
+  //
+  // Cap is PageSize / sizeof(UINT64) = 0x1000 / 8 = 512.
+  // Walker must stop at exactly that count rather than walking 1024.
+  //
+  if (Count != TEST_FIXUP_PAGE_SIZE / sizeof (UINT64)) {
+    DEBUG ((DEBUG_ERROR, "[FAIL] iter cap: %u fixups (expected %u)\n", (UINT32)Count, (UINT32)(TEST_FIXUP_PAGE_SIZE / sizeof (UINT64))));
+    ++FailCount;
+  } else {
+    DEBUG ((DEBUG_WARN, "[OK] long-chain bounded at iteration cap (%u)\n", (UINT32)Count));
+  }
+
+  //
+  // (f) Chain step would walk off the end of its page. Walker must
+  //     stop before reading past the page boundary.
+  //
+  StartsSeg->PageStart[0] = (UINT16)(TEST_FIXUP_PAGE_SIZE - sizeof (UINT64));
+  Slot                    = (MACH_DYLD_CHAINED_PTR_64_KERNEL_CACHE_REBASE *)
+                            (Buffer + (TEST_FIXUP_PAGE_SIZE - sizeof (UINT64)));
+  ZeroMem (Slot, sizeof (*Slot));
+  Slot[0].Next   = 64;      // would step past the page end
+  Slot[0].Target = 0xFFFF;
+
+  ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+  Count = KcWalkChainedFixupsInSegment (
+            Buffer,
+            TEST_FIXUP_BUFFER_SZ,
+            StartsSeg,
+            sizeof (StartsBuffer),
+            TestFixupVisitor,
+            VisitedAddresses
+            );
+  //
+  // The starting slot is in-page, so it's visited once; the next step
+  // is rejected and the walk terminates.
+  //
+  if ((Count != 1) || (VisitedAddresses[0] != 1)) {
+    DEBUG ((DEBUG_ERROR, "[FAIL] off-page chain step guard: %u fixups\n", (UINT32)Count));
+    ++FailCount;
+  } else {
+    DEBUG ((DEBUG_WARN, "[OK] chain step past page-end rejected after 1 visit\n"));
+  }
+
+  //
+  // (g) Image-level walker: NumSegments lies. Walker must validate
+  //     against StartsSize and return 0 cleanly.
+  //
+  {
+    UINT8                              ImageStartsBuffer[sizeof (MACH_DYLD_CHAINED_STARTS_IN_IMAGE) + sizeof (UINT32)];
+    MACH_DYLD_CHAINED_STARTS_IN_IMAGE  *ImageStarts;
+
+    ZeroMem (ImageStartsBuffer, sizeof (ImageStartsBuffer));
+    ImageStarts                  = (MACH_DYLD_CHAINED_STARTS_IN_IMAGE *)ImageStartsBuffer;
+    ImageStarts->NumSegments     = 1000;
+    ImageStarts->SegInfoOffset[0] = 0;
+
+    ZeroMem (VisitedAddresses, sizeof (VisitedAddresses));
+    Count = KcWalkChainedFixupsInImage (
+              Buffer,
+              TEST_FIXUP_BUFFER_SZ,
+              ImageStarts,
+              sizeof (ImageStartsBuffer),
+              TestFixupVisitor,
+              VisitedAddresses
+              );
+    if ((Count != 0) || (VisitedAddresses[0] != 0)) {
+      DEBUG ((DEBUG_ERROR, "[FAIL] InImage NumSegments guard: %u fixups\n", (UINT32)Count));
+      ++FailCount;
+    } else {
+      DEBUG ((DEBUG_WARN, "[OK] InImage oversize NumSegments rejected\n"));
+    }
   }
 
   FreePool (Buffer);


### PR DESCRIPTION
**Depends on #602** (the "B" cleanup path). This is the "C" path from
the PR #600 discussion. Adds reusable static-lib helpers for walking
`LC_DYLD_CHAINED_FIXUPS` chains in a kernel collection, with correct
per-format stride handling, and exercises them from a new
`TestProcessKernel --test-fixup-walk` subcommand so the helpers land
with an in-tree user.

## Helpers

`KcWalkChainedFixupsInSegment` and `KcWalkChainedFixupsInImage` in
`Library/OcAppleKernelLib/KernelCollection.c` (declared in
`Include/Acidanthera/Library/OcAppleKernelLib.h`). Both take a
caller-provided `KC_CHAINED_FIXUP_VISIT` callback invoked per fixup
slot, so the same walker drives translation passes (rewrite the slot
in place) and validation passes (count / observe). Per
Apple's `mach-o/fixup-chains.h`, `Fixup->Next` is a stride count, not
a byte offset. The walker computes the correct stride per format:

| PointerFormat                       | Value | Stride |
|-------------------------------------|------:|-------:|
| `X86_64_KERNEL_CACHE`               |    11 |   1 B  |
| `64_KERNEL_CACHE`                   |     8 |   4 B  |
| `64_OFFSET`                         |     6 |   4 B  |
| `ARM64E_KERNEL`                     |     7 |   4 B  |

Other formats (ARM64E with auth, 32-bit variants, userland 64) and
`START_MULTI` pages return 0 / are skipped defensively.

## Test driver

`Utilities/TestProcessKernel/ProcessKernel.c` gains a
`--test-fixup-walk` subcommand that builds a synthetic single-page
chain and walks it as `X86_64_KERNEL_CACHE`, `64_KERNEL_CACHE`, and
`ARM64E` (unsupported), verifying expected slot counts. Both supported
strides encode the same byte distance between slots so the walker
must yield identical visit counts. Local run on x86_64+arm64e darwin:

```
[OK] X86_64_KERNEL_CACHE walk visited 4 fixups (stride 1)
[OK] 64_KERNEL_CACHE walk visited 4 fixups (stride 4)
[OK] unsupported-format guard returned 0
```

## Notes

`Library/OcAppleKernelLib/KernelCollection.c` does not currently
contain an `InternalApplyKernelCollectionFixups` to refactor — that
function only exists in PR #600's part A. So C ships the helpers
fresh rather than as an extraction; behaviour of every existing
in-tree caller is unchanged. When future work needs a fixup walker
(SystemKC loading, fileset entry rebasing, or any other use case
mentioned in #600), it can route through these helpers rather than
hand-rolling another walker.

`TestKextInject` and `TestProcessKernel` both build clean with
`WERROR=1 USE_SHARED_OBJS=1` against this tree.