### PR TITLE
Dockerfiles/oc-dev: retry LLVM install on transient apt.llvm.org network failures

### DIFF
--- a/Dockerfiles/oc-dev/Dockerfile
+++ b/Dockerfiles/oc-dev/Dockerfile
@@ -12,7 +12,13 @@ RUN apt-get update && \
     apt-get install -y lsb-release wget software-properties-common gnupg build-essential nasm uuid-dev libssl-dev libx11-dev libxext-dev iasl curl git zip file && \
     { { [ "$(dpkg --print-architecture)" != "i386" ] && [ "$(dpkg --print-architecture)" != "amd64" ] ; } || apt-get install -y gcc-multilib ; } && \
     { [ "$(dpkg --print-architecture)" == "amd64" ] || { apt-get install -y gcc-x86-64-linux-gnu && export GCC_BIN=x86_64-linux-gnu- ; } ; } && echo "export GCC_BIN=$GCC_BIN" > ~/.edk2_rc.sh && echo ". ~/.edk2_rc.sh" > /etc/profile.d/edk2-gcc5.sh && \
-    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh ${OC_DEV_EDK2_LLVM_VER} && rm -f llvm.sh && \
+    ( for i in 1 2 3 4 5; do \
+        rm -f llvm.sh && \
+        wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh ${OC_DEV_EDK2_LLVM_VER} && exit 0; \
+        echo "apt.llvm.org install attempt $i/5 failed, retrying in 15s..." >&2; \
+        sleep 15; \
+      done; exit 1 ) && \
+    rm -f llvm.sh && \
     apt-get purge --auto-remove -y wget software-properties-common gnupg && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The Linux CLANGPDB CI job intermittently fails during the oc-dev-edk2
image build: llvm.sh's own key-fetch helper (wget to
apt.llvm.org/llvm-snapshot.gpg.key) returns exit code 4 (network
failure) despite its built-in 3 retries, which aborts the whole Docker
build even though the underlying toolchain setup is otherwise fine.

Wrap the llvm.sh download+execution in an outer retry loop (5 attempts,
15s backoff) so a short-lived apt.llvm.org outage or rate limit no
longer fails CI outright. A persistent failure still fails the build
after all attempts are exhausted.