### PR TITLE
OcMainLib: Add HideVerbose option

### DIFF
--- a/Docs/Configuration.tex
+++ b/Docs/Configuration.tex
@@ -8434,6 +8434,12 @@ OpenCore is installed, in order for the \texttt{Launchd.command} script to work 
   \textbf{Description}: If \texttt{false} this driver entry will be ignored.
 
 \item
+  \texttt{HideVerbose}\\
+  \textbf{Type}: \texttt{plist\ boolean}\\
+  \textbf{Failsafe}: \texttt{false}\\
+  \textbf{Description}: If \texttt{true} text output for this driver will be disabled.
+
+\item
   \texttt{LoadEarly}\\
   \textbf{Type}: \texttt{plist\ boolean}\\
   \textbf{Failsafe}: \texttt{false}\\

--- a/Docs/Sample.plist
+++ b/Docs/Sample.plist
@@ -1624,6 +1624,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<true/>
 				<key>Path</key>
@@ -1636,6 +1638,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<true/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1647,6 +1651,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1660,6 +1666,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1671,6 +1679,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1684,6 +1694,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1695,6 +1707,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1708,6 +1722,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1719,6 +1735,8 @@
 				<key>Comment</key>
 				<string>HFS+ Driver</string>
 				<key>Enabled</key>
+				<true/>
+				<key>HideVerbose</key>
 				<true/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1732,6 +1750,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1743,6 +1763,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1756,6 +1778,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1767,6 +1791,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1780,6 +1806,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1791,6 +1819,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1804,6 +1834,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1815,6 +1847,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1828,6 +1862,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1839,6 +1875,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1852,6 +1890,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1863,6 +1903,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1876,6 +1918,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1887,6 +1931,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1900,6 +1946,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1911,6 +1959,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1924,6 +1974,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1935,6 +1987,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1948,6 +2002,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1959,6 +2015,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1972,6 +2030,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -1983,6 +2043,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -1996,6 +2058,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2007,6 +2071,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2020,6 +2086,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2031,6 +2099,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2044,6 +2114,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2055,6 +2127,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2068,6 +2142,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2079,6 +2155,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2092,6 +2170,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2103,6 +2183,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2116,6 +2198,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2127,6 +2211,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2140,6 +2226,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2151,6 +2239,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2164,6 +2254,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2175,6 +2267,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2188,6 +2282,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2200,6 +2296,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2211,6 +2309,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>

--- a/Docs/SampleCustom.plist
+++ b/Docs/SampleCustom.plist
@@ -1992,6 +1992,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<true/>
 				<key>Path</key>
@@ -2004,6 +2006,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<true/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2015,6 +2019,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2028,6 +2034,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2039,6 +2047,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2052,6 +2062,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2063,6 +2075,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2076,6 +2090,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2087,6 +2103,8 @@
 				<key>Comment</key>
 				<string>HFS+ Driver</string>
 				<key>Enabled</key>
+				<true/>
+				<key>HideVerbose</key>
 				<true/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2100,6 +2118,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2111,6 +2131,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2124,6 +2146,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2135,6 +2159,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2148,6 +2174,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2159,6 +2187,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2172,6 +2202,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2183,6 +2215,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2196,6 +2230,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2207,6 +2243,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2220,6 +2258,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2231,6 +2271,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2244,6 +2286,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2255,6 +2299,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2268,6 +2314,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2279,6 +2327,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2292,6 +2342,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2303,6 +2355,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2316,6 +2370,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2327,6 +2383,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2340,6 +2398,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2351,6 +2411,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2364,6 +2426,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2375,6 +2439,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2388,6 +2454,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2399,6 +2467,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2412,6 +2482,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2423,6 +2495,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2436,6 +2510,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2447,6 +2523,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2460,6 +2538,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2471,6 +2551,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2484,6 +2566,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2495,6 +2579,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2508,6 +2594,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2519,6 +2607,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2532,6 +2622,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2543,6 +2635,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>
@@ -2556,6 +2650,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2568,6 +2664,8 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
+				<key>HideVerbose</key>
+				<false/>
 				<key>LoadEarly</key>
 				<false/>
 				<key>Path</key>
@@ -2579,6 +2677,8 @@
 				<key>Comment</key>
 				<string></string>
 				<key>Enabled</key>
+				<false/>
+				<key>HideVerbose</key>
 				<false/>
 				<key>LoadEarly</key>
 				<false/>

