### PR TITLE
CI: Adapt for new GitHub and Homebrew 6 requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
 
   build-windows:
     name: Windows VS2022
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       HAS_OPENSSL_BUILD: 0
       CC: gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Linux Toolchain
         run: |
           brew tap FiloSottile/homebrew-musl-cross
-          brew install musl-cross
+          brew install FiloSottile/musl-cross/musl-cross
 
       - name: Install Dependencies
         run: brew install mingw-w64


### PR DESCRIPTION
Since GitHub has [announced ](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/)new changes to CI and Homebrew 6 was released, I suggest making the following changes:

- Change macOS runner to macos-15 since Tahoe causes compilation problems
- Change Windows runner to windows-2022 since AUDK currently doesn't support VS2026
- Add brew trust for 3rd party taps