### PR TITLE
ci: grant contents:write to build-macos job for release uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
   build-macos:
     name: macOS XCODE5
     runs-on: macos-latest
+    permissions:
+      contents: write
     env:
       JOB_TYPE: BUILD
       HOMEBREW_NO_INSTALL_CLEANUP: 1


### PR DESCRIPTION
Fixes "Resource not accessible by integration" from svenstaro/upload-release-action, caused by the default read-only GITHUB_TOKEN.