### PR TITLE
Dockerfiles/oc-dev: fix flaky LLVM install (IPv4 + reset trust anchor…

### DIFF
--- a/Dockerfiles/oc-dev/Dockerfile
+++ b/Dockerfiles/oc-dev/Dockerfile
@@ -12,8 +12,9 @@ RUN apt-get update && \
     apt-get install -y lsb-release wget software-properties-common gnupg build-essential nasm uuid-dev libssl-dev libx11-dev libxext-dev iasl curl git zip file && \
     { { [ "$(dpkg --print-architecture)" != "i386" ] && [ "$(dpkg --print-architecture)" != "amd64" ] ; } || apt-get install -y gcc-multilib ; } && \
     { [ "$(dpkg --print-architecture)" == "amd64" ] || { apt-get install -y gcc-x86-64-linux-gnu && export GCC_BIN=x86_64-linux-gnu- ; } ; } && echo "export GCC_BIN=$GCC_BIN" > ~/.edk2_rc.sh && echo ". ~/.edk2_rc.sh" > /etc/profile.d/edk2-gcc5.sh && \
+    echo "prefer-family = IPv4" >> /etc/wgetrc && \
     ( for i in 1 2 3 4 5; do \
-        rm -f llvm.sh && \
+        rm -f llvm.sh /etc/apt/trusted.gpg.d/apt.llvm.org.asc /etc/apt/sources.list.d/archive_uri-https_apt_llvm_org_*.list && \
         wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh ${OC_DEV_EDK2_LLVM_VER} && exit 0; \
         echo "apt.llvm.org install attempt $i/5 failed, retrying in 15s..." >&2; \
         sleep 15; \


### PR DESCRIPTION
Dockerfiles/oc-dev: fix flaky LLVM install (IPv4 + reset trust anchor on retry)
The llvm.sh retry loop could fail permanently instead of recovering:

1. apt.llvm.org resolves to both an A and an AAAA record. On runners/
   BuildKit sandboxes without working IPv6 egress, wget can pick the
   AAAA record and fail with "Network is unreachable" instead of
   falling back to IPv4.
2. If a wget call inside llvm.sh is interrupted by that failure while
   writing /etc/apt/trusted.gpg.d/apt.llvm.org.asc, it leaves behind an
   empty/corrupt key file. llvm.sh only (re)downloads the key when that
   file is absent, so every subsequent retry in the loop reuses the
   broken key and apt-get update fails with NO_PUBKEY, even once the
   network recovers.

Fix: prefer IPv4 for wget via /etc/wgetrc, and remove the trust anchor
and any partially-added apt.llvm.org sources list entry at the start of
every retry iteration, so a bad attempt cannot poison the ones after it.

CI log of the original failure: image 'Linux CLANGDWARF' job, docker
compose build-duet, all 5 llvm.sh attempts failing (2x unreachable
IPv6, 3x NO_PUBKEY from a stale key file left by a previous attempt).

This should fix this error: 
[Annotations.txt](https://github.com/user-attachments/files/31353407/Annotations.txt)
 