--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -621,6 +621,7 @@ OC_DECLARE (OC_UEFI_UNLOAD_ARRAY)
   _(OC_STRING                   , Arguments          ,     , OC_STRING_CONSTR ("", _, __)                    , OC_DESTR (OC_STRING) ) \
   _(OC_STRING                   , Comment            ,     , OC_STRING_CONSTR ("", _, __)                    , OC_DESTR (OC_STRING) ) \
   _(BOOLEAN                     , Enabled            ,     , FALSE                                           , ()) \
+  _(BOOLEAN                     , HideVerbose        ,     , FALSE                                           , ()) \
   _(BOOLEAN                     , LoadEarly          ,     , FALSE                                           , ()) \
   _(OC_STRING                   , Path               ,     , OC_STRING_CONSTR ("", _, __)                    , OC_DESTR (OC_STRING) )
 OC_DECLARE (OC_UEFI_DRIVER_ENTRY)

--- a/Library/OcConfigurationLib/OcConfigurationLib.c
+++ b/Library/OcConfigurationLib/OcConfigurationLib.c
@@ -703,11 +703,12 @@ OC_SCHEMA
 STATIC
 OC_SCHEMA
   mUefiDriversSchemaEntry[] = {
-  OC_SCHEMA_STRING_IN ("Arguments",  OC_UEFI_DRIVER_ENTRY, Arguments),
-  OC_SCHEMA_STRING_IN ("Comment",    OC_UEFI_DRIVER_ENTRY, Comment),
-  OC_SCHEMA_BOOLEAN_IN ("Enabled",   OC_UEFI_DRIVER_ENTRY, Enabled),
-  OC_SCHEMA_BOOLEAN_IN ("LoadEarly", OC_UEFI_DRIVER_ENTRY, LoadEarly),
-  OC_SCHEMA_STRING_IN ("Path",       OC_UEFI_DRIVER_ENTRY, Path),
+  OC_SCHEMA_STRING_IN ("Arguments",    OC_UEFI_DRIVER_ENTRY, Arguments),
+  OC_SCHEMA_STRING_IN ("Comment",      OC_UEFI_DRIVER_ENTRY, Comment),
+  OC_SCHEMA_BOOLEAN_IN ("Enabled",     OC_UEFI_DRIVER_ENTRY, Enabled),
+  OC_SCHEMA_BOOLEAN_IN ("HideVerbose", OC_UEFI_DRIVER_ENTRY, HideVerbose),
+  OC_SCHEMA_BOOLEAN_IN ("LoadEarly",   OC_UEFI_DRIVER_ENTRY, LoadEarly),
+  OC_SCHEMA_STRING_IN ("Path",         OC_UEFI_DRIVER_ENTRY, Path),
 };
 
 STATIC

--- a/Library/OcMainLib/OpenCoreUefi.c
+++ b/Library/OcMainLib/OpenCoreUefi.c
@@ -67,6 +67,7 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 STATIC EFI_EVENT_NOTIFY  mOcExitBootServicesHandlers[OC_EXIT_BOOT_SERVICES_HANDLER_MAX+1];
 STATIC VOID              *mOcExitBootServicesContexts[OC_EXIT_BOOT_SERVICES_HANDLER_MAX];
 STATIC UINTN             mOcExitBootServicesIndex;
+STATIC EFI_SYSTEM_TABLE  *mNullSystemTable;
 
 VOID
 OcScheduleExitBootServices (
@@ -206,7 +207,7 @@ OcLoadDrivers (
       continue;
     }
 
-    if ((DriverArguments != NULL) && (DriverArguments[0] != '\0')) {
+    if (((DriverArguments != NULL) && (DriverArguments[0] != '\0')) || DriverEntry->HideVerbose) {
       Status = gBS->HandleProtocol (
                       ImageHandle,
                       &gEfiLoadedImageProtocolGuid,
@@ -224,7 +225,19 @@ OcLoadDrivers (
         FreePool (Driver);
         continue;
       }
+    }
 
+    if (DriverEntry->HideVerbose) {
+      if (mNullSystemTable == NULL) {
+        mNullSystemTable = AllocateNullTextOutSystemTable (gST);
+      }
+
+      if (mNullSystemTable != NULL) {
+        LoadedImage->SystemTable = mNullSystemTable;
+      }
+    }
+
+    if ((DriverArguments != NULL) && (DriverArguments[0] != '\0')) {
       UnescapedArguments = XmlUnescapeString (DriverArguments);
       if (UnescapedArguments == NULL) {
         DEBUG ((


### PR DESCRIPTION
Starting with macOS Tahoe, users have begun using apfs_aligned.efi due to issues with FV2. However, this driver produces unnecessary console output. I propose adding a HideVerbose option to suppress this output, similar to how IgnoreVerbose works in OcApfsLib.