### PR TITLE
Fix uninitialized L3 cache value on CPUs without L3 cache

### DIFF
--- a/Library/OcAppleKernelLib/CpuidPatches.c
+++ b/Library/OcAppleKernelLib/CpuidPatches.c
@@ -1960,6 +1960,11 @@ PatchProvideCurrentCpuInfo (
     ZeroMem (CacheLineSizes, sizeof (CacheLineSizes));
 
     //
+    // CacheSizes[] init
+    //
+    ZeroMem (CacheSizes, sizeof (CacheSizes));
+
+    //
     // Build CPU info struct
     //
     Index = 0;


### PR DESCRIPTION
## Issue
When using the `ProvideCurrentCpuInfo` quirk on CPUs without L3 cache (e.g. Intel Core 2 Quad Q9550), Mac OS X Tiger (10.4.x) correctly populates L2 cache information but reports a bogus 16 EB garbage value for L3 cache in *About This Mac* / System Profiler.

This quirk is designed to inject real CPU cache information for older macOS versions. While L2 cache reporting works as intended, the L3 cache field was left uninitialized, leaking raw stack‑memory garbage values.

## Root Cause
In `Library/OcAppleKernelLib/CpuidPatches.c`, the Tiger‑specific cache injection logic triggered by `ProvideCurrentCpuInfo` does **not zero‑initialize the L3 cache field** when the target CPU lacks L3 cache. Uninitialized stack data gets injected into the kernel‑visible CPU cache structure.

## Fix
Explicitly zero‑initialize the L3 cache field before injecting cache metadata for Tiger under `ProvideCurrentCpuInfo`.
CPUs without L3 cache now omit the L3 entry entirely, preserving correct L2 cache reporting.

## Testing
- Hardware: Gigabyte EP45 + Intel Core 2 Quad Q9550 (CPU has no L3 cache)
- Quirk enabled: `ProvideCurrentCpuInfo`
- OS: Mac OS X 10.4.11 (Tiger)
- Before fix: L2 cache shown correctly, L3 cache displayed as 16 EB garbage
- After fix: L2 cache remains visible, invalid L3 cache entry is gone
