### PR TITLE
docs: fix typo noticable -> noticeable

### DIFF
--- a/Staging/EnableGop/README.md
+++ b/Staging/EnableGop/README.md
@@ -10,7 +10,7 @@ EnableGop version (OpenCore version)
 
 ### 1.3 (0.9.2)
  - Included fix to GopBurstMode for non-standard frame buffer information on AMD Radeon HD 7970 and similar
- - Applied GopBurstMode even on natively supported cards, as it can provide a noticable speed up
+ - Applied GopBurstMode even on natively supported cards, as it can provide a noticeable speed up
 
 ### 1.2 (0.9.1)
  - Added GopBurstMode support


### PR DESCRIPTION
Corrects the misspelling `noticable` -> `noticeable` in `Staging/EnableGop/README.md`.

Documentation only, no behaviour change.