### PR TITLE
CI: Fix warnings

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -18,7 +18,7 @@ jobs:
       JOB_TYPE: ANALYZE
       HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Due to brew adopting PEP 668 https://github.com/orgs/Homebrew/discussions/3404 pip installs should be in a Python venv
       - name: Install Dependencies
@@ -68,7 +68,7 @@ jobs:
     env:
       JOB_TYPE: ANALYZE
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Dependencies
         run: |
@@ -80,7 +80,7 @@ jobs:
           python3 -m prospector . -P ./profile.yml | tee prospector_result.txt || exit 1
 
       - name: Upload prospector result to Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: Prospector Artifacts
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.repository_owner == 'acidanthera' && github.ref_name == 'master'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Dependencies
         run: |
@@ -109,7 +109,7 @@ jobs:
       TOOLCHAINS: GCC
     if: github.repository_owner == 'acidanthera' && github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Linux Toolchain
         run: |
@@ -31,7 +31,7 @@ jobs:
           brew install musl-cross
 
       - name: Install Dependencies
-        run: brew install openssl mingw-w64
+        run: brew install mingw-w64
 
       - name: CI Bootstrap
         run: |
@@ -41,7 +41,7 @@ jobs:
       - run: ./build_oc.tool
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: macOS XCODE5 Artifacts
           path: Binaries/*.zip
@@ -60,7 +60,7 @@ jobs:
     env:
       TOOLCHAINS: CLANGPDB
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Apply Docker AppArmor settings
         run: |
@@ -76,7 +76,7 @@ jobs:
         run: docker compose run build-oc
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Linux CLANGPDB Artifacts
           path: Binaries/*.zip
@@ -87,7 +87,7 @@ jobs:
     env:
       TOOLCHAINS: GCC
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Apply Docker AppArmor settings
         run: |
@@ -103,7 +103,7 @@ jobs:
         run: docker compose run build-oc
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Linux GCC Artifacts
           path: Binaries/*.zip
@@ -114,7 +114,7 @@ jobs:
     env:
       TOOLCHAINS: CLANGDWARF
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Apply Docker AppArmor settings
         run: |
@@ -130,7 +130,7 @@ jobs:
         run: docker compose run build-oc
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Linux CLANGDWARF Artifacts
           path: Binaries/*.zip
@@ -139,7 +139,7 @@ jobs:
     name: Linux Docs
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Apply Docker AppArmor settings
         run: |
@@ -161,7 +161,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
           arch: x86
@@ -177,7 +177,7 @@ jobs:
       - run: ./build_oc.tool
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Windows Artifacts
           path: Binaries/*.zip

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check Codestyle
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Dependencies
         run: |
@@ -32,7 +32,7 @@ jobs:
           python3 -c "$(/usr/bin/curl https://raw.githubusercontent.com/acidanthera/ocbuild/master/uncstrap/uncstrap.py)" ./Uncrustify.yml || exit 1
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: Uncrustify Artifacts


### PR DESCRIPTION
1. Updated actions from version v4 to version v6 to avoid the Node.js 20 actions warning
2. Removed the unnecessary OpenSSL dependency from the macOS build since it is already installed