### PR TITLE
OcMainLib: treat empty Generic->SystemUUID like "OEM"

### DIFF
--- a/Library/OcMainLib/OpenCorePlatform.c
+++ b/Library/OcMainLib/OpenCorePlatform.c
@@ -35,6 +35,37 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 
 STATIC CHAR8  mCurrentSmbiosProductName[OC_OEM_NAME_MAX];
 
+/**
+  Determine whether an ASCII PlatformInfo->Generic->SystemUUID value should
+  be treated as OEM, i.e. extracted from the real, unspoofed SMBIOS table
+  instead of parsed as a user-specified UUID.
+
+  Per Configuration.pdf and OcValidateLib (see ValidatePlatformInfo.c), an
+  empty PlatformInfo->Generic->SystemUUID is documented as a legal value
+  equivalent to explicitly specifying "OEM". Previously only the literal
+  "OEM" string was recognised at the two call sites below, so leaving
+  SystemUUID empty silently fell through to OcAsciiStrToRawGuid() on an
+  empty string. That call fails and its status is not checked, so
+  MacInfo->Oem.SystemUuid was left zeroed by GetMacInfo(). A zero UUID is
+  skipped when populating the Data Hub entry (OcPlatformUpdateDataHub) and
+  the "system-id" NVRAM variable (OcPlatformUpdateNvram/
+  OcGetLegacySecureBootECID), but is NOT skipped by the SMBIOS UUID
+  override, which falls back to the real hardware UUID from the original
+  SMBIOS table instead of leaving it zero (see SMBIOS_OVERRIDE_V in
+  SmbiosPatch.c). This asymmetry allowed PlatformInfo->Generic (Data Hub/
+  NVRAM/IOPlatformUUID) and PlatformInfo->SMBIOS to end up exposing two
+  different UUIDs whenever SystemUUID was left empty for automatic
+  generation.
+**/
+STATIC
+BOOLEAN
+PlatformInfoUuidIsOem (
+  IN CONST CHAR8  *AsciiSystemUuid
+  )
+{
+  return (AsciiSystemUuid[0] == '\0') || (AsciiStrCmp (AsciiSystemUuid, "OEM") == 0);
+}
+
 STATIC
 VOID
 OcPlatformUpdateDataHub (
@@ -774,7 +805,7 @@ OcLoadPlatformSupport (
     GetMacInfo (OC_BLOB_GET (&Config->PlatformInfo.Generic.SystemProductName), &InfoData);
     UsedMacInfo  = &InfoData;
     UseOemSerial = AsciiStrCmp (OC_BLOB_GET (&Config->PlatformInfo.Generic.SystemSerialNumber), "OEM") == 0;
-    UseOemUuid   = AsciiStrCmp (OC_BLOB_GET (&Config->PlatformInfo.Generic.SystemUuid), "OEM") == 0;
+    UseOemUuid   = PlatformInfoUuidIsOem (OC_BLOB_GET (&Config->PlatformInfo.Generic.SystemUuid));
     UseOemMlb    = AsciiStrCmp (OC_BLOB_GET (&Config->PlatformInfo.Generic.Mlb), "OEM") == 0;
     UseOemRom    = AsciiStrCmp ((CHAR8 *)Config->PlatformInfo.Generic.Rom, "OEM") == 0;
   } else {
@@ -891,7 +922,7 @@ OcGetLegacySecureBootECID (
   //
   if (Config->PlatformInfo.UpdateNvram) {
     if (Config->PlatformInfo.Automatic) {
-      if (AsciiStrCmp (OC_BLOB_GET (&Config->PlatformInfo.Generic.SystemUuid), "OEM") == 0) {
+      if (PlatformInfoUuidIsOem (OC_BLOB_GET (&Config->PlatformInfo.Generic.SystemUuid))) {
         Status = OcSmbiosTablePrepare (&SmbiosTable);
         if (!EFI_ERROR (Status)) {
           OcSmbiosExtractOemInfo (

--- a/Library/OcMainLib/OpenCorePlatform.c
+++ b/Library/OcMainLib/OpenCorePlatform.c
@@ -34,29 +34,6 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include <Guid/AppleVariable.h>
 
 STATIC CHAR8  mCurrentSmbiosProductName[OC_OEM_NAME_MAX];
-
-/**
-  Determine whether an ASCII PlatformInfo->Generic->SystemUUID value should
-  be treated as OEM, i.e. extracted from the real, unspoofed SMBIOS table
-  instead of parsed as a user-specified UUID.
-
-  Per Configuration.pdf and OcValidateLib (see ValidatePlatformInfo.c), an
-  empty PlatformInfo->Generic->SystemUUID is documented as a legal value
-  equivalent to explicitly specifying "OEM". Previously only the literal
-  "OEM" string was recognised at the two call sites below, so leaving
-  SystemUUID empty silently fell through to OcAsciiStrToRawGuid() on an
-  empty string. That call fails and its status is not checked, so
-  MacInfo->Oem.SystemUuid was left zeroed by GetMacInfo(). A zero UUID is
-  skipped when populating the Data Hub entry (OcPlatformUpdateDataHub) and
-  the "system-id" NVRAM variable (OcPlatformUpdateNvram/
-  OcGetLegacySecureBootECID), but is NOT skipped by the SMBIOS UUID
-  override, which falls back to the real hardware UUID from the original
-  SMBIOS table instead of leaving it zero (see SMBIOS_OVERRIDE_V in
-  SmbiosPatch.c). This asymmetry allowed PlatformInfo->Generic (Data Hub/
-  NVRAM/IOPlatformUUID) and PlatformInfo->SMBIOS to end up exposing two
-  different UUIDs whenever SystemUUID was left empty for automatic
-  generation.
-**/
 STATIC
 BOOLEAN
 PlatformInfoUuidIsOem (


### PR DESCRIPTION
PlatformInfo->Generic->SystemUUID being empty is documented (Configuration.pdf, ValidatePlatformInfo.c) as legal and equivalent to "OEM", but OcLoadPlatformSupport()/OcGetLegacySecureBootECID() only recognised the literal "OEM" string. An empty value instead fell through to OcAsciiStrToRawGuid() on an empty string, whose failure status was not checked, leaving MacInfo->Oem.SystemUuid zeroed.

A zero UUID is skipped when writing the Data Hub entry and the system-id NVRAM variable, but SMBIOS_OVERRIDE_V falls back to the real hardware UUID from the original SMBIOS table instead of leaving it zero. So with an empty SystemUUID, PlatformInfo->SMBIOS ended up with the real hardware UUID while PlatformInfo->Generic (Data Hub/NVRAM/IOPlatformUUID) got nothing set, letting the OS mint its own value independently - exposing two different, sometimes per-boot-varying UUIDs instead of one consistent one.

Add PlatformInfoUuidIsOem() and use it at both call sites so empty and "OEM" are handled identically, matching the documented failsafe.

Again commited using Claude.
This is designed to attempt to fix this on unsupported T2 Macs:
This picture is from my 2018 Mac mini booted inside macOS 26's installer with the buggy OC version before this fix:
<img width="5712" height="4284" alt="IMG_0857" src="https://github.com/user-attachments/assets/695e1611-e625-42ba-b61d-416365179c7f" />

Here's the EFI with the buggy version before this fix:
[Archiv.zip](https://github.com/user-attachments/files/31444888/Archiv.zip)
