### PR TITLE
OpenLegacyBoot: Add grub4dos (grldr) PBR detection support

### DIFF
--- a/Platform/OpenLegacyBoot/LegacyBootInternal.h
+++ b/Platform/OpenLegacyBoot/LegacyBootInternal.h
@@ -34,7 +34,8 @@ typedef enum OC_LEGACY_OS_TYPE_ {
   OcLegacyOsTypeNone,
   OcLegacyOsTypeWindowsNtldr,
   OcLegacyOsTypeWindowsBootmgr,
-  OcLegacyOsTypeIsoLinux
+  OcLegacyOsTypeIsoLinux,
+  OcLegacyOsTypeGrldr
 } OC_LEGACY_OS_TYPE;
 
 EFI_STATUS

--- a/Platform/OpenLegacyBoot/LegacyBootSupport.c
+++ b/Platform/OpenLegacyBoot/LegacyBootSupport.c
@@ -353,6 +353,10 @@ InternalGetPartitionLegacyOsType (
             || CheckLegacySignature ("isolinux", Buffer, BufferSize))
   {
     LegacyOsType = OcLegacyOsTypeIsoLinux;
+  } else if (  CheckLegacySignature ("GRLDR", Buffer, BufferSize)
+            || CheckLegacySignature ("grldr", Buffer, BufferSize))
+  {
+    LegacyOsType = OcLegacyOsTypeGrldr;
   } else {
     LegacyOsType = OcLegacyOsTypeNone;
     DEBUG ((DEBUG_INFO, "OLB: Unknown legacy bootsector signature\n"));

--- a/Platform/OpenLegacyBoot/OpenLegacyBoot.c
+++ b/Platform/OpenLegacyBoot/OpenLegacyBoot.c
@@ -34,7 +34,25 @@ GetLegacyEntryName (
   OC_LEGACY_OS_TYPE  LegacyOsType
   )
 {
-  return AllocateCopyPool (L_STR_SIZE ("Windows (legacy)"), "Windows (legacy)");
+  CONST CHAR8  *Name;
+
+  switch (LegacyOsType) {
+    case OcLegacyOsTypeIsoLinux:
+      Name = "Linux (legacy)";
+      break;
+
+    case OcLegacyOsTypeGrldr:
+      Name = "Grub4dos (legacy)";
+      break;
+
+    case OcLegacyOsTypeWindowsBootmgr:
+    case OcLegacyOsTypeWindowsNtldr:
+    default:
+      Name = "Windows (legacy)";
+      break;
+  }
+
+  return AllocateCopyPool (AsciiStrSize (Name), Name);
 }
 
 STATIC


### PR DESCRIPTION
## Summary

Adds grub4dos (`grldr`) PBR detection to OpenLegacyBoot, allowing OC to
chain-load grub4dos as a standalone legacy boot entry.

## Background

OpenLegacyBoot currently detects `NTLDR`, `BOOTMGR`, and `ISOLINUX` PBR
signatures but not `grldr`. grub4dos is a legacy (MBR) boot loader
chain-loaded via OpenLegacyBoot to boot NT5 systems (Windows 2000/XP).

Unlike Vista/7, which can boot natively via UEFI+GPT (requiring CSM only
for video), NT5 requires a full legacy BIOS environment and cannot boot
through UEFI at all. In OpenDuet or CSM-based UEFI systems, `ntldr`'s
strict `DL=0x80` requirement often fails because the firmware's disk
enumeration differs from native BIOS. grub4dos serves as an intermediary
that performs the necessary drive mapping (`map () (hd0)`) before
chain-loading `ntldr`.

With grldr detection, each NT5 installation can have its own grub4dos
PBR and appear as an independent entry in the OC picker, rather than
relying on a single shared grub4dos menu with multiple entries.

## Changes

- `LegacyBootInternal.h`: Add `OcLegacyOsTypeGrldr` enum value.
- `LegacyBootSupport.c`: Detect both `"GRLDR"` and `"grldr"` PBR
  signatures. Case-insensitive search is required because FAT32 stores
  directory entries in uppercase while NTFS preserves the original
  lowercase filename.
- `OpenLegacyBoot.c`: Add `Grub4dos (legacy)` entry name. Flavour reuses
  `OC_FLAVOUR_WINDOWS` (consistent with all existing legacy entries), so
  no new theme assets are required.

The existing `NTLDR` detection branch is preserved unchanged — partitions
without grub4dos installed continue to appear as `Windows (legacy)`.

## Testing

- **EP45 (OpenDuet) + Windows 2000**: OC detects grldr PBR, chain-loads
  grub4dos, boots Win2000 successfully.
- **Z77 (UEFI + CSM) + Windows XP**: Same flow, boots successfully.
- Native BIOS boot (without OC): grub4dos menu.lst with conditional
  `map` works correctly.

## Recommended menu.lst

For environments where the target disk may not be `hd0` (e.g. OpenDuet
disk enumeration), a conditional map avoids errors on native BIOS boot:

```
find --set-root /ntldr
if not "%@root%"=="(hd0,0)" map () (hd0) && map --hook
chainloader /ntldr
```